### PR TITLE
Support for enums for ensure_inclusion_of_matcher

### DIFF
--- a/spec/shoulda/active_record/ensure_inclusion_of_matcher_spec.rb
+++ b/spec/shoulda/active_record/ensure_inclusion_of_matcher_spec.rb
@@ -2,6 +2,39 @@ require 'spec_helper'
 
 describe Shoulda::Matchers::ActiveRecord::EnsureInclusionOfMatcher do
 
+  context "an attribute which must be included in an enumerable" do
+    before do
+      @model = define_model(:example, :attr => :string) do
+        validates_inclusion_of :attr, :in => ['foo', 'bar']
+      end.new
+    end
+
+    it "should accept ensuring a correct value" do
+      @model.should ensure_inclusion_of(:attr).in(['foo', 'bar']), @model
+    end
+
+    it "should reject ensuring an incorrect value" do
+      @model.should_not ensure_inclusion_of(:attr).in(['baz', 'quux']), @model
+    end
+
+    it "should not override the default message with a blank" do
+      @model.should ensure_inclusion_of(:attr).in(['foo', 'bar']).with_message(nil), @model
+    end
+  end
+
+  context "an attribute which must be included in an enumerable with a custom message" do
+    before do
+      @model = define_model(:example, :attr => :string) do
+        validates_inclusion_of :attr, :in => ['foo', 'bar'], :message => 'not good'
+
+      end.new
+    end
+
+    it "should accept ensuring the correct value" do
+      @model.should ensure_inclusion_of(:attr).in(['foo', 'bar']).with_message(/not good/), @model
+    end
+  end
+
   context "an attribute which must be included in a range" do
     before do
       @model = define_model(:example, :attr => :integer) do
@@ -10,27 +43,27 @@ describe Shoulda::Matchers::ActiveRecord::EnsureInclusionOfMatcher do
     end
 
     it "should accept ensuring the correct range" do
-      @model.should ensure_inclusion_of(:attr).in_range(2..5)
+      @model.should ensure_inclusion_of(:attr).in(2..5)
     end
 
     it "should reject ensuring a lower minimum value" do
-      @model.should_not ensure_inclusion_of(:attr).in_range(1..5)
+      @model.should_not ensure_inclusion_of(:attr).in(1..5)
     end
 
     it "should reject ensuring a higher minimum value" do
-      @model.should_not ensure_inclusion_of(:attr).in_range(3..5)
+      @model.should_not ensure_inclusion_of(:attr).in(3..5)
     end
 
     it "should reject ensuring a lower maximum value" do
-      @model.should_not ensure_inclusion_of(:attr).in_range(2..4)
+      @model.should_not ensure_inclusion_of(:attr).in(2..4)
     end
 
     it "should reject ensuring a higher maximum value" do
-      @model.should_not ensure_inclusion_of(:attr).in_range(2..6)
+      @model.should_not ensure_inclusion_of(:attr).in(2..6)
     end
 
     it "should not override the default message with a blank" do
-      @model.should ensure_inclusion_of(:attr).in_range(2..5).with_message(nil)
+      @model.should ensure_inclusion_of(:attr).in(2..5).with_message(nil)
     end
   end
 
@@ -43,7 +76,7 @@ describe Shoulda::Matchers::ActiveRecord::EnsureInclusionOfMatcher do
     end
 
     it "should accept ensuring the correct range" do
-      @model.should ensure_inclusion_of(:attr).in_range(2..4).with_message(/not good/)
+      @model.should ensure_inclusion_of(:attr).in(2..4).with_message(/not good/)
     end
   end
 
@@ -63,7 +96,7 @@ describe Shoulda::Matchers::ActiveRecord::EnsureInclusionOfMatcher do
     end
 
     it "should accept ensuring the correct range and messages" do
-      @model.should ensure_inclusion_of(:attr).in_range(2..5).with_low_message(/low/).with_high_message(/high/)
+      @model.should ensure_inclusion_of(:attr).in(2..5).with_low_message(/low/).with_high_message(/high/)
     end
 
   end


### PR DESCRIPTION
This applies https://github.com/wfarr/shoulda/commit/ad2a45abbb31f2a7645669569930ce54e1a7a1ac to the shoulda-matchers gem
