### PR TITLE
Shoulda::ActiveRecord::Helpers#default_error_message does not use I18n in a proper way

### DIFF
--- a/lib/shoulda/matchers/active_record/helpers.rb
+++ b/lib/shoulda/matchers/active_record/helpers.rb
@@ -17,13 +17,8 @@ module Shoulda # :nodoc:
         #   default_error_message(:too_short, :count => 5)
         #   default_error_message(:too_long, :count => 60)
         def default_error_message(key, values = {})
-          if Object.const_defined?(:I18n) # Rails >= 2.2
-            result = I18n.translate("activerecord.errors.messages.#{key}", values)
-            if result =~ /^translation missing/
-              I18n.translate("errors.messages.#{key}", values)
-            else
-              result
-            end
+          if Object.const_defined?(:I18n) # Rails >= 2.2           
+            I18n.translate(:"activerecord.errors.messages.#{key}", {:default => :"errors.messages.#{key}"}.merge(values))
           else # Rails <= 2.1.x
             ::ActiveRecord::Errors.default_error_messages[key] % values[:count]
           end


### PR DESCRIPTION
Instead of using `default` option, it unnecessarily calls I18n.translate twice, and might throw `I18n::MissingTranslationData`, when translation exists, what not proper behavior. 

Also, determining whether translation exists by matching to `translation missing` is not pretty - better to use `I18n.translate!` and catch `I18n::MissingTranslationData` exception.
