### PR TITLE
Quick README change

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -53,8 +53,8 @@ Matchers to test common patterns:
 In Rails 3 and Bundler, add the following to your Gemfile:
 
   group :test do
-    gem "shoulda-matchers"
     gem "rspec-rails"
+    gem "shoulda-matchers"
   end
 
 Shoulda will automatically include matchers into the appropriate example groups.


### PR DESCRIPTION
This probably should have been obvious, but it took me a while to realize why the matchers weren't available. I finally found this:

https://github.com/thoughtbot/shoulda/issues/151
