### PR TITLE
Fix for AssignToMatcher failure message

### DIFF
--- a/lib/shoulda/matchers/action_controller/assign_to_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/assign_to_matcher.rb
@@ -82,8 +82,8 @@ module Shoulda # :nodoc:
           else
             @failure_message =
               "Expected action to assign a kind of #{@expected_class} " <<
-              "for #{@variable}, but got #{@variable.inspect} " <<
-              "(#{@variable.class.name})"
+              "for #{@variable}, but got #{assigned_value.inspect} " <<
+              "(#{assigned_value.class.name})"
             false
           end
         end

--- a/spec/shoulda/action_controller/assign_to_matcher_spec.rb
+++ b/spec/shoulda/action_controller/assign_to_matcher_spec.rb
@@ -2,6 +2,18 @@ require 'spec_helper'
 
 describe Shoulda::Matchers::ActionController::AssignToMatcher do
 
+  it "should include the actual class in the failure message" do
+    WrongClass = Class.new do
+      def to_s; "wrong class" end
+    end
+
+    controller = build_response { @var = WrongClass.new }
+    matcher = AssignToMatcher.new(:var).with_kind_of(Fixnum)
+    matcher.matches?(controller)
+
+    matcher.failure_message.should =~ /but got wrong class \(WrongClass\)$/
+  end
+
   context "a controller that assigns to an instance variable" do
     before do
       @controller = build_response { @var = 'value' }


### PR DESCRIPTION
AssignToMatcher did not include the assigned object in the failure message when the assigned object is of the wrong kind.
