### PR TITLE
primary_key_name is deprecated in Rails 3.1

### DIFF
--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -191,11 +191,7 @@ module Shoulda # :nodoc:
         end
 
         def foreign_key
-          if defined?(Rails) && Rails::VERSION::MAJOR >= 3 && Rails::VERSION::MINOR >= 1
-            reflection.foreign_key
-          else
-            reflection.primary_key_name
-          end
+          reflection.respond_to?(:foreign_key) ? reflection.foreign_key : reflection.primary_key_name
         end
 
         def through?


### PR DESCRIPTION
primary_key_name is deprecated in Rails 3 and shouts warnings in 3.1. Replaced with foreign_key
