### PR TITLE
Mass assigment matcher should respect empty attr_accessible declaration

### DIFF
--- a/lib/shoulda/matchers/active_model/allow_mass_assignment_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/allow_mass_assignment_of_matcher.rb
@@ -7,6 +7,10 @@ module Shoulda # :nodoc:
       #   it { should_not allow_mass_assignment_of(:password) }
       #   it { should allow_mass_assignment_of(:first_name) }
       #
+      # In Rails 3.1 you can check role as well:
+      #
+      #   it { should allow_mass_assigment_of(:first_name).as(:admin) }
+      #
       def allow_mass_assignment_of(value)
         AllowMassAssignmentOfMatcher.new(value)
       end
@@ -17,8 +21,15 @@ module Shoulda # :nodoc:
           @attribute = attribute.to_s
         end
 
+        def as(role)
+          raise "You can specify role only in Rails 3.1 or greater" unless rails_3_1?
+          @role = role
+          self
+        end
+
         def matches?(subject)
           @subject = subject
+          @role ||= :default
           if attr_mass_assignable?
             if whitelisting?
               @negative_failure_message = "#{@attribute} was made accessible"
@@ -69,11 +80,19 @@ module Shoulda # :nodoc:
         end
 
         def authorizer
-          @subject.class.active_authorizer
+          if rails_3_1?
+            @subject.class.active_authorizer[@role]
+          else
+            @subject.class.active_authorizer
+          end
         end
 
         def class_name
           @subject.class.name
+        end
+
+        def rails_3_1?
+          ::ActiveModel::VERSION::MAJOR == 3 && ::ActiveModel::VERSION::MINOR >= 1
         end
       end
     end

--- a/spec/shoulda/active_model/allow_mass_assignment_of_matcher_spec.rb
+++ b/spec/shoulda/active_model/allow_mass_assignment_of_matcher_spec.rb
@@ -83,4 +83,23 @@ describe Shoulda::Matchers::ActiveModel::AllowMassAssignmentOfMatcher do
       @model.should_not allow_mass_assignment_of(:attr)
     end
   end
+
+  if ::ActiveModel::VERSION::MAJOR == 3 && ::ActiveModel::VERSION::MINOR >= 1
+    context "an attribute included in the mass-assignment whitelist for admin role only" do
+      before do
+        define_model :example, :attr => :string do
+          attr_accessible :attr, :as => :admin
+        end
+        @model = Example.new
+      end
+
+      it "should reject being mass-assignable" do
+        @model.should_not allow_mass_assignment_of(:attr)
+      end
+
+      it "should accept being mass-assignable for admin" do
+        @model.should allow_mass_assignment_of(:attr).as(:admin)
+      end
+    end
+  end
 end


### PR DESCRIPTION
In Rails declaration like this one:

``` ruby
class MyModel < AR::Base
  attr_accessible
end
```

is protecting all attributes from mass assigment.
Currently shoulda matcher fails to properly recognize this case.
I fixed this, however this wont work on rails 3.1, because of changes with mass assigment roles.
I can prepare another patch with fixes for 3.1 and also support for checking those roles, such as:
`allow_mass_assigment_of(:attribute).as(:admin)`

I need to know however if we want to have backward compatibility (to work on both 3.0 and 3.1) or if there will be seperate gem versions for rails 3.0 and 3.1.
