### PR TITLE
fixed repository address

### DIFF
--- a/CONTRIBUTION_GUIDELINES.rdoc
+++ b/CONTRIBUTION_GUIDELINES.rdoc
@@ -1,10 +1,10 @@
 We're using GitHub[http://github.com/thoughtbot/shoulda/tree/master], and we've been getting any combination of github pull requests, tickets, patches, emails, etc.  We need to normalize this workflow to make sure we don't miss any fixes.
 
-* Make sure you're accessing the source from the {official repository}[http://github.com/thoughtbot/shoulda/tree/master].
+* Make sure you're accessing the source from the {official repository}[https://github.com/thoughtbot/shoulda-matchers].
 * We prefer git branches over patches, but we can take either.
 * If you're using git, please make a branch for each separate contribution.  We can cherry pick your commits, but pulling from a branch is easier.
 * If you're submitting patches, please cut each fix or feature into a separate patch.
-* There should be an issue[http://github.com/thoughtbot/shoulda/issues] for any submission.  If you've found a bug and want to fix it, open a new ticket at the same time.
+* There should be an issue[https://github.com/thoughtbot/shoulda-matchers/issues] for any submission.  If you've found a bug and want to fix it, open a new ticket at the same time.
 * Please <b>don't send pull requests</b>  Just update the issue with the url for your fix (or attach the patch) when it's ready.  The github pull requests pretty much get dropped on the floor until someone with commit rights notices them in the mailbox.
 * Contributions without tests won't be accepted.  The file <tt>/test/README</tt> explains the testing system pretty thoroughly.
 


### PR DESCRIPTION
There is no active github issues for shoulda-matchers.
Please, make it available.
Also there is no url to source code and bug tracker on https://rubygems.org/gems/shoulda-matchers
