### PR TITLE
fail when expecting to allow mass assignment of unknown attribute

### DIFF
--- a/lib/shoulda/matchers/active_model/allow_mass_assignment_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/allow_mass_assignment_of_matcher.rb
@@ -30,27 +30,32 @@ module Shoulda # :nodoc:
         def matches?(subject)
           @subject = subject
           @role ||= :default
-          if attr_mass_assignable?
-            if whitelisting?
-              @negative_failure_message = "#{@attribute} was made accessible"
-            else
-              if protected_attributes.empty?
-                @negative_failure_message = "no attributes were protected"
+          if @subject.class.attribute_method?(@attribute)
+            if attr_mass_assignable?
+              if whitelisting?
+                @negative_failure_message = "#{@attribute} was made accessible"
               else
-                @negative_failure_message = "#{class_name} is protecting " <<
-                  "#{protected_attributes.to_a.to_sentence}, " <<
-                  "but not #{@attribute}."
+                if protected_attributes.empty?
+                  @negative_failure_message = "no attributes were protected"
+                else
+                  @negative_failure_message = "#{class_name} is protecting " <<
+                    "#{protected_attributes.to_a.to_sentence}, " <<
+                    "but not #{@attribute}."
+                end
               end
-            end
-            true
-          else
-            if whitelisting?
-              @failure_message =
-                "Expected #{@attribute} to be accessible"
+              true
             else
-              @failure_message =
-                "Did not expect #{@attribute} to be protected"
+              if whitelisting?
+                @failure_message =
+                  "Expected #{@attribute} to be accessible"
+              else
+                @failure_message =
+                  "Did not expect #{@attribute} to be protected"
+              end
+              false
             end
+          else
+            @failure_message = "Unknown attribute '#{@attribute}'"
             false
           end
         end

--- a/spec/shoulda/active_model/allow_mass_assignment_of_matcher_spec.rb
+++ b/spec/shoulda/active_model/allow_mass_assignment_of_matcher_spec.rb
@@ -84,6 +84,18 @@ describe Shoulda::Matchers::ActiveModel::AllowMassAssignmentOfMatcher do
     end
   end
 
+  context "an unknown attribute" do
+    before do
+      define_model :example, :attr => :string do
+      end
+      @model = Example.new
+    end
+
+    it "should reject being mass-assignable" do
+      @model.should_not allow_mass_assignment_of(:unknown_attr)
+    end
+  end
+
   if ::ActiveModel::VERSION::MAJOR == 3 && ::ActiveModel::VERSION::MINOR >= 1
     context "an attribute included in the mass-assignment whitelist for admin role only" do
       before do


### PR DESCRIPTION
I'm not sure if this would be considered outside the scope of this matcher, but since ActiveRecord raises an UnknownAttributeError when attempting to assign an unknown attribute via mass assignment, I found it misleading that something like 

```
it { should allow_mass_assignment_of(:unknown_attribute) }
```

was passing and not failing.
