### PR TITLE
Fix have_readonly_attribute documentation typo.

### DIFF
--- a/lib/shoulda/matchers/active_record/have_readonly_attribute_matcher.rb
+++ b/lib/shoulda/matchers/active_record/have_readonly_attribute_matcher.rb
@@ -5,7 +5,7 @@ module Shoulda # :nodoc:
       # Ensures that the attribute cannot be changed once the record has been
       # created.
       #
-      #   it { should have_readonly_attributes(:password) }
+      #   it { should have_readonly_attribute(:password) }
       #
       def have_readonly_attribute(value)
         HaveReadonlyAttributeMatcher.new(value)


### PR DESCRIPTION
Fix documentation typo.  Method is named have_readonly_attribute, but documentation refers to have_readonly_attributes.
