### PR TITLE
Remove dependencies on uglifier and coffee-rails

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -4,8 +4,6 @@ end
 
 appraise "3.1" do
   gem "rails", "3.1.0"
-  gem 'uglifier'
   gem 'jquery-rails'
-  gem 'coffee-rails'
   gem 'sass-rails'
 end

--- a/gemfiles/3.1.gemfile
+++ b/gemfiles/3.1.gemfile
@@ -10,9 +10,7 @@ gem "jdbc-sqlite3", :platform=>:jruby
 gem "jruby-openssl", :platform=>:jruby
 gem "shoulda-context", "~> 1.0.0.beta1"
 gem "rails", "3.1.0"
-gem "uglifier"
 gem "jquery-rails"
-gem "coffee-rails"
 gem "sass-rails"
 
 gemspec :path=>"../"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ FileUtils.rm_rf(TESTAPP_ROOT) if File.exists?(TESTAPP_ROOT)
 `rails new #{TESTAPP_ROOT}`
 
 ENV['RAILS_ENV'] = 'test'
-ENV['BUNDLE_GEMFILE'] = TESTAPP_ROOT + '/Gemfile'
+ENV['BUNDLE_GEMFILE'] ||= TESTAPP_ROOT + '/Gemfile'
 
 require "#{TESTAPP_ROOT}/config/environment"
 require 'rspec'


### PR DESCRIPTION
Remove uglifier and coffee-rails from the 3.1 gemfile, and modify spec_helper.rb to respect a BUNDLE_GEMFILE set on the command line. Fixes thoughtbot/shoulda#190.
