### PR TITLE
Fix typo on allow_mass_assignment_of_matcher documentation.

### DIFF
--- a/lib/shoulda/matchers/active_model/allow_mass_assignment_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/allow_mass_assignment_of_matcher.rb
@@ -9,7 +9,7 @@ module Shoulda # :nodoc:
       #
       # In Rails 3.1 you can check role as well:
       #
-      #   it { should allow_mass_assigment_of(:first_name).as(:admin) }
+      #   it { should allow_mass_assignment_of(:first_name).as(:admin) }
       #
       def allow_mass_assignment_of(value)
         AllowMassAssignmentOfMatcher.new(value)


### PR DESCRIPTION
Minor fix to documentation. Copy and paste didn't work ;-)
