### PR TITLE
Add new active model matcher `use_default_value(value = nil).for(:attribute)`

### DIFF
--- a/lib/shoulda/matchers/active_model.rb
+++ b/lib/shoulda/matchers/active_model.rb
@@ -10,7 +10,7 @@ require 'shoulda/matchers/active_model/validate_uniqueness_of_matcher'
 require 'shoulda/matchers/active_model/validate_acceptance_of_matcher'
 require 'shoulda/matchers/active_model/validate_numericality_of_matcher'
 require 'shoulda/matchers/active_model/allow_mass_assignment_of_matcher'
-
+require 'shoulda/matchers/active_model/use_default_value_for_matcher'
 
 module Shoulda
   module Matchers

--- a/lib/shoulda/matchers/active_model/use_default_value_for_matcher.rb
+++ b/lib/shoulda/matchers/active_model/use_default_value_for_matcher.rb
@@ -1,0 +1,64 @@
+module Shoulda # :nodoc:
+  module Matchers
+    module ActiveModel # :nodoc:
+
+      # Ensures that the attribute's default value is set correctly.
+      #
+      # Example:
+      #   it { should_not use_default_value(0).for(:count) }  #the :count field's default value is not 0
+      #   it { should_not use_default_value.for(:count) }     #the :count field has no default value (e.g. it's default value is nil)
+      #   it { should use_default_value(0).for(:count) }      #the :count field's default value is O
+      #   it { should use_default_value.for(:count) }         #the :count field has a default value (e.g. it's default value is not nil)
+      #
+      def use_default_value(value=nil)
+        UseDefaultValueMatcher.new(value)
+      end
+
+      class UseDefaultValueMatcher # :nodoc:
+
+        def initialize(value)
+          @default_value = value
+        end
+
+        def for(attribute)
+          @attribute = attribute
+          self
+        end
+
+        def matches?(instance)
+           #instance.send("#{@attribute}=".to_sym) = nil
+           @instance = instance
+           @instance.valid?
+           @default_value.nil? ? value : value == @default_value
+        end
+
+        def failure_message
+          if @default_value
+            "Expected default value for #{@attribute} to be #{@default_value.inspect} but it was #{value.inspect} !"
+          else
+            "Expected to find a default value for #{@attribute} but there wasn't any !"
+          end
+        end
+
+        def negative_failure_message
+          if @default_value
+            "Expected default value for #{@attribute} not to be #{@default_value.inspect} but it was!"
+          else
+            "Not expecting to find a default value for #{@attribute} but found #{value.inspect}!"
+          end
+        end
+
+        def description
+          "checks if the #{@attribute}'s default value is #{@default_value.inspect}"
+        end
+
+        private
+
+        def value
+          @instance.send(@attribute.to_sym)
+        end
+      end
+
+    end
+  end
+end

--- a/spec/shoulda/active_model/use_default_value_for_matcher_spec.rb
+++ b/spec/shoulda/active_model/use_default_value_for_matcher_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe Shoulda::Matchers::ActiveModel::UseDefaultValueMatcher do
+
+  context "an attribute with a default value" do
+    before do
+      define_model :example, :attr => :string do
+        before_validation :set_attr
+        def set_attr
+          self.attr = "abc" if attr.nil?
+        end
+      end
+      @model = Example.new
+    end
+
+    it "should use the right default value" do
+      @model.should use_default_value("abc").for(:attr)
+    end
+
+    it "should use a default value" do
+      @model.should use_default_value.for(:attr)
+    end
+
+    it "should not use a bad default value" do
+      @model.should_not use_default_value("xyz").for(:attr)
+    end
+  end
+
+  context "an attribute without a default value" do
+    before do
+      define_model :example, :attr => :string
+      @model = Example.new
+    end
+    it "should not use a default value" do
+      @model.should_not use_default_value.for(:attr)
+    end
+
+    it "should not use a bad default value" do
+      @model.should_not use_default_value("xyz").for(:attr)
+    end
+  end
+end


### PR DESCRIPTION
Add new active model matcher `use_default_value(value = nil).for(:attribute)`. This mathcher ensures that the attribute’s default value is set correctly.

Ensures that the attribute's default value is set correctly.

Examples:

 it { should_not use_default_value(0).for(:count) }  #the :count field's default value is not 0
 it { should_not use_default_value.for(:count) }     #the :count field has no default value (e.g. it's default value is nil)
 it { should use_default_value(0).for(:count) }      #the :count field's default value is O
  it { should use_default_value.for(:count) }         #the :count field has a default value (e.g. it's default value is not nil)
