### PR TITLE
Will you accept a patch to avoid type column mutations?

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_uniqueness_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_uniqueness_of_matcher.rb
@@ -112,6 +112,7 @@ module Shoulda # :nodoc:
           else
             @scopes.all? do |scope|
               previous_value = @existing.send(scope)
+              next if scope.match(/_type$/) && previous_value.is_a?(String) && Object.const_defined?(previous_value)
 
               # Assume the scope is a foreign key if the field is nil
               previous_value ||= 0


### PR DESCRIPTION
I have monkey punched my donkey with a duck to avoid the mutating of ploymorphic and STI type AR columns.

This is an active model matcher having active record issues would the fix really belong here?

Spec to follow if this makes sense and you are willing to accept.

Cheers
