### PR TITLE
Enhance AllowValueMatcher to take multiple arguments

### DIFF
--- a/spec/shoulda/active_model/allow_value_matcher_spec.rb
+++ b/spec/shoulda/active_model/allow_value_matcher_spec.rb
@@ -17,6 +17,14 @@ describe Shoulda::Matchers::ActiveModel::AllowValueMatcher do
     it "should not allow a bad value" do
       @model.should_not allow_value("xyz").for(:attr)
     end
+
+    it "should allow several good values" do
+      @model.should allow_value("abcde", "deabc").for(:attr)
+    end
+
+    it "should not allow several bad values" do
+      @model.should_not allow_value("xyz", "zyx", nil, []).for(:attr)
+    end
   end
 
   context "an attribute with a format validation and a custom message" do
@@ -51,12 +59,31 @@ describe Shoulda::Matchers::ActiveModel::AllowValueMatcher do
       @model.should allow_value("12345").for(:attr)
     end
 
-    bad_values = [nil, "", "abc", "0", "50001", "123456"]
+    bad_values = [nil, "", "abc", "0", "50001", "123456", []]
     bad_values.each do |value|
       it "should not allow a bad value (#{value.inspect})" do
         @model.should_not allow_value(value).for(:attr)
       end
     end
+
+    it "should not allow bad values (#{bad_values.map {|v| v.inspect}.join(', ')})" do
+      @model.should_not allow_value(*bad_values).for(:attr)
+    end
   end
 
+  context "an AllowValueMatcher with multiple values" do
+    before { @matcher = allow_value("foo", "bar").for(:baz) }
+
+    it "should describe itself" do
+      @matcher.description.should eq('allow baz to be set to any of ["foo", "bar"]')
+    end
+  end
+
+  context "an AllowValueMatcher with a single value" do
+    before { @matcher = allow_value("foo").for(:baz) }
+
+    it "should describe itself" do
+      @matcher.description.should eq('allow baz to be set to "foo"')
+    end
+  end
 end


### PR DESCRIPTION
With the deprecation of "should_allow_values_for", specifying multiple good (or bad) values has become quite noisy (array literal + iterator or roll-your-own macro).

Since it is completely downward compatible, I've enhanced the matcher with the ability to take multiple value arguments.
