### PR TITLE
Fix spec failure in jruby and add support for Rails 3.0

### DIFF
--- a/lib/shoulda/matchers/active_record/query_the_database_matcher.rb
+++ b/lib/shoulda/matchers/active_record/query_the_database_matcher.rb
@@ -44,12 +44,10 @@ module Shoulda # :nodoc:
         end
 
         def matches?(subject)
-          raise "Rails 3.1 or greater is required" unless rails_3_1?
-
           @queries = []
 
           subscriber = ActiveSupport::Notifications.subscribe('sql.active_record') do |name, started, finished, id, payload|
-            @queries << payload unless filter_query(payload[:name])
+            @queries << payload unless filter_query(payload)
           end
 
           if @method_arguments
@@ -93,14 +91,17 @@ module Shoulda # :nodoc:
           end.join
         end
 
-        def filter_query(query_name)
-          query_name == 'SCHEMA'
+        def filter_query(query)
+          query[:name] == 'SCHEMA' || looks_like_schema(query[:sql])
         end
 
-        def rails_3_1?
-          ::ActiveRecord::VERSION::MAJOR == 3 && ::ActiveRecord::VERSION::MINOR >= 1
+        def schema_terms
+          ['FROM sqlite_master', 'PRAGMA', 'SHOW TABLES', 'SHOW KEYS FROM', 'SHOW FIELDS FROM']
         end
 
+        def looks_like_schema(sql)
+          schema_terms.any? { |term| sql.include?(term) }
+        end
       end
     end
   end

--- a/spec/shoulda/active_record/query_the_database_matcher_spec.rb
+++ b/spec/shoulda/active_record/query_the_database_matcher_spec.rb
@@ -1,54 +1,45 @@
 require 'spec_helper'
 
 describe Shoulda::Matchers::ActiveRecord::QueryTheDatabaseMatcher do
-  if ::ActiveRecord::VERSION::MAJOR == 3 && ::ActiveRecord::VERSION::MINOR >= 1
-    before do
-      @parent = define_model :litter do
-        has_many :kittens
-      end
-      @child = define_model :kitten, :litter_id => :integer do
-        belongs_to :litter
-      end
+  before do
+    @parent = define_model :litter do
+      has_many :kittens
     end
+    @child = define_model :kitten, :litter_id => :integer do
+      belongs_to :litter
+    end
+  end
 
-    it "accepts the correct number of queries when there is a single query" do
-      @parent.should query_the_database(1.times).when_calling(:count)
-    end
+  it "accepts the correct number of queries when there is a single query" do
+    @parent.should query_the_database(1.times).when_calling(:count)
+  end
 
-    it "accepts any number of queries when no number is specified" do
-      @parent.should query_the_database.when_calling(:count)
-    end
+  it "accepts any number of queries when no number is specified" do
+    @parent.should query_the_database.when_calling(:count)
+  end
 
-    it "rejects any number of queries when no number is specified" do
-      @parent.should_not query_the_database.when_calling(:to_s)
-    end
+  it "rejects any number of queries when no number is specified" do
+    @parent.should_not query_the_database.when_calling(:to_s)
+  end
 
-    it "accepts the correct number of queries when there are two queries" do
-      nonsense = lambda do
-        @parent.create.kittens.create
-      end
-      nonsense.should query_the_database(2.times).when_calling(:call)
+  it "accepts the correct number of queries when there are two queries" do
+    nonsense = lambda do
+      @parent.create.kittens.create
     end
+    nonsense.should query_the_database(2.times).when_calling(:call)
+  end
 
-    it "rejects the wrong number of queries" do
-      @parent.should_not query_the_database(10.times).when_calling(:count)
-    end
+  it "rejects the wrong number of queries" do
+    @parent.should_not query_the_database(10.times).when_calling(:count)
+  end
 
-    it "accepts fewer than the specified maximum" do
-      @parent.should query_the_database(5.times).or_less.when_calling(:count)
-    end
+  it "accepts fewer than the specified maximum" do
+    @parent.should query_the_database(5.times).or_less.when_calling(:count)
+  end
 
-    it "passes arguments to the method to examine" do
-      model = stub("Model", :count => nil)
-      model.should_not query_the_database.when_calling(:count).with("arguments")
-      model.should have_received(:count).with("arguments")
-    end
-  else
-    it "should raise an exception on Rails < 3.1" do
-      model = define_model(:litter)
-      lambda do
-        model.should query_the_database(1.times).when_calling(:count)
-      end.should raise_exception(RuntimeError, "Rails 3.1 or greater is required")
-    end
+  it "passes arguments to the method to examine" do
+    model = stub("Model", :count => nil)
+    model.should_not query_the_database.when_calling(:count).with("arguments")
+    model.should have_received(:count).with("arguments")
   end
 end


### PR DESCRIPTION
This patch fixes the error in jruby (see Travis CI 71.12).  The error stemmed from the jdbc-sqlite3 adapter not sending payload consistent with the built-in sqlite3 adapter.  Correcting for this also allows support for Rails 3.0.  Full test suite passes for me on MRI 1.9.3 and jruby 1.6.5.  This patch is based on e70e1bf since HEAD was failing on Travis CI for other reasons.
