### PR TITLE
Clear up the validates_uniqueness_of

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ Matchers to test validations and mass assignments:
       it { should validate_presence_of(:body).with_message(/wtf/) }
       it { should validate_presence_of(:title) }
       it { should validate_numericality_of(:user_id) }
+
+      #validates_uniqueness_of requires an entry to be in the database already
+      it "should validate uniqueness of title" do
+        Post.create!(title: "My Awesome Post")
+        subject.should validate_uniqueness_of(:title)
+      end
     end
 
     describe User do


### PR DESCRIPTION
This validation requires that an item already be in the database for the model, this just clears up the readme a bit for that item.
