### PR TITLE
Add option to skip column(s) during uniqueness testing

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_uniqueness_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_uniqueness_of_matcher.rb
@@ -19,6 +19,8 @@ module Shoulda # :nodoc:
       #   <tt>errors.on(:attribute)</tt>. <tt>Regexp</tt> or <tt>String</tt>.
       #   Defaults to the translation for <tt>:taken</tt>.
       # * <tt>scoped_to</tt> - field(s) to scope the uniqueness to.
+      # * <tt>skip_mutation_of</tt> - field(s) to skip the mutation of when testing for uniqueness.
+      #
       # * <tt>case_insensitive</tt> - ensures that the validation does not
       #   check case. Off by default. Ignored by non-text attributes.
       #
@@ -28,6 +30,9 @@ module Shoulda # :nodoc:
       #   it { should validate_uniqueness_of(:email).scoped_to(:name) }
       #   it { should validate_uniqueness_of(:email).
       #                 scoped_to(:first_name, :last_name) }
+      #   it { should validate_uniqueness_of(:user_id).
+      #                 scoped_to(:commentable_id, :commentable_type).
+      #                 skip_mutation_of(:commentable_type) }
       #   it { should validate_uniqueness_of(:keyword).case_insensitive }
       #
       def validate_uniqueness_of(attr)
@@ -43,6 +48,11 @@ module Shoulda # :nodoc:
 
         def scoped_to(*scopes)
           @scopes = [*scopes].flatten
+          self
+        end
+
+        def skip_mutation_of(*columns)
+          @skip_mutation_columns = [*columns].flatten
           self
         end
 
@@ -111,6 +121,7 @@ module Shoulda # :nodoc:
             true
           else
             @scopes.all? do |scope|
+              return true if @skip_mutation_columns.present? && @skip_mutation_columns.include?(scope)
               previous_value = @existing.send(scope)
 
               # Assume the scope is a foreign key if the field is nil

--- a/spec/shoulda/active_model/validate_uniqueness_of_matcher_spec.rb
+++ b/spec/shoulda/active_model/validate_uniqueness_of_matcher_spec.rb
@@ -159,7 +159,7 @@ describe Shoulda::Matchers::ActiveModel::ValidateUniquenessOfMatcher do
       lambda { @model.should validate_uniqueness_of(:attr).scoped_to(:scope1, :magic_column) }.should raise_error(NameError)
     end
 
-    pending "should no longer throw a type error when we tell the matcher to skip the magic column" do
+    it "should no longer throw a type error when we tell the matcher to skip the magic column" do
       lambda { @model.should validate_uniqueness_of(:attr).scoped_to(:scope1, :magic_column).skip_mutation_of(:magic_column) }.should_not raise_error(NameError)
       @model.should validate_uniqueness_of(:attr).scoped_to(:scope1, :magic_column).skip_mutation_of(:magic_column)
     end


### PR DESCRIPTION
Allows for columns to bypass mutation during the uniqueness testing. Matcher throws NameError and is able test scopes with STI and ploymorphic AR models.

Some more background of the pull request can be seen on #60.  Implemented the solution as a shoulda style matcher option rather then blindly trying to skip over "*_type" columns.

Congrats on the new office, looks great!

Cheers,
Mike D. 
