### PR TITLE
Remove `rspec-rails` from installation example code. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ Matchers to test common patterns:
 In Rails 3 and Bundler, add the following to your Gemfile:
 
     group :test do
-      gem "rspec-rails"
       gem "shoulda-matchers"
     end
 


### PR DESCRIPTION
In order to get RSpec Rails generators in a Rails app, `rspec-rails` must be included in the "development" and "test" Bundler group.

Just trying to reduce confusion with RSpec Rails users ("where are the generators?!").
