### PR TITLE
Removed old Rails 2.x layout lookup.

### DIFF
--- a/lib/shoulda/matchers/action_controller/render_with_layout_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/render_with_layout_matcher.rb
@@ -66,16 +66,7 @@ module Shoulda # :nodoc:
         end
 
         def rendered_layouts
-          if recorded_layouts.size > 0
-            recorded_layouts.keys.compact.map { |layout| layout.sub(%r{^layouts/}, '') }
-          else
-            layout = @controller.response.layout
-            if layout.nil?
-              []
-            else
-              [layout.split('/').last]
-            end
-          end
+          recorded_layouts.keys.compact.map { |layout| layout.sub(%r{^layouts/}, '') }
         end
 
         def recorded_layouts

--- a/spec/shoulda/action_controller/render_with_layout_matcher_spec.rb
+++ b/spec/shoulda/action_controller/render_with_layout_matcher_spec.rb
@@ -31,6 +31,14 @@ describe Shoulda::Matchers::ActionController::RenderWithLayoutMatcher do
     end
   end
 
+  context "a controller that renders a partial" do
+    let(:controller) { build_response { render :partial => 'partial' } }
+
+    it "should reject rendering with a layout" do
+      controller.should_not render_with_layout
+    end
+  end
+
   context "given a context with layouts" do
     let(:layout) { 'happy' }
     let(:controller) { build_response { render :layout => false } }


### PR DESCRIPTION
Fixes render_with_layout matcher when rendering with only a partial. (Rendering with :layout => false would also have had this problem on Edge Rails.)
