### PR TITLE
Mix RSpec with Test::Unit

### DIFF
--- a/features/rails_integration.feature
+++ b/features/rails_integration.feature
@@ -86,3 +86,31 @@ Feature: integrate with Rails
     Then the output should contain "2 examples, 0 failures"
     And the output should contain "should require name to be set"
     And the output should contain "should assign @example"
+
+  Scenario: generate a Rails application that mixes Rspec and Test::Unit
+    When I configure the application to use rspec-rails in test and development
+    And I configure the application to use "shoulda-matchers" from this project in test and development
+    And I run the rspec generator
+    And I write to "spec/models/user_spec.rb" with:
+      """
+      require 'spec_helper'
+
+      describe User do
+        it { should validate_presence_of(:name) }
+      end
+      """
+    When I write to "test/functional/examples_controller_test.rb" with:
+      """
+      require 'test_helper'
+
+      class ExamplesControllerTest < ActionController::TestCase
+        test 'assigns to @example' do
+          get :show
+          assert assign_to(:example).matches?(@controller)
+        end
+      end
+      """
+    When I successfully run `bundle exec rake spec test:functionals SPEC_OPTS=-fs --trace`
+    Then the output should contain "1 example, 0 failures"
+    And the output should contain "1 tests, 1 assertions, 0 failures, 0 errors"
+    And the output should contain "should require name to be set"

--- a/features/step_definitions/rails_steps.rb
+++ b/features/step_definitions/rails_steps.rb
@@ -36,6 +36,15 @@ When /^I configure the application to use "([^\"]+)" from this project$/ do |nam
   steps %{And I run `bundle install --local`}
 end
 
+When /^I configure the application to use "([^\"]+)" from this project in test and development$/ do |name|
+  append_to_gemfile <<-GEMFILE
+  group :test, :development do
+    gem '#{name}', :path => '#{PROJECT_ROOT}'
+  end
+  GEMFILE
+  steps %{And I run `bundle install --local`}
+end
+
 When 'I run the rspec generator' do
   steps %{
     When I successfully run `rails generate rspec:install`
@@ -44,6 +53,15 @@ end
 
 When 'I configure the application to use rspec-rails' do
   append_to_gemfile "gem 'rspec-rails', '~> 2.8.1'"
+  steps %{And I run `bundle install --local`}
+end
+
+When 'I configure the application to use rspec-rails in test and development' do
+  append_to_gemfile <<-GEMFILE
+  group :test, :development do
+    gem 'rspec-rails', '~> 2.8.1'
+  end
+  GEMFILE
   steps %{And I run `bundle install --local`}
 end
 

--- a/lib/shoulda/matchers.rb
+++ b/lib/shoulda/matchers.rb
@@ -3,6 +3,6 @@ require 'shoulda/matchers/assertion_error'
 
 if defined?(RSpec)
   require 'shoulda/matchers/integrations/rspec'
-else
-  require 'shoulda/matchers/integrations/test_unit'
 end
+
+require 'shoulda/matchers/integrations/test_unit'


### PR DESCRIPTION
An edge case occurs when mixing RSpec and Test::Unit tests and also
loading both the 'rspec-rails' gem and 'shoulda-matchers' gem from the
same Gemfile group, namely [:test, :development] . Work around this by
always inserting the shoulda matchers into Test::Unit, regardless of
whether RSpec is loaded.
