### PR TITLE
Fix ensure_length_of matcher to work for is_equal_to cases when the attribute has other validations on it

### DIFF
--- a/lib/shoulda/matchers/active_model/ensure_length_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/ensure_length_of_matcher.rb
@@ -58,6 +58,7 @@ module Shoulda # :nodoc:
           @options[:minimum] = length
           @options[:maximum] = length
           @short_message ||= :wrong_length
+          @long_message ||= :wrong_length
           self
         end
 

--- a/spec/shoulda/active_model/ensure_length_of_matcher_spec.rb
+++ b/spec/shoulda/active_model/ensure_length_of_matcher_spec.rb
@@ -86,6 +86,19 @@ describe Shoulda::Matchers::ActiveModel::EnsureLengthOfMatcher do
     end
   end
 
+  context "an attribute with a required exact length and another validation" do
+    before do
+      @model = define_model(:example, :attr => :string) do
+        validates_length_of :attr, :is => 4
+        validates_numericality_of :attr
+      end.new
+    end
+
+    it "should accept ensuring the correct length" do
+      @model.should ensure_length_of(:attr).is_equal_to(4)
+    end
+  end
+
   context "an attribute with a custom minimum length validation" do
     before do
       @model = define_model(:example, :attr => :string) do


### PR DESCRIPTION
After a recent refactor, ensure_length_of started failing in the is_equal_to case for any attribute that has other validations on it.

Now that the upper bound matchers are not being skipped for the is_equal_to case, the expected error message needs to be set for the upper bound.
