### PR TITLE
Additional parameters for validate numericality

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_numericality_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_numericality_of_matcher.rb
@@ -8,16 +8,44 @@ module Shoulda # :nodoc:
       #   <tt>errors.on(:attribute)</tt>. Regexp or string.  Defaults to the
       #   translation for <tt>:not_a_number</tt>.
       # * <tt>only_integer</tt> - allows only integer values
+      # * <tt>with_greater_than_message</tt> - value the test expects to find in
+      #   <tt>errors.on(:attribute)</tt> when parameter 'greater_than' added. Regexp or string.  Defaults to the
+      #   translation for <tt>:greater_than</tt>.
+      # * <tt>with_less_than_message</tt> - value the test expects to find in
+      #   <tt>errors.on(:attribute)</tt> when parameter 'less_than' added. Regexp or string.  Defaults to the
+      #   translation for <tt>:less_than</tt>.
+      # * <tt>with_greater_than_or_equal_to_message</tt> - value the test expects to find in
+      #   <tt>errors.on(:attribute)</tt> when parameter 'greater_than_or_equal_to' added. Regexp or string.  Defaults to the
+      #   translation for <tt>:greater_than_or_equal_to</tt>.
+      # * <tt>with_less_than_or_equal_to_message</tt> - value the test expects to find in
+      #   <tt>errors.on(:attribute)</tt> when parameter 'less_than_or_equal_to' added. Regexp or string.  Defaults to the
+      #   translation for <tt>:less_than_or_equal_to</tt>.
+      # * <tt>with_equal_to_message</tt> - value the test expects to find in
+      #   <tt>errors.on(:attribute)</tt> when parameter 'equal_to' added. Regexp or string.  Defaults to the
+      #   translation for <tt>:equal_to</tt>.
       #
       # Examples:
       #   it { should validate_numericality_of(:price) }
       #   it { should validate_numericality_of(:age).only_integer }
+      #   it { should validate_numericality_of(:age).with_message('custom message') }
+      #   it { should validate_numericality_of(:age).greater_than(18) }
+      #   it { should validate_numericality_of(:age).greater_than(18).with_greater_than_message('custom message') }
+      #   it { should validate_numericality_of(:age).less_than(300) }
+      #   it { should validate_numericality_of(:age).less_than(300).with_less_than_message('custom message') }
+      #   it { should validate_numericality_of(:age).greater_than_or_equal_to(18) }
+      #   it { should validate_numericality_of(:age).greater_than_or_equal_to(18).with_greater_than_or_equal_to_message('custom message') }
+      #   it { should validate_numericality_of(:age).less_than_or_equal_to(300) }
+      #   it { should validate_numericality_of(:age).less_than_or_equal_to(300).with_less_than_or_equal_to_message('custom message') }
+      #   it { should validate_numericality_of(:age).equal_to(25) }
+      #   it { should validate_numericality_of(:age).equal_to(25).with_equal_to_message('custom message') }
       #
       def validate_numericality_of(attr)
         ValidateNumericalityOfMatcher.new(attr)
       end
 
       class ValidateNumericalityOfMatcher < ValidationMatcher # :nodoc:
+        include Helpers
+
         def initialize(attribute)
           super(attribute)
           @options = {}
@@ -25,6 +53,61 @@ module Shoulda # :nodoc:
 
         def only_integer
           @options[:only_integer] = true
+          self
+        end
+
+        def greater_than(number)
+          @greater_than = number
+          @greater_than_message ||= :greater_than
+          self
+        end
+
+        def with_greater_than_message(message)
+          @greater_than_message = message if message
+          self
+        end
+
+        def less_than(number)
+          @less_than = number
+          @less_than_message ||= :less_than
+          self
+        end
+
+        def with_less_than_message(message)
+          @less_than_message = message if message
+          self
+        end
+
+        def greater_than_or_equal_to(number)
+          @greater_than_or_equal_to = number
+          @greater_than_or_equal_to_message ||= :greater_than_or_equal_to
+          self
+        end
+
+        def with_greater_than_or_equal_to_message(message)
+          @greater_than_or_equal_to_message = message if message
+          self
+        end
+
+        def less_than_or_equal_to(number)
+          @less_than_or_equal_to = number
+          @less_than_or_equal_to_message ||= :less_than_or_equal_to
+          self
+        end
+
+        def with_less_than_or_equal_to_message(message)
+          @less_than_or_equal_to_message = message if message
+          self
+        end
+
+        def equal_to(number)
+          @equal_to = number
+          @equal_to_message ||= :equal_to
+          self
+        end
+
+        def with_equal_to_message(message)
+          @equal_to_message = message if message
           self
         end
 
@@ -37,11 +120,22 @@ module Shoulda # :nodoc:
 
         def matches?(subject)
           super(subject)
-          disallows_non_integers? && disallows_text?
+          translate_messages!
+
+          disallows_non_integers? &&
+            disallows_text? &&
+            disallows_greater_than_value &&
+            disallows_less_than_value &&
+            disallows_greater_than_or_equal_to_value &&
+            disallows_less_than_or_equal_to_value &&
+            disallows_equal_to_value
         end
 
         def description
-          "only allow #{allowed_type} values for #{@attribute}"
+          result = [:greater_than, :greater_than_or_equal_to, :less_than, :less_than_or_equal_to, :equal_to].map do |method|
+            "#{method} #{instance_variable_get("@#{method}")}" if instance_variable_get("@#{method}")
+          end
+          ["only allow #{allowed_type} values", result.compact.join(', '), "for", @attribute].join(" ")
         end
 
         private
@@ -66,6 +160,48 @@ module Shoulda # :nodoc:
         def disallows_text?
           message = @expected_message || :not_a_number
           disallows_value_of('abcd', message)
+        end
+
+        def disallows_greater_than_value
+          @greater_than.nil? || disallows_value_of(@greater_than, @greater_than_message)
+        end
+
+        def disallows_less_than_value
+          @less_than.nil? || disallows_value_of(@less_than, @less_than_message)
+        end
+
+        def disallows_greater_than_or_equal_to_value
+          @greater_than_or_equal_to.nil? || disallows_value_of(@greater_than_or_equal_to-1, @greater_than_or_equal_to_message)
+        end
+
+        def disallows_less_than_or_equal_to_value
+          @less_than_or_equal_to.nil? || disallows_value_of(@less_than_or_equal_to+1, @less_than_or_equal_to_message)
+        end
+
+        def disallows_equal_to_value
+          @equal_to.nil? || disallows_value_of(@equal_to+1, @equal_to_message)
+        end
+
+        def translate_messages!
+          if Symbol === @greater_than_message
+            @greater_than_message = default_error_message(@greater_than_message, :count => @greater_than)
+          end
+
+          if Symbol === @less_than_message
+            @less_than_message = default_error_message(@less_than_message, :count => @less_than)
+          end
+
+          if Symbol === @greater_than_or_equal_to_message
+            @greater_than_or_equal_to_message = default_error_message(@greater_than_or_equal_to_message, :count => @greater_than_or_equal_to)
+          end
+
+          if Symbol === @less_than_or_equal_to_message
+            @less_than_or_equal_to_message = default_error_message(@less_than_or_equal_to_message, :count => @less_than_or_equal_to)
+          end
+
+          if Symbol === @equal_to_message
+            @equal_to_message = default_error_message(@equal_to_message, :count => @equal_to)
+          end
         end
       end
     end

--- a/spec/shoulda/active_model/validate_numericality_of_matcher_spec.rb
+++ b/spec/shoulda/active_model/validate_numericality_of_matcher_spec.rb
@@ -49,6 +49,62 @@ describe Shoulda::Matchers::ActiveModel::ValidateNumericalityOfMatcher do
     end
   end
 
+  all_possible_validate_numericality_of_methods.each do |parameter|
+    context "a numeric attribute with a '#{parameter.to_s}' parameter" do
+      before do
+        define_model(:example, :attr => :integer) do
+          validates_numericality_of :attr, parameter => 0
+        end
+        @model = Example.new
+      end
+
+      it "should only allow numeric values #{parameter} indicated value for that attribute" do
+        @model.should validate_numericality_of(:attr).send(parameter, 0)
+      end
+    end
+
+    context "a numeric attribute without a '#{parameter.to_s}' parameter" do
+      before do
+        define_model(:example, :attr => :integer) do
+          validates_numericality_of :attr
+        end
+        @model = Example.new
+      end
+
+      it "should not allow numeric values without #{parameter} indicated value for that attribute" do
+        @model.should_not validate_numericality_of(:attr).send(parameter, 0)
+      end
+    end
+
+    context "a numeric attribute with a '#{parameter.to_s}' parameter and a custom message" do
+      before do
+        define_model(:example, :attr => :integer) do
+          validates_numericality_of :attr
+          validates_numericality_of :attr, parameter => 0, :message => "#{parameter} custom message"
+        end
+        @model = Example.new
+      end
+
+      it "should only allow numeric values #{parameter} indicated value for that attribute with message '#{parameter} custom message'" do
+        @model.should validate_numericality_of(:attr).send(parameter, 0).send("with_#{parameter}_message", "#{parameter} custom message")
+      end
+    end
+  end
+
+  context "description tests" do
+    all_possible_validate_numericality_of_methods.each do |parameter|
+      it "should return the correct description when the #{parameter} validation fails" do
+        validate_numericality_of(:attr).send(parameter, 0).description.should == "only allow numeric values #{parameter} 0 for attr"
+      end
+    end
+
+    all_possible_combinations_of_greater_than_or_less_than_methods.each do |parameter_with_greater, parameter_with_less|
+      it "should return the correct description when the #{parameter_with_greater}, #{parameter_with_less} validations fails" do
+        validate_numericality_of(:attr).send(parameter_with_greater, 0).send(parameter_with_less, 10).description.should == "only allow numeric values #{parameter_with_greater} 0, #{parameter_with_less} 10 for attr"
+      end
+    end
+  end
+
   context "a non-numeric attribute" do
     before do
       @model = define_model(:example, :attr => :string).new

--- a/spec/support/validate_numericality_of.rb
+++ b/spec/support/validate_numericality_of.rb
@@ -1,0 +1,10 @@
+RSpec.configure do |c|
+  def all_possible_combinations_of_greater_than_or_less_than_methods
+    [:greater_than, :greater_than_or_equal_to].product([:less_than_or_equal_to, :less_than])
+  end
+
+  def all_possible_validate_numericality_of_methods
+    [:greater_than, :greater_than_or_equal_to, :equal_to, :less_than, :less_than_or_equal_to]
+  end
+end
+


### PR DESCRIPTION
I merged the current master branch with pull request from:

https://github.com/thoughtbot/shoulda-matchers/pull/82

and resolved merge conflicts.

The code has changed a little bit, so it is possible that it will require some refactoring. Few suggestions:
1. use @options hash, instead instance variables. Example:

``` ruby
    def greater_than(number)
      @options[:greater_than] = number
      @options[:grader_than_message] ||= :greater_than
    end
```
1. disallows_text? and disallows_non_integers? methods have _?_ at the end of the method, but new methods like disallows_equal_to_value, doesn't have it. It would be good to make it uniform.
