### PR TITLE
protect against unmatchable to

### DIFF
--- a/lib/shoulda/matchers/action_controller/set_the_flash_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/set_the_flash_matcher.rb
@@ -25,6 +25,9 @@ module Shoulda # :nodoc:
         attr_reader :failure_message, :negative_failure_message
 
         def to(value)
+          if !value.is_a?(String) && !value.is_a?(Regexp)
+            raise "cannot match against #{value.inspect}"
+          end
           @value = value
           self
         end

--- a/spec/shoulda/action_controller/set_the_flash_matcher_spec.rb
+++ b/spec/shoulda/action_controller/set_the_flash_matcher_spec.rb
@@ -1,6 +1,12 @@
 require 'spec_helper'
 
 describe Shoulda::Matchers::ActionController::SetTheFlashMatcher do
+  it "should fail with unmatchable to" do
+    expect{
+      set_the_flash.to(1)
+    }.to raise_error
+  end
+
   context "a controller that sets a flash message" do
     let(:controller) { build_response { flash[:notice] = 'value' } }
 


### PR DESCRIPTION
we had a bunch of evergreen

```
should set_the_flash.to :notice => "xxx"
```

which look like they worked but did not, this commit warns you when you do something stupid :)
