### PR TITLE
response is undefined when using respond_with and subject

### DIFF
--- a/lib/shoulda/matchers/action_controller/respond_with_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/respond_with_matcher.rb
@@ -16,12 +16,13 @@ module Shoulda # :nodoc:
       #   it { should respond_with(:error)    }
       #   it { should respond_with(501)       }
       def respond_with(status)
-        RespondWithMatcher.new(status)
+        RespondWithMatcher.new(self, status)
       end
 
       class RespondWithMatcher # :nodoc:
 
-        def initialize(status)
+        def initialize(controller, status)
+          @controller = controller
           @status = symbol_to_status_code(status)
         end
 


### PR DESCRIPTION
I have tried rails with rspec and shoulda, but I run into following issue:

The example in controller spec:

``` ruby
  describe '#index' do
    subject { get :index }
    it { should respond_with(:success) }
  end
```

fails with:

```
 Failure/Error: it { should respond_with(:forbidden) }
     NoMethodError:
       undefined method `response' for #<ActionController::TestResponse:0xbcb2018>
```

If I substitute the line 

``` ruby
it { should respond_with(:success) } 
```

with some rspec matcher, i.e. 

``` ruby
it { should redirect_to(login_path) }
```

it works. I looked up to the difference between rspec matchers and shoulda matchers and realized that rspec matchers pass the controller object to the matcher at constructor, like here: https://github.com/rspec/rspec-rails/blob/master/lib/rspec/rails/matchers/redirect_to.rb. I modified `respond_with` matcher in a similar way and it fixes my issue and doesn't break any other spec or feature.

Versions:
- rails (3.2.8)
- rspec (2.11.0)
- shoulda-matchers (1.0.0)
