### PR TITLE
Ability to use 'have_and_belong_to_many' matcher when models use an alternate database

### DIFF
--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -243,7 +243,7 @@ module Shoulda # :nodoc:
 
         def join_table_exists?
           if @macro != :has_and_belongs_to_many ||
-              ::ActiveRecord::Base.connection.tables.include?(join_table)
+              model_class.connection.tables.include?(join_table)
             true
           else
             @missing = "join table #{join_table} doesn't exist"


### PR DESCRIPTION
The have_and_belong_to_many matcher assumes that the join table exists in the database defined in ActiveRecord::Base.connection.  However, it's possible to define models that point to alternate databases.  When these models use HABTM relationships, the join table will also exist in this "other" database.

The code change I have made is simple:  Instead of using ActiveRecord::Base.connection, I use model_class.connection.  This ensures that we look for the join table using the parent model's connection. 

In theory, there should be no test changes.  All the the tests should continue to work, that's the test.

However, if you have some suggestions for how I should test this, please let me know.
