### PR TITLE
Add "is_within" method to EnsureLengthOfMatcher

### DIFF
--- a/lib/shoulda/matchers/active_model/ensure_length_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/ensure_length_of_matcher.rb
@@ -9,6 +9,7 @@ module Shoulda # :nodoc:
       # * <tt>is_at_least</tt> - minimum length of this attribute
       # * <tt>is_at_most</tt> - maximum length of this attribute
       # * <tt>is_equal_to</tt> - exact requred length of this attribute
+      # * <tt>is_within</tt> - attribute is within a given range
       # * <tt>with_short_message</tt> - value the test expects to find in
       #   <tt>errors.on(:attribute)</tt>. Regexp or string.  Defaults to the
       #   translation for :too_short.
@@ -24,6 +25,8 @@ module Shoulda # :nodoc:
       #   it { should ensure_length_of(:password).
       #                 is_at_least(6).
       #                 is_at_most(20) }
+      #   it { should ensure_length_of(:password).
+      #                 is_within(6..20) }
       #   it { should ensure_length_of(:name).
       #                 is_at_least(3).
       #                 with_short_message(/not long enough/) }
@@ -58,6 +61,11 @@ module Shoulda # :nodoc:
           @options[:minimum] = length
           @options[:maximum] = length
           @short_message ||= :wrong_length
+          self
+        end
+
+        def is_within(range)
+          is_at_least(range.min) && is_at_most(range.max)
           self
         end
 

--- a/spec/shoulda/active_model/ensure_length_of_matcher_spec.rb
+++ b/spec/shoulda/active_model/ensure_length_of_matcher_spec.rb
@@ -122,4 +122,20 @@ describe Shoulda::Matchers::ActiveModel::EnsureLengthOfMatcher do
     end
   end
 
+  context "an attribute with a length validation within a range" do
+    before do
+      @model = define_model(:example, :attr => :string) do
+        validates_length_of :attr, :within => 5..10
+      end.new
+    end
+
+    it "should accept ensuring the correct minimum and maximum length" do
+      @model.should ensure_length_of(:attr).is_within(5..10)
+    end
+
+    it "should accept with an exclusive range" do
+      @model.should ensure_length_of(:attr).is_within(5...11)
+    end
+  end
+
 end


### PR DESCRIPTION
This seems like something you guys would have added already if you
actually wanted it, so apologies if that's the case.

Otherwise, this seems like it would be a handy shortcut to calling both
`is_at_least` and `is_at_most`.
