### PR TITLE
Allow matched_index.unique to be truthy.

### DIFF
--- a/lib/shoulda/matchers/active_record/have_db_index_matcher.rb
+++ b/lib/shoulda/matchers/active_record/have_db_index_matcher.rb
@@ -62,13 +62,16 @@ module Shoulda # :nodoc:
         def correct_unique?
           return true unless @options.key?(:unique)
 
-          if matched_index.unique == @options[:unique]
-            true
-          else
+          is_unique = matched_index.unique
+
+          is_unique = !is_unique unless @options[:unique]
+
+          unless is_unique
             @missing = "#{table_name} has an index named #{matched_index.name} " <<
-                       "of unique #{matched_index.unique}, not #{@options[:unique]}."
-            false
+            "of unique #{matched_index.unique}, not #{@options[:unique]}."
           end
+
+          is_unique
         end
 
         def matched_index

--- a/spec/shoulda/active_record/have_db_index_matcher_spec.rb
+++ b/spec/shoulda/active_record/have_db_index_matcher_spec.rb
@@ -85,4 +85,21 @@ describe Shoulda::Matchers::ActiveRecord::HaveDbIndexMatcher do
   it "should not context an index's uniqueness when it isn't important" do
     have_db_index(:user_id).description.should_not =~ /unique/
   end
+
+  it "allows an IndexDefinition to have a truthy value for unique" do
+    db_connection = create_table 'superheros' do |table|
+      table.integer :age
+    end
+    db_connection.add_index :superheros, :age
+    define_model_class 'Superhero'
+
+    @matcher = have_db_index(:age).unique(true)
+
+    index_definition = stub("ActiveRecord::ConnectionAdapters::IndexDefinition",
+                            :unique => 7,
+                            :name => :age)
+    @matcher.stubs(:matched_index => index_definition)
+
+    Superhero.new.should @matcher
+  end
 end


### PR DESCRIPTION
Currently, there is an assumption that `matched_index.unique` will
be `true` and not truthy. This is not always the case. This can
cause tests to fail, even though they should pass. This allows
`matched_index.unique` to be truthy.

This is just a first go to see what you think, I'm more than happy to adjust, as I've never even used shoulda before, to be honest.

This was inspired by https://groups.google.com/forum/?fromgroups=#!topic/rubyonrails-core/MM3Lh2M8QBE , more information is there.
