### PR TITLE
Test more blank values with allow_blank

### DIFF
--- a/lib/shoulda/matchers/active_model/ensure_inclusion_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/ensure_inclusion_of_matcher.rb
@@ -96,7 +96,10 @@ module Shoulda # :nodoc:
 
         def allows_blank_value?
           if @options.key?(:allow_blank)
-            @options[:allow_blank] == allows_value_of('')
+            blank_values = ['', ' ', "\n", "\r", "\t", "\f"]
+            @options[:allow_blank] == blank_values.inject(true) do |memo, value|
+              memo &&= allows_value_of(value)
+            end
           else
             true
           end

--- a/spec/shoulda/active_model/ensure_inclusion_of_matcher_spec.rb
+++ b/spec/shoulda/active_model/ensure_inclusion_of_matcher_spec.rb
@@ -121,6 +121,19 @@ describe Shoulda::Matchers::ActiveModel::EnsureInclusionOfMatcher do
     end
   end
 
+  context "an attribute allowing some blank values but not others" do
+    before do
+      @model = define_model(:example, :attr => :string) do
+        validates_inclusion_of :attr, :in => ['one', 'two', '']
+      end.new
+    end
+
+    it "rejects allow_blank" do
+      @model.should_not ensure_inclusion_of(:attr).in_array(['one', 'two', '']).allow_blank(true)
+      @model.should ensure_inclusion_of(:attr).in_array(['one', 'two', '']).allow_blank(false)
+    end
+  end
+
   if Rails::VERSION::STRING.to_f >= 3.2
     context "a strict attribute which must be included in a range" do
       before do


### PR DESCRIPTION
This fixes the specific issue described in #120. It doesn't rigorously account for all cases where an attribute allows a subset of "blank" values, but I'm not sure how that could be accomplished or whether it's even necessary to do so.
