### PR TITLE
Use arbitrary string for outside value

### DIFF
--- a/lib/shoulda/matchers/active_model/ensure_inclusion_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/ensure_inclusion_of_matcher.rb
@@ -22,6 +22,8 @@ module Shoulda # :nodoc:
       end
 
       class EnsureInclusionOfMatcher < ValidationMatcher # :nodoc:
+        ARBITRARY_OUTSIDE_STRING = "shouldamatchersteststring"
+
         def initialize(attribute)
           super(attribute)
           @options = {}
@@ -138,20 +140,14 @@ module Shoulda # :nodoc:
         end
 
         def disallows_value_outside_of_array?
-          if value_outside_of_array
-            disallows_value_of(value_outside_of_array)
-          else
-            raise CouldNotDetermineValueOutsideOfArray
-          end
+          disallows_value_of(value_outside_of_array)
         end
 
         def value_outside_of_array
-          found = @array.detect do |item|
-            !@array.include?(item.next)
-          end
-
-          if found
-            found.next
+          if @array.include?(ARBITRARY_OUTSIDE_STRING)
+            raise CouldNotDetermineValueOutsideOfArray
+          else
+            ARBITRARY_OUTSIDE_STRING
           end
         end
       end

--- a/spec/shoulda/active_model/ensure_inclusion_of_matcher_spec.rb
+++ b/spec/shoulda/active_model/ensure_inclusion_of_matcher_spec.rb
@@ -12,11 +12,20 @@ describe Shoulda::Matchers::ActiveModel::EnsureInclusionOfMatcher do
     end
   end
 
+  context "with true/false values" do
+    it "can verify outside values to ensure the negative case" do
+      model = define_model(:example, :attr => :string).new
+
+      model.should_not ensure_inclusion_of(:attr).in_array([true, false])
+    end
+  end
+
   context "where we cannot determine a value outside the array" do
     it "should raise a custom exception" do
-      @model = define_model(:example, :attr => :string).new
+      model = define_model(:example, :attr => :string).new
 
-      expect { @model.should ensure_inclusion_of(:attr).in_array([""]) }.to raise_error Shoulda::Matchers::ActiveModel::CouldNotDetermineValueOutsideOfArray
+      arbitrary_string = Shoulda::Matchers::ActiveModel::EnsureInclusionOfMatcher::ARBITRARY_OUTSIDE_STRING
+      expect { model.should ensure_inclusion_of(:attr).in_array([arbitrary_string]) }.to raise_error Shoulda::Matchers::ActiveModel::CouldNotDetermineValueOutsideOfArray
     end
   end
 


### PR DESCRIPTION
Use .next was causing issues.  

I used a short arbitrary string to prevent possibly stepping on other validations such as length or characters.
