### PR TITLE
Fix an issue with formatting between 1.9.3 & 1.8.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     shoulda-matchers (1.4.1)
       activesupport (>= 3.0.0)
+      bourne (~> 1.1.2)
 
 GEM
   remote: http://rubygems.org/
@@ -137,7 +138,6 @@ DEPENDENCIES
   activerecord-jdbcsqlite3-adapter
   appraisal (~> 0.4.0)
   aruba
-  bourne (~> 1.1.2)
   bundler (~> 1.1)
   cucumber (~> 1.1.9)
   jdbc-sqlite3

--- a/gemfiles/3.0.gemfile.lock
+++ b/gemfiles/3.0.gemfile.lock
@@ -1,8 +1,9 @@
 PATH
   remote: /Users/draper/Dropbox/Development/shoulda-matchers
   specs:
-    shoulda-matchers (1.4.0)
+    shoulda-matchers (1.4.1)
       activesupport (>= 3.0.0)
+      bourne (~> 1.1.2)
 
 GEM
   remote: http://rubygems.org/
@@ -107,7 +108,7 @@ GEM
       activesupport (>= 3.0)
       railties (>= 3.0)
       rspec (~> 2.8.0)
-    shoulda-context (1.0.0)
+    shoulda-context (1.0.1)
     sqlite3 (1.3.6)
     term-ansicolor (1.0.7)
     thor (0.14.6)
@@ -124,7 +125,6 @@ DEPENDENCIES
   activerecord-jdbcsqlite3-adapter
   appraisal (~> 0.4.0)
   aruba
-  bourne (~> 1.1.2)
   bundler (~> 1.1)
   cucumber (~> 1.1.9)
   jdbc-sqlite3

--- a/gemfiles/3.1.gemfile.lock
+++ b/gemfiles/3.1.gemfile.lock
@@ -1,8 +1,9 @@
 PATH
   remote: /Users/draper/Dropbox/Development/shoulda-matchers
   specs:
-    shoulda-matchers (1.4.0)
+    shoulda-matchers (1.4.1)
       activesupport (>= 3.0.0)
+      bourne (~> 1.1.2)
 
 GEM
   remote: http://rubygems.org/
@@ -46,7 +47,7 @@ GEM
       rspec-expectations (>= 2.7.0)
     bourne (1.1.2)
       mocha (= 0.10.5)
-    builder (3.0.3)
+    builder (3.0.4)
     childprocess (0.2.3)
       ffi (~> 1.0.6)
     cucumber (1.1.9)
@@ -122,7 +123,7 @@ GEM
       railties (~> 3.1.0)
       sass (>= 3.1.10)
       tilt (~> 1.3.2)
-    shoulda-context (1.0.0)
+    shoulda-context (1.0.1)
     sprockets (2.0.4)
       hike (~> 1.2)
       rack (~> 1.0)
@@ -144,7 +145,6 @@ DEPENDENCIES
   activerecord-jdbcsqlite3-adapter
   appraisal (~> 0.4.0)
   aruba
-  bourne (~> 1.1.2)
   bundler (~> 1.1)
   cucumber (~> 1.1.9)
   jdbc-sqlite3

--- a/gemfiles/3.2.gemfile.lock
+++ b/gemfiles/3.2.gemfile.lock
@@ -1,8 +1,9 @@
 PATH
   remote: /Users/draper/Dropbox/Development/shoulda-matchers
   specs:
-    shoulda-matchers (1.4.0)
+    shoulda-matchers (1.4.1)
       activesupport (>= 3.0.0)
+      bourne (~> 1.1.2)
 
 GEM
   remote: http://rubygems.org/
@@ -45,7 +46,7 @@ GEM
       rspec-expectations (>= 2.7.0)
     bourne (1.1.2)
       mocha (= 0.10.5)
-    builder (3.0.3)
+    builder (3.0.4)
     childprocess (0.2.3)
       ffi (~> 1.0.6)
     cucumber (1.1.9)
@@ -119,7 +120,7 @@ GEM
       railties (~> 3.2.0)
       sass (>= 3.1.10)
       tilt (~> 1.3)
-    shoulda-context (1.0.0)
+    shoulda-context (1.0.1)
     sprockets (2.1.3)
       hike (~> 1.2)
       rack (~> 1.0)
@@ -141,7 +142,6 @@ DEPENDENCIES
   activerecord-jdbcsqlite3-adapter
   appraisal (~> 0.4.0)
   aruba
-  bourne (~> 1.1.2)
   bundler (~> 1.1)
   cucumber (~> 1.1.9)
   jdbc-sqlite3

--- a/lib/shoulda/matchers/independent/delegate_matcher.rb
+++ b/lib/shoulda/matchers/independent/delegate_matcher.rb
@@ -71,7 +71,7 @@ module Shoulda # :nodoc:
 
         def add_clarifications_to(message)
           if @delegated_arguments.present?
-            message << " with arguments: #{@delegated_arguments}"
+            message << " with arguments: #{@delegated_arguments.inspect}"
           end
 
           if @method_on_target.present?


### PR DESCRIPTION
The tests fail on travis ci due to the printing difference of an array in 1.9.3 & 1.8.7.  This should fix that issue.
