### PR TITLE
#88: Do not force minitest loading when test-unit is available

### DIFF
--- a/lib/shoulda/matchers/assertion_error.rb
+++ b/lib/shoulda/matchers/assertion_error.rb
@@ -4,7 +4,7 @@ module Shoulda
       require 'test/unit'
       AssertionError = Test::Unit::AssertionFailedError
     elsif defined?(Test::Unit::AssertionFailedError)
-      # It looks like we already have what we need ;)
+      # Test::Unit has been loaded already, so we use it
       AssertionError = Test::Unit::AssertionFailedError
     elsif Gem.ruby_version >= Gem::Version.new("1.9")
       require 'minitest/unit'


### PR DESCRIPTION
It looks like fix for #88 was removed by the very next change in assertion_error.rb (27b8b781a5d708fbbea10b6a431df6b09ba95e47)
So, here is a re-fix for the problem described in #88 (we should not load minitest if test-unit is already available)
