### PR TITLE
updated RouteMatcher syntax

### DIFF
--- a/lib/shoulda/matchers/action_controller/route_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/route_matcher.rb
@@ -22,6 +22,8 @@ module Shoulda # :nodoc:
       #                 to(:action => :destroy, :id => 1) }
       #   it { should route(:get, "/users/1/posts/1").
       #                 to(:action => :show, :id => 1, :user_id => 1) }
+      #
+      #   it { should_not route(:get, "/bad_route") }
       def route(method, path)
         RouteMatcher.new(method, path, self)
       end
@@ -31,6 +33,7 @@ module Shoulda # :nodoc:
           @method  = method
           @path    = path
           @context = context
+          @params  = {}
         end
 
         attr_reader :failure_message, :negative_failure_message

--- a/spec/shoulda/action_controller/route_matcher_spec.rb
+++ b/spec/shoulda/action_controller/route_matcher_spec.rb
@@ -51,6 +51,10 @@ describe Shoulda::Matchers::ActionController::RouteMatcher do
       controller.should_not route(:get, '/bad_route').to(:var => 'value')
     end
 
+    it "should reject an undefined route without using to" do
+      controller.should_not route(:get, '/bad_route')
+    end
+
     it "should reject a route for another controller" do
       other = define_controller('Other').new
       other.should_not route(:get, '/examples/1').


### PR DESCRIPTION
to understand something like this:

```
it { should_not route(:get, "/bad_route") }
```
