### PR TITLE
ValidateFormatOfMatcher#not_with renamed to #without

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_format_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_format_of_matcher.rb
@@ -12,14 +12,14 @@ module Shoulda # :nodoc:
       #   <tt>errors.on(:attribute)</tt>. <tt>Regexp</tt> or <tt>String</tt>.
       #   Defaults to the translation for <tt>:invalid</tt>.
       # * <tt>with(string to test against)</tt>
-      # * <tt>not_with(string to test against)</tt>
+      # * <tt>without(string to test against)</tt>
       #
       # Examples:
       #   it { should validate_format_of(:name).
       #                 with('12345').
       #                 with_message(/is not optional/) }
       #   it { should validate_format_of(:name).
-      #                 not_with('12D45').
+      #                 without('12D45').
       #                 with_message(/is not optional/) }
       #
       def validate_format_of(attr)
@@ -49,15 +49,21 @@ module Shoulda # :nodoc:
         end
 
         def with(value)
-          raise "You may not call both with and not_with" if @value_to_fail
+          raise "You may not call both with and without" if @value_to_fail
           @value_to_pass = value
           self
         end
 
-        def not_with(value)
-          raise "You may not call both with and not_with" if @value_to_pass
+        def without(value)
+          raise "You may not call both with and without" if @value_to_pass
           @value_to_fail = value
           self
+        end
+
+        # Deprecated
+        # See: ValidateFormatOfMatcher#without
+        def not_with(value)
+          without(value)
         end
 
         def matches?(subject)

--- a/spec/shoulda/active_model/validate_format_of_matcher_spec.rb
+++ b/spec/shoulda/active_model/validate_format_of_matcher_spec.rb
@@ -15,7 +15,7 @@ describe Shoulda::Matchers::ActiveModel::ValidateFormatOfMatcher do
 
     it "is not valid with blank" do
       @model.should_not validate_format_of(:attr).with(' ')
-      @model.should validate_format_of(:attr).not_with(' ')
+      @model.should validate_format_of(:attr).without(' ')
     end
 
     it "is not valid with nil" do
@@ -24,21 +24,21 @@ describe Shoulda::Matchers::ActiveModel::ValidateFormatOfMatcher do
 
     it "is not valid with alpha in zip" do
       @model.should_not validate_format_of(:attr).with('1234a')
-      @model.should validate_format_of(:attr).not_with('1234a')
+      @model.should validate_format_of(:attr).without('1234a')
     end
 
     it "is not valid with too few digits" do
       @model.should_not validate_format_of(:attr).with('1234')
-      @model.should validate_format_of(:attr).not_with('1234')
+      @model.should validate_format_of(:attr).without('1234')
     end
 
     it "is not valid with too many digits" do
       @model.should_not validate_format_of(:attr).with('123456')
-      @model.should validate_format_of(:attr).not_with('123456')
+      @model.should validate_format_of(:attr).without('123456')
     end
 
-    it "raises error if you try to call both with and not_with" do
-      expect { validate_format_of(:attr).not_with('123456').with('12345') }.
+    it "raises error if you try to call both with and without" do
+      expect { validate_format_of(:attr).without('123456').with('12345') }.
         to raise_error(RuntimeError)
     end
   end


### PR DESCRIPTION
Hello Sirs,

As discussed in https://github.com/thoughtbot/shoulda-matchers/pull/178, I renamed the method #not_with to #without.
- The #not_with now calls #without
- Deprecation comment added to #not_with
- Tests and examples in comments updated to use #without
