### PR TITLE
clean up documentation in validate_uniqueness_of

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_uniqueness_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_uniqueness_of_matcher.rb
@@ -3,15 +3,14 @@ module Shoulda # :nodoc:
     module ActiveModel # :nodoc:
 
       # Ensures that the model is invalid if the given attribute is not unique.
+      # It uses the first existing record or creates a new one if no record
+      # exists in the database. It simply uses `:validate => false` to get
+      # around validations, so it will probably fail if there are `NOT NULL`
+      # constraints. In that case, you must create a record before calling
+      # `validate_uniqueness_of`.
       #
-      # Internally, this uses values from existing records to test validations,
-      # so this will always fail if you have not saved at least one record for
-      # the model being tested, like so:
-      #
-      #   describe User do
-      #     before(:each) { User.create!(:email => 'address@example.com') }
-      #     it { should validate_uniqueness_of(:email) }
-      #   end
+      # Example:
+      #   it { should validate_uniqueness_of(:email) }
       #
       # Options:
       #


### PR DESCRIPTION
Current documentation out of date. In documentation pointed to create new (first) record manually, but this is not needed.
