### PR TITLE
Rewritten rspec integration to use RSpec's configure for matchers loading

### DIFF
--- a/lib/shoulda/matchers/integrations/rspec.rb
+++ b/lib/shoulda/matchers/integrations/rspec.rb
@@ -1,42 +1,28 @@
 # :enddoc:
+require 'rspec'
 
-require 'shoulda/matchers/independent'
-module RSpec::Matchers
-  include Shoulda::Matchers::Independent
-end
+RSpec.configure do |config|
+  require 'shoulda/matchers/independent'
+  config.include Shoulda::Matchers::Independent
 
-if defined?(::ActiveRecord)
-  require 'shoulda/matchers/active_record'
-  require 'shoulda/matchers/active_model'
-  module RSpec::Matchers
-    include Shoulda::Matchers::ActiveRecord
-    include Shoulda::Matchers::ActiveModel
+  if defined?(::ActiveRecord)
+    require 'shoulda/matchers/active_record'
+    require 'shoulda/matchers/active_model'
+    config.include Shoulda::Matchers::ActiveRecord
+    config.include Shoulda::Matchers::ActiveModel
+
+  elsif defined?(::ActiveModel)
+    require 'shoulda/matchers/active_model'
+    config.include Shoulda::Matchers::ActiveModel
   end
-elsif defined?(::ActiveModel)
-  require 'shoulda/matchers/active_model'
-  module RSpec::Matchers
-    include Shoulda::Matchers::ActiveModel
-  end
-end
 
-if defined?(::ActionController)
-  require 'shoulda/matchers/action_controller'
-  module RSpec
-    module Rails
-      module ControllerExampleGroup
-        include Shoulda::Matchers::ActionController
-      end
-    end
+  if defined?(::ActionController)
+    require 'shoulda/matchers/action_controller'
+    config.include Shoulda::Matchers::ActionController
   end
-end
 
-if defined?(::ActionMailer)
-  require 'shoulda/matchers/action_mailer'
-  module RSpec
-    module Rails
-      module MailerExampleGroup
-        include Shoulda::Matchers::ActionMailer
-      end
-    end
+  if defined?(::ActionMailer)
+    require 'shoulda/matchers/action_mailer'
+    config.include Shoulda::Matchers::ActionMailer
   end
 end


### PR DESCRIPTION
I've tried to use RSpec.configure {|c| c.include ...} for loading shoulda matchers. This fixes random failures that are mentioned in #174. At least for my case. ;)
