### PR TITLE
Resolve class name in AssociationMatcher

### DIFF
--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -4,7 +4,7 @@ module Shoulda # :nodoc:
       # Ensure that the belongs_to relationship exists.
       #
       # Options:
-      # * <tt>:class_name</tt> - tests that the association makes use of the class_name option.
+      # * <tt>:class_name</tt> - tests that the association resolves to class_name.
       # * <tt>:validate</tt> - tests that the association makes use of the validate
       # option.
       #
@@ -23,7 +23,7 @@ module Shoulda # :nodoc:
       # * <tt>through</tt> - association name for <tt>has_many :through</tt>
       # * <tt>dependent</tt> - tests that the association makes use of the
       #   dependent option.
-      # * <tt>:class_name</tt> - tests that the association makes use of the class_name option.
+      # * <tt>:class_name</tt> - tests that the association resoves to class_name.
       # * <tt>:validate</tt> - tests that the association makes use of the validate
       # option.
       #
@@ -43,7 +43,7 @@ module Shoulda # :nodoc:
       # Options:
       # * <tt>:dependent</tt> - tests that the association makes use of the
       #   dependent option.
-      # * <tt>:class_name</tt> - tests that the association makes use of the class_name option.
+      # * <tt>:class_name</tt> - tests that the association resolves to class_name.
       # * <tt>:validate</tt> - tests that the association makes use of the validate
       # option.
       #
@@ -58,6 +58,7 @@ module Shoulda # :nodoc:
       # the join table is in place.
       #
       # Options:
+      # * <tt>:class_name</tt> - tests that the association resolves to class_name.
       # * <tt>:validate</tt> - tests that the association makes use of the validate
       # option.
       #
@@ -209,10 +210,10 @@ module Shoulda # :nodoc:
 
         def class_name_correct?
           if @options.key?(:class_name)
-            if @options[:class_name].to_s == reflection.options[:class_name].to_s
+            if @options[:class_name].to_s == reflection.klass.to_s
               true
             else
-              @missing = "#{@name} should have #{@options[:class_name]} as class_name"
+              @missing = "#{@name} should resolve to #{@options[:class_name]} for class_name"
               false
             end
           else

--- a/spec/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -64,6 +64,10 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher do
       Child.new.should_not belong_to(:parent).conditions(:adopter => true)
     end
 
+    it 'accepts an association without a :class_name option' do
+      belonging_to_parent.should belong_to(:parent).class_name('Parent')
+    end
+
     it 'accepts an association with a valid :class_name option' do
       define_model :tree_parent
       define_model :child, :parent_id => :integer do
@@ -234,6 +238,10 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher do
       Parent.new.should_not have_many(:children).conditions(:adopted => true)
     end
 
+    it 'accepts an association without a :class_name option' do
+      having_many_children.should have_many(:children).class_name('Child')
+    end
+
     it 'accepts an association with a valid :class_name option' do
       define_model :node, :parent_id => :integer
       define_model :parent do
@@ -374,6 +382,10 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher do
       Person.new.should_not have_one(:detail).conditions(:disabled => true)
     end
 
+    it 'accepts an association without a :class_name option' do
+      having_one_detail.should have_one(:detail).class_name('Detail')
+    end
+
     it 'accepts an association with a valid :class_name option' do
       define_model :person_detail, :person_id => :integer
       define_model :person do
@@ -488,6 +500,11 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher do
         :relative_id => :integer
 
       Person.new.should_not have_and_belong_to_many(:relatives).conditions(:adopted => true)
+    end
+
+    it 'accepts an association without a :class_name option' do
+      having_and_belonging_to_many_relatives.
+        should have_and_belong_to_many(:relatives).class_name('Relative')
     end
 
     it 'accepts an association with a valid :class_name option' do


### PR DESCRIPTION
I want to assert that my relationships _behave_ correctly, not that I typed them a certain way.

This changes the behavior of the `class_name` option of `AssociationMatcher` to assert on the name of the other model rather than the value passed in the association definition. Now the following works:

``` ruby
module Some
  class Person < ActiveRecord::Base
    has_many :children
  end

  class Child < ActiveRecord::Base
    belongs_to :person
  end
end

describe Some::Person do
  it { should have_many(:children).class_name('Some::Child') }
end

describe Some::Child do
  it { should belong_to(:person).class_name('Some::Person') }
end
```
