### PR TITLE
Add option to match belong_to with touch

### DIFF
--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -266,7 +266,7 @@ module Shoulda # :nodoc:
         end
 
         def validate_correct?
-          if !@options.key?(:validate) || @options[:validate] == (reflection.options[:validate] == true ? true : false)
+          if !@options.key?(:validate) || @options[:validate] == !!reflection.options[:validate]
             true
           else
             @missing = "#{@name} should have :validate => #{@options[:validate]}"
@@ -275,7 +275,7 @@ module Shoulda # :nodoc:
         end
 
         def touch_correct?
-          if !@options.key?(:touch) || @options[:touch] == (reflection.options[:touch] == true ? true : false)
+          if !@options.key?(:touch) || @options[:touch] == !!reflection.options[:touch]
             true
           else
             @missing = "#{@name} should have :touch => #{@options[:touch]}"

--- a/spec/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -105,8 +105,7 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher do
           end
 
           it 'will not break matcher when validate option is unspecified' do
-            belonging_to_parent(:validate => validate_value).
-              should belong_to(:parent)
+            belonging_to_parent(:validate => validate_value).should belong_to(:parent)
           end
         end
       end
@@ -130,28 +129,27 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher do
       [false, true].each do |touch_value|
         context "when the model has :touch => #{touch_value}" do
           it 'accepts a matching touch option' do
-            belonging_to_parent(:touch => touch_value).should
-              belong_to(:parent).touch(touch_value)
+            belonging_to_parent(:touch => touch_value).
+              should belong_to(:parent).touch(touch_value)
           end
 
           it 'rejects a non-matching touch option' do
-            belonging_to_parent(:touch => touch_value).should_not
-              belong_to(:parent).touch(!touch_value)
+            belonging_to_parent(:touch => touch_value).
+              should_not belong_to(:parent).touch(!touch_value)
           end
 
           it 'defaults to touch(true)' do
             if touch_value
-              belonging_to_parent(:touch => touch_value).should
-                belong_to(:parent).touch
+              belonging_to_parent(:touch => touch_value).
+                should belong_to(:parent).touch
             else
-              belonging_to_parent(:touch => touch_value).should_not
-                belong_to(:parent).touch
+              belonging_to_parent(:touch => touch_value).
+                should_not belong_to(:parent).touch
             end
           end
 
           it 'will not break matcher when touch option is unspecified' do
-            belonging_to_parent(:touch => touch_value).should
-              belong_to(:parent)
+            belonging_to_parent(:touch => touch_value).should belong_to(:parent)
           end
         end
       end


### PR DESCRIPTION
This option has been missing but is pretty much the same thing as matching the validate option. It could probably be refactored to prevent code duplication.
