### PR TITLE
`require': cannot load such file -- rspec (LoadError)

### DIFF
--- a/lib/shoulda/matchers/integrations/rspec.rb
+++ b/lib/shoulda/matchers/integrations/rspec.rb
@@ -1,5 +1,5 @@
 # :enddoc:
-require 'rspec'
+require 'rspec-rails'
 
 RSpec.configure do |config|
   require 'shoulda/matchers/independent'


### PR DESCRIPTION
Hello everyone

Gemfile:

```
source 'https://rubygems.org'

gem 'rails'

gem 'sqlite3'
gem 'youtube_it'
gem 'viddl-rb'
gem 'paperclip'
gem 'paperclip-dropbox', :git => 'git://github.com/janko-m/paperclip-dropbox.git'
gem 'squeel'

group :assets do
  gem 'sass-rails',   '~> 3.2.3'
  gem 'coffee-rails', '~> 3.2.1'

  gem 'uglifier', '>= 1.0.3'
end

gem 'jquery-rails'

group :test, :development do
  gem 'rspec-rails'
end

group :test do
  gem 'factory_girl_rails'
  gem 'shoulda-matchers', :git => 'git://github.com/thoughtbot/shoulda-matchers.git'
  gem 'vcr'
  gem 'fakeweb'
  gem 'database_cleaner'
end
```

I've got exception:

```
/Users/roman/.rvm/gems/ruby-1.9.3-p327@sample_project/gems/activesupport-3.2.11/lib/active_support/dependencies.rb:251:in `require': cannot load such file -- rspec (LoadError)
from /Users/roman/.rvm/gems/ruby-1.9.3-p327@sample_project/gems/activesupport-3.2.11/lib/active_support/dependencies.rb:251:in `require': cannot load such file -- rspec (LoadError)
from /Users/roman/.rvm/gems/ruby-1.9.3-p327@sample_project/gems/activesupport-3.2.11/lib/active_support/dependencies.rb:251:in `block in require'
from /Users/roman/.rvm/gems/ruby-1.9.3-p327@sample_project/gems/activesupport-3.2.11/lib/active_support/dependencies.rb:236:in `load_dependency'
from /Users/roman/.rvm/gems/ruby-1.9.3-p327@sample_project/gems/activesupport-3.2.11/lib/active_support/dependencies.rb:251:in `require'
from /Users/roman/.rvm/gems/ruby-1.9.3-p327@sample_project/bundler/gems/shoulda-matchers-f7337c62bb8f/lib/shoulda/matchers/integrations/rspec.rb:2:in `<top (required)>'
from /Users/roman/.rvm/gems/ruby-1.9.3-p327@sample_project/gems/activesupport-3.2.11/lib/active_support/dependencies.rb:251:in `require'
from /Users/roman/.rvm/gems/ruby-1.9.3-p327@sample_project/gems/activesupport-3.2.11/lib/active_support/dependencies.rb:251:in `block in require'
from /Users/roman/.rvm/gems/ruby-1.9.3-p327@sample_project/gems/activesupport-3.2.11/lib/active_support/dependencies.rb:236:in `load_dependency'
from /Users/roman/.rvm/gems/ruby-1.9.3-p327@sample_project/gems/activesupport-3.2.11/lib/active_support/dependencies.rb:251:in `require'
from /Users/roman/.rvm/gems/ruby-1.9.3-p327@sample_project/bundler/gems/shoulda-matchers-f7337c62bb8f/lib/shoulda/matchers.rb:6:in `<top (required)>'
from /Users/roman/.rvm/gems/ruby-1.9.3-p327@global/gems/bundler-1.2.3/lib/bundler/runtime.rb:74:in `require'
from /Users/roman/.rvm/gems/ruby-1.9.3-p327@global/gems/bundler-1.2.3/lib/bundler/runtime.rb:74:in `rescue in block in require'
from /Users/roman/.rvm/gems/ruby-1.9.3-p327@global/gems/bundler-1.2.3/lib/bundler/runtime.rb:62:in `block in require'
from /Users/roman/.rvm/gems/ruby-1.9.3-p327@global/gems/bundler-1.2.3/lib/bundler/runtime.rb:55:in `each'
from /Users/roman/.rvm/gems/ruby-1.9.3-p327@global/gems/bundler-1.2.3/lib/bundler/runtime.rb:55:in `require'
from /Users/roman/.rvm/gems/ruby-1.9.3-p327@global/gems/bundler-1.2.3/lib/bundler.rb:128:in `require'
from /Users/roman/projects/sample_project/config/application.rb:13:in `<top (required)>'
from /Users/roman/projects/sample_project/config/environment.rb:2:in `require'
from /Users/roman/projects/sample_project/config/environment.rb:2:in `<top (required)>'
from /Users/roman/projects/sample_project/spec/spec_helper.rb:3:in `require'
from /Users/roman/projects/sample_project/spec/spec_helper.rb:3:in `<top (required)>'
from /Users/roman/projects/sample_project/spec/models/sample_model_spec.rb:1:in `require'
from /Users/roman/projects/sample_project/spec/models/sample_model_spec.rb:1:in `<top (required)>'
from /Users/roman/.rvm/gems/ruby-1.9.3-p327@sample_project/gems/rspec-core-2.12.2/lib/rspec/core/configuration.rb:789:in `load'
from /Users/roman/.rvm/gems/ruby-1.9.3-p327@sample_project/gems/rspec-core-2.12.2/lib/rspec/core/configuration.rb:789:in `block in load_spec_files'
from /Users/roman/.rvm/gems/ruby-1.9.3-p327@sample_project/gems/rspec-core-2.12.2/lib/rspec/core/configuration.rb:789:in `each'
from /Users/roman/.rvm/gems/ruby-1.9.3-p327@sample_project/gems/rspec-core-2.12.2/lib/rspec/core/configuration.rb:789:in `load_spec_files'
from /Users/roman/.rvm/gems/ruby-1.9.3-p327@sample_project/gems/rspec-core-2.12.2/lib/rspec/core/command_line.rb:22:in `run'
from /Users/roman/.rvm/gems/ruby-1.9.3-p327@sample_project/gems/rspec-core-2.12.2/lib/rspec/core/runner.rb:80:in `run'
from /Users/roman/.rvm/gems/ruby-1.9.3-p327@sample_project/gems/rspec-core-2.12.2/lib/rspec/core/runner.rb:17:in `block in autorun'
```

This small fix should resolve problem

Thanks
