### PR TITLE
Add #description method to DelegateMatcher

### DIFF
--- a/lib/shoulda/matchers/independent/delegate_matcher.rb
+++ b/lib/shoulda/matchers/independent/delegate_matcher.rb
@@ -10,12 +10,15 @@ module Shoulda # :nodoc:
       #   it { should delegate_method(:deliver_mail).to(:mailman) }
       #
       # Options:
-      # * <tt>:as</tt> - tests that the object being delegated to is called with a certain method (defaults to same name as delegating method)
-      # * <tt>:with_arguments</tt> - tests that the method on the object being delegated to is called with certain arguments
+      # * <tt>:as</tt> - tests that the object being delegated to is called with a certain method
+      #   (defaults to same name as delegating method)
+      # * <tt>:with_arguments</tt> - tests that the method on the object being delegated to is
+      #   called with certain arguments
       #
       # Examples:
       #   it { should delegate_method(:deliver_mail).to(:mailman).as(:deliver_with_haste)
-      #   it { should delegate_method(:deliver_mail).to(:mailman).with_arguments('221B Baker St.', :hastily => true)
+      #   it { should delegate_method(:deliver_mail).to(:mailman).
+      #     with_arguments('221B Baker St.', :hastily => true) }
       #
       def delegate_method(delegating_method)
         DelegateMatcher.new(delegating_method)
@@ -41,6 +44,10 @@ module Shoulda # :nodoc:
           rescue NoMethodError, RSpec::Expectations::ExpectationNotMetError, Mocha::ExpectationError
             false
           end
+        end
+
+        def description
+          add_clarifications_to("delegate method ##{@delegating_method} to :#{@target_method}")
         end
 
         def does_not_match?(subject)
@@ -75,7 +82,7 @@ module Shoulda # :nodoc:
           end
 
           if @method_on_target.present?
-            message << " as :#{@method_on_target}"
+            message << " as ##{@method_on_target}"
           end
 
           message

--- a/spec/shoulda/matchers/independent/delegate_matcher_spec.rb
+++ b/spec/shoulda/matchers/independent/delegate_matcher_spec.rb
@@ -1,6 +1,33 @@
 require 'spec_helper'
 
 describe Shoulda::Matchers::Independent::DelegateMatcher do
+  context '#description' do
+    context 'by default' do
+      it 'states that it should delegate method to the right object' do
+        matcher = delegate_method(:method_name).to(:target)
+
+        matcher.description.should == 'delegate method #method_name to :target'
+      end
+    end
+
+    context 'with #as chain' do
+      it 'states that it should delegate method to the right object and method' do
+        matcher = delegate_method(:method_name).to(:target).as(:alternate)
+
+        matcher.description.should == 'delegate method #method_name to :target as #alternate'
+      end
+    end
+
+    context 'with #with_argument chain' do
+      it 'states that it should delegate method to the right object with right argument' do
+        matcher = delegate_method(:method_name).to(:target).with_arguments(:foo, :bar => [1, 2])
+
+        matcher.description.should ==
+          'delegate method #method_name to :target with arguments: [:foo, {:bar=>[1, 2]}]'
+      end
+    end
+  end
+
   it 'supports chaining on #to' do
     matcher = delegate_method(:method)
 
@@ -155,7 +182,7 @@ describe Shoulda::Matchers::Independent::DelegateMatcher do
 
         matcher.matches?(post_office)
 
-        message = 'Expected PostOffice#deliver_mail to delegate to PostOffice#mailman as :watch_tv'
+        message = 'Expected PostOffice#deliver_mail to delegate to PostOffice#mailman as #watch_tv'
         matcher.failure_message.should == message
       end
     end


### PR DESCRIPTION
Also, fixing code style for documentation, and update the method
referencing style to be #method_name instead of :method_name.

Fixes #226 

/cc @gabebw
