### PR TITLE
Remove RSpec `#should` syntax to support Test::Unit

### DIFF
--- a/lib/shoulda/matchers/action_controller/strong_parameters_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/strong_parameters_matcher.rb
@@ -60,11 +60,12 @@ module Shoulda
         end
 
         def verify_permit_call(model_attrs)
-          model_attrs.should have_received(:permit).with { |*params|
+          matcher = Mocha::API::HaveReceived.new(:permit).with do |*params|
             self.permitted_params = params
-          }
-          true
-        rescue RSpec::Expectations::ExpectationNotMetError, Mocha::ExpectationError
+          end
+
+          matcher.matches?(model_attrs)
+        rescue Mocha::ExpectationError
           false
         end
 

--- a/lib/shoulda/matchers/independent/delegate_matcher.rb
+++ b/lib/shoulda/matchers/independent/delegate_matcher.rb
@@ -40,8 +40,9 @@ module Shoulda # :nodoc:
             subject.stubs(@target_method).returns(stubbed_object)
             subject.send(@delegating_method)
 
-            stubbed_object.should have_received(method_on_target).with(*@delegated_arguments)
-          rescue NoMethodError, RSpec::Expectations::ExpectationNotMetError, Mocha::ExpectationError
+            matcher = Mocha::API::HaveReceived.new(method_on_target).with(*@delegated_arguments)
+            matcher.matches?(stubbed_object)
+          rescue NoMethodError, Mocha::ExpectationError
             false
           end
         end


### PR DESCRIPTION
There was no need for us to call `#should` in those matchers, as we only
need to return true/false in `#matches?` method. By removing those
`should`, those two matchers are now working fine with Test::Unit
and minitest.
