### PR TITLE
Show Test::Unit syntax example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Official Documentation](http://rubydoc.info/github/thoughtbot/shoulda-matchers/master/frames)
 
-Test::Unit- and RSpec-compatible one-liners that test common Rails functionality.
+Test::Unit and RSpec-compatible one-liners that test common Rails functionality.
 These tests would otherwise be much longer, more complex, and error-prone.
 
 Refer to the [shoulda-context](https://github.com/thoughtbot/shoulda-context) gem if you want to know more
@@ -73,6 +73,28 @@ Matchers to test non-Rails-dependent code:
 ```ruby
 describe Human do
   it { should delegate_method(:work).to(:robot) }
+end
+```
+
+## Test::Unit Syntax
+
+```ruby
+class MyTest < ActiveSupport::TestCase
+  subject { Post.new } # dictates which class to perform matchers on
+
+  should validate_uniqueness_of(:title)
+  should validate_uniqueness_of(:title).scoped_to(:user_id, :category_id)
+end
+```
+
+Or if your name the test classes aptly, `subject` will be set implicitly.
+ 
+```ruby
+class PostTest < ActiveSupport::TestCase
+  # `subject` value is set implicitly based on name of test, gets set to `Post.new`
+
+  should validate_uniqueness_of(:title)
+  should validate_uniqueness_of(:title).scoped_to(:user_id, :category_id)
 end
 ```
 


### PR DESCRIPTION
It says in the very beginning of the README that the gem is compatible with `Test::Unit`, however, all successive code examples demonstrate usage in `Rspec`.  I thought it would be helpful to provide an example demonstrating syntax to use in `Test::Unit`.

I love this gem and use it frequently when working with `Rspec`, however, I recently took over  a project that had a fully fledged test suite written in `Test::Unit`.  Having little experience with `Test::Unit`, it took some experimentation before I was able to get the 'one-liners' working in `Test::Unit` that I had become so accustomed to using in `Rspec`.  I also struggled to find examples of usage in conjunction with `Test::Unit` anywhere in the documentation or on the web, (eventually I found [an issue filed against `shoulda` which pointed me in the right direction](https://github.com/thoughtbot/shoulda/issues/216)).  This type of thing would have been handy though.
