### PR TITLE
Add support for validation contexts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # HEAD
 
+* Support validation contexts for testing validations `on: :create` and when
+  using custom contexts like `model.valid?(:my_context)`.
+
 # v 1.5.6
 * Revert previous change in `AllowValueMatcher` that added a check for a
 properly-set attribute.

--- a/lib/shoulda/matchers/active_model/allow_value_matcher.rb
+++ b/lib/shoulda/matchers/active_model/allow_value_matcher.rb
@@ -43,6 +43,11 @@ module Shoulda # :nodoc:
           self
         end
 
+        def on(context)
+          @context = context
+          self
+        end
+
         def with_message(message)
           self.options[:expected_message] = message
           self
@@ -78,7 +83,7 @@ module Shoulda # :nodoc:
         private
 
         attr_accessor :values_to_match, :message_finder_factory,
-          :instance, :attribute, :value, :matched_error
+          :instance, :attribute, :context, :value, :matched_error
 
         def errors_match?
           has_messages? && errors_for_attribute_match?
@@ -161,7 +166,7 @@ module Shoulda # :nodoc:
         end
 
         def message_finder
-          message_finder_factory.new(instance, attribute)
+          message_finder_factory.new(instance, attribute, context)
         end
       end
     end

--- a/lib/shoulda/matchers/active_model/exception_message_finder.rb
+++ b/lib/shoulda/matchers/active_model/exception_message_finder.rb
@@ -3,9 +3,10 @@ module Shoulda
     module ActiveModel
       # Finds message information from exceptions thrown by #valid?
       class ExceptionMessageFinder
-        def initialize(instance, attribute)
+        def initialize(instance, attribute, context=nil)
           @instance = instance
           @attribute = attribute
+          @context = context
         end
 
         def allow_description(allowed_values)
@@ -39,7 +40,7 @@ module Shoulda
         private
 
         def validate_and_rescue
-          @instance.valid?
+          @instance.valid?(@context)
           []
         rescue ::ActiveModel::StrictValidationFailed => exception
           [exception.message]

--- a/lib/shoulda/matchers/active_model/validation_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validation_matcher.rb
@@ -9,6 +9,11 @@ module Shoulda # :nodoc:
           @strict = false
         end
 
+        def on(context)
+          @context = context
+          self
+        end
+
         def strict
           @strict = true
           self

--- a/lib/shoulda/matchers/active_model/validation_message_finder.rb
+++ b/lib/shoulda/matchers/active_model/validation_message_finder.rb
@@ -6,9 +6,10 @@ module Shoulda
       class ValidationMessageFinder
         include Helpers
 
-        def initialize(instance, attribute)
+        def initialize(instance, attribute, context=nil)
           @instance = instance
           @attribute = attribute
+          @context = context
         end
 
         def allow_description(allowed_values)
@@ -58,7 +59,7 @@ module Shoulda
         end
 
         def validate_instance
-          @instance.valid?
+          @instance.valid?(@context)
           @instance
         end
       end

--- a/spec/shoulda/matchers/active_model/allow_value_matcher_spec.rb
+++ b/spec/shoulda/matchers/active_model/allow_value_matcher_spec.rb
@@ -56,6 +56,24 @@ describe Shoulda::Matchers::ActiveModel::AllowValueMatcher do
     end
   end
 
+  context "an attribute with a context-dependent validation" do
+    context "without the validation context" do
+      it "allows a bad value" do
+        validating_format(:with => /abc/, :on => :customisable).should allow_value("xyz").for(:attr)
+      end
+    end
+
+    context "with the validation context" do
+      it "allows a good value" do
+        validating_format(:with => /abc/, :on => :customisable).should allow_value("abcde").for(:attr).on(:customisable)
+      end
+
+      it "rejects a bad value" do
+        validating_format(:with => /abc/, :on => :customisable).should_not allow_value("xyz").for(:attr).on(:customisable)
+      end
+    end
+  end
+
   context 'an attribute with several validations' do
     let(:model) do
       define_model :example, :attr => :string do


### PR DESCRIPTION
There's no easy way to test validation contexts with the current shoulda matchers. The context must be provided in the call to the instance's `valid?` method. This patch adds a simple way to optionally pass a context.

Example:

``` ruby
class User
  include ActiveModel::Model
  validates_presence_of :email, on: :emailable
end

describe User do
  it { should_not validate_presence_of(:email) }
  it { should validate_presence_of(:email).on(:emailable) }
end
```

Previously this would have to involve stubbing the implementation detail validation_context, simply setting it is not enough as it is overridden by every run of [valid?](https://github.com/rails/rails/blob/927e649bc9dc5740285e4b4e9899421c2bbfefbe/activemodel/lib/active_model/validations.rb#L193):

``` ruby
describe User do
  it { should_not validate_presence_of(:email) }
  context do
    before { subject.stub(validation_context: :emailable) }
    it { should validate_presence_of(:email) }
  end
end
```

This can also be used for the idiomatic activerecord contexts:

``` ruby
class User < ActiveRecord::Base
  validates_presence_of :password, on: :create
end

describe User do
  it { should validate_presence_of(:password).on(:create) }
  it { should_not validate_presence_of(:password).on(:update) }
end
```
