### PR TITLE
Use correct variable in validate_confirmation_of matcher description

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_confirmation_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_confirmation_of_matcher.rb
@@ -24,7 +24,7 @@ module Shoulda # :nodoc:
         end
 
         def description
-          "require #{@base_attribute} to match #{@attribute}"
+          "require #{@confirmation} to match #{@attribute}"
         end
 
         def matches?(subject)

--- a/spec/shoulda/matchers/active_model/validate_confirmation_of_matcher_spec.rb
+++ b/spec/shoulda/matchers/active_model/validate_confirmation_of_matcher_spec.rb
@@ -1,6 +1,12 @@
 require 'spec_helper'
 
 describe Shoulda::Matchers::ActiveModel::ValidateConfirmationOfMatcher do
+  context '#description' do
+    it 'states that the confirmation must match its base attribute' do
+      matcher.description.should == 'require attr_confirmation to match attr'
+    end
+  end
+
   context 'a model with a confirmation validation' do
     it 'accepts' do
       validating_confirmation.should matcher


### PR DESCRIPTION
Fixes #251 to use the right variable in the matcher's description.
