### PR TITLE
Reverting to requiring rspec instead of rspec/rails.

### DIFF
--- a/lib/shoulda/matchers/integrations/rspec.rb
+++ b/lib/shoulda/matchers/integrations/rspec.rb
@@ -1,5 +1,5 @@
 # :enddoc:
-require 'rspec/rails'
+require 'rspec'
 
 RSpec.configure do |config|
   require 'shoulda/matchers/independent'


### PR DESCRIPTION
Fix for thoughtbot/shoulda-matchers#259. Thanks to @odaeus for pointing this out.
