### PR TITLE
Fix for #259

### DIFF
--- a/lib/shoulda/matchers/integrations/rspec.rb
+++ b/lib/shoulda/matchers/integrations/rspec.rb
@@ -1,5 +1,5 @@
 # :enddoc:
-require 'rspec/rails'
+require 'rspec'
 
 RSpec.configure do |config|
   require 'shoulda/matchers/independent'


### PR DESCRIPTION
In addition to fixing the the problems being experienced in #259, this should also fix compatibility for any usage of `shoulda-matchers` in conjunction with `RSpec` outside of a `Rails` application.  Cheers.
