### PR TITLE
Test deprecation warnings

### DIFF
--- a/spec/shoulda/matchers/action_controller/assign_to_matcher_spec.rb
+++ b/spec/shoulda/matchers/action_controller/assign_to_matcher_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe Shoulda::Matchers::ActionController::AssignToMatcher do
+  before do
+    ActiveSupport::Deprecation.expects(:warn).with { |value| /assign_to matcher/ =~ value }
+  end
+
   it 'includes the actual class in the failure message' do
     define_class(:WrongClass) do
       def to_s

--- a/spec/shoulda/matchers/action_controller/respond_with_content_type_matcher_spec.rb
+++ b/spec/shoulda/matchers/action_controller/respond_with_content_type_matcher_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe Shoulda::Matchers::ActionController::RespondWithContentTypeMatcher do
+  before do
+    ActiveSupport::Deprecation.expects(:warn).with { |value| /respond_with_content_type matcher/ =~ value }
+  end
+
   it 'generates the correct description' do
     expected = 'respond with content type of application/xml'
 

--- a/spec/shoulda/matchers/action_controller/strong_parameters_matcher_spec.rb
+++ b/spec/shoulda/matchers/action_controller/strong_parameters_matcher_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe Shoulda::Matchers::ActionController do
+  before do
+    ActiveSupport::Deprecation.expects(:warn).with { |value| /strong_parameters matcher/ =~ value }
+  end
+
   describe ".permit" do
     it "is true when the sent parameter is allowed" do
       controller_class = controller_for_resource_with_strong_parameters do
@@ -33,6 +37,8 @@ describe Shoulda::Matchers::ActionController::StrongParametersMatcher do
     controller_for_resource_with_strong_parameters do
       params.require(:user).permit(:name, :age)
     end
+
+    ActiveSupport::Deprecation.expects(:warn).with { |value| /strong_parameters matcher/ =~ value }
   end
 
   describe "#matches?" do

--- a/spec/shoulda/matchers/action_mailer/have_sent_email_spec.rb
+++ b/spec/shoulda/matchers/action_mailer/have_sent_email_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe Shoulda::Matchers::ActionMailer::HaveSentEmailMatcher do
+  before do
+    ActiveSupport::Deprecation.expects(:warn).at_least_once.with { |value| /have_sent_email matcher/ =~ value }
+  end
+
   subject { described_class.new(self) }
   after { ::ActionMailer::Base.deliveries.clear }
 

--- a/spec/shoulda/matchers/active_model/validate_format_of_matcher_spec.rb
+++ b/spec/shoulda/matchers/active_model/validate_format_of_matcher_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe Shoulda::Matchers::ActiveModel::ValidateFormatOfMatcher do
+  before do
+    ActiveSupport::Deprecation.expects(:warn).with { |value| /validate_format_of matcher/ =~ value }
+  end
+
   context 'a model with a format validation' do
     it 'accepts when format matches ' do
       validating_format(:with => /^\d{5}$/).should matcher.with('12345')

--- a/spec/shoulda/matchers/active_record/query_the_database_matcher_spec.rb
+++ b/spec/shoulda/matchers/active_record/query_the_database_matcher_spec.rb
@@ -8,6 +8,8 @@ describe Shoulda::Matchers::ActiveRecord::QueryTheDatabaseMatcher do
     @child = define_model :kitten, :litter_id => :integer do
       belongs_to :litter
     end
+
+    ActiveSupport::Deprecation.expects(:warn).with { |value| /query_the_database matcher/ =~ value }
   end
 
   it 'accepts the correct number of queries when there is a single query' do

--- a/spec/shoulda/matchers/independent/delegate_matcher_spec.rb
+++ b/spec/shoulda/matchers/independent/delegate_matcher_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe Shoulda::Matchers::Independent::DelegateMatcher do
+  before do
+    ActiveSupport::Deprecation.expects(:warn).with { |value| /delegate_method matcher/ =~ value }
+  end
+
   context '#description' do
     context 'by default' do
       it 'states that it should delegate method to the right object' do


### PR DESCRIPTION
This has the added benefit of squelching a deluge of warnings during tests.

---

This is my first use of Mocha. RSpec mocks would be the following:

``` ruby
ActiveSupport::Deprecation.should_receive(:warn).with(/.../)
```
