### PR TITLE
Fix a bug where matchers fail on models with an autosaved belongs_to associations

### DIFF
--- a/lib/shoulda/matchers/active_model/helpers.rb
+++ b/lib/shoulda/matchers/active_model/helpers.rb
@@ -5,7 +5,10 @@ module Shoulda # :nodoc:
         def pretty_error_messages(obj) # :nodoc:
           obj.errors.map do |attribute, model|
             msg = "#{attribute} #{model}"
-            msg << " (#{obj.send(attribute).inspect})" unless attribute.to_sym == :base
+            if attribute.to_sym != :base && obj.respond_to?(attribute)
+              msg << " (#{obj.send(attribute).inspect})"
+            end
+            msg
           end
         end
 

--- a/spec/shoulda/matchers/active_model/validation_message_finder_spec.rb
+++ b/spec/shoulda/matchers/active_model/validation_message_finder_spec.rb
@@ -70,6 +70,20 @@ describe Shoulda::Matchers::ActiveModel::ValidationMessageFinder do
 
       description.should == 'no errors'
     end
+
+    it 'should not fetch attribute values for errors that were copied from an autosaved belongs_to association' do
+      instance = define_model(:example) do
+        validate do |record|
+          # Errors in an autosaved belongs_to are copied into the containing object's errors like this:
+          record.errors.add('association.association_attribute', 'is invalid')
+        end
+      end.new
+      finder = Shoulda::Matchers::ActiveModel::ValidationMessageFinder.new(instance, :attribute)
+
+      expected_messages = ['association.association_attribute is invalid']
+      finder.messages_description.should == "errors: #{expected_messages}"
+    end
+
   end
 
   context '#source_description' do


### PR DESCRIPTION
When a model has an autosaved belongs_to associations, matchers fail when validating records of that model.

E.g. you have a `User` that `belongs_to` a `Group` and accepts nested attributes for that group:

```
class User < ActiveRecord::Base
  accepts_nested_attributes_for :group
end

class Group < ActiveRecord::Base
  validates_presence_of :name
end
```

When using one of the matchers on `User` records with a nameless group, `user.errors` has an entry for `group.name` (sic). The matcher tries to come up with a helpful error message that includes the value for `group.name` but of course fails because the user does not `respond_to?('group.name')`.

The attached pull request checks if a record responds to an error key before obtaining the attribute value for that key.

A new patch release would be greatly appreciated!

Thanks.
