### PR TITLE
Use DisallowValueMatcher for `disallows_value_of` method

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 # HEAD
+* Use DisallowValueMatcher for `disallows_value_of` method
 * Assert `class_name` value on real class name for `AssociationMatcher`
 * Correct the variable used for `validate_confirmation_of` matcher description
 

--- a/lib/shoulda/matchers/active_model/disallow_value_matcher.rb
+++ b/lib/shoulda/matchers/active_model/disallow_value_matcher.rb
@@ -24,8 +24,17 @@ module Shoulda # :nodoc:
           @allow_matcher.failure_message_for_should_not
         end
 
+        def failure_message_for_should_not
+          @allow_matcher.failure_message_for_should
+        end
+
         def allowed_types
           ''
+        end
+
+        def strict
+          @allow_matcher.strict
+          self
         end
       end
     end

--- a/lib/shoulda/matchers/active_model/validation_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validation_matcher.rb
@@ -38,19 +38,32 @@ module Shoulda # :nodoc:
         end
 
         def disallows_value_of(value, message = nil)
-          disallow = allow_value_matcher(value, message)
+          disallow = disallow_value_matcher(value, message)
 
           if disallow.matches?(@subject)
-            @failure_message_for_should = disallow.failure_message_for_should_not
-            false
-          else
             @failure_message_for_should_not = disallow.failure_message_for_should
             true
+          else
+            @failure_message_for_should = disallow.failure_message_for_should_not
+            false
           end
         end
 
         def allow_value_matcher(value, message)
           matcher = AllowValueMatcher.
+            new(value).
+            for(@attribute).
+            with_message(message)
+
+          if strict?
+            matcher.strict
+          else
+            matcher
+          end
+        end
+
+        def disallow_value_matcher(value, message)
+          matcher = DisallowValueMatcher.
             new(value).
             for(@attribute).
             with_message(message)


### PR DESCRIPTION
We should take advantage of DisallowValueMatcher when we use the `disallows_value_of` method instead of using AllowValueMatcher and inverting logic.
