### PR TITLE
Not more raise a error on set_the_flash when receives a not string or regex

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 raised exceptions
 * Support datetime columns in `validate_uniqueness_of.scoped_to`
 * Add `allow_nil` option to the `validate_uniqueness_of` matcher
+* Not more raise a error on `set_the_flash` when receives a not string or regex
 
 # v 2.0.0
 * Remove the following matchers:

--- a/lib/shoulda/matchers/action_controller/set_the_flash_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/set_the_flash_matcher.rb
@@ -23,9 +23,6 @@ module Shoulda # :nodoc:
         end
 
         def to(value)
-          if !value.is_a?(String) && !value.is_a?(Regexp)
-            raise "cannot match against #{value.inspect}"
-          end
           @value = value
           self
         end

--- a/spec/shoulda/matchers/action_controller/set_the_flash_matcher_spec.rb
+++ b/spec/shoulda/matchers/action_controller/set_the_flash_matcher_spec.rb
@@ -1,9 +1,6 @@
 require 'spec_helper'
 
 describe Shoulda::Matchers::ActionController::SetTheFlashMatcher do
-  it 'fails with unmatchable #to' do
-    expect { set_the_flash.to(1) }.to raise_error('cannot match against 1')
-  end
 
   context 'a controller that sets a flash message' do
     it 'accepts setting any flash message' do
@@ -130,6 +127,17 @@ describe Shoulda::Matchers::ActionController::SetTheFlashMatcher do
       controller_with_no_flashes.should_not set_the_flash
     end
   end
+
+  context "not string values" do
+    it 'not fails with a boolean' do
+      expect { set_the_flash.to(true) }.to_not raise_error
+    end
+
+    it 'be possible match to a boolean' do
+      controller_with_flash(:notice => true).should set_the_flash.to(true)
+    end
+  end
+
 
   def controller_with_no_flashes
     build_response


### PR DESCRIPTION
More info about flash messages with not string values on http://thepugautomatic.com/2012/08/the-rails-flash/
