### PR TITLE
Fixes #241 have_and_belong_to_many assertions

### DIFF
--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -283,6 +283,7 @@ module Shoulda # :nodoc:
         end
 
         def join_table
+          return reflection.join_table if reflection.respond_to? :join_table
           reflection.options[:join_table].to_s
         end
 


### PR DESCRIPTION
Rails 4 made a small change to their reflection api, this simple change takes that into consideration. Doesn't break any backwards compatibility.
