### PR TITLE
Loads 'test/unit/assertionfailederror' instead of 'test/unit'.

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_uniqueness_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_uniqueness_of_matcher.rb
@@ -106,7 +106,7 @@ module Shoulda # :nodoc:
 
         def ensure_nil_record_in_database
           unless existing_record_is_nil?
-            create_record_in_database(nil_value: true)
+            create_record_in_database(:nil_value => true)
           end
         end
 

--- a/lib/shoulda/matchers/assertion_error.rb
+++ b/lib/shoulda/matchers/assertion_error.rb
@@ -1,7 +1,7 @@
 module Shoulda
   module Matchers
     if Gem.ruby_version >= Gem::Version.new('1.8') && Gem.ruby_version < Gem::Version.new('1.9')
-      require 'test/unit'
+      require 'test/unit/assertionfailederror'
       AssertionError = Test::Unit::AssertionFailedError
     elsif defined?(Test::Unit::AssertionFailedError)
       # Test::Unit has been loaded already, so we use it


### PR DESCRIPTION
In ruby 1.8, test/unit.rb adds a Kernel.at_exit hook which is intended to run
the test suite. When using rspec this triggers an empty test suite to be run.
Since the intention of this code is to load Test::Unit::AssertionFailedError,
we can require the file that contains that error class directly.

When the empty test suite runs, it spits out something similar to:

```
Loaded suite /Users/user/.rvm/gems/ree-1.8.7-2012.02@my-gemset/bin/rspec
Started

Finished in 0.000153 seconds.

0 tests, 0 assertions, 0 failures, 0 errors
```

This is confusing to new developers on a project and it may confuse tools that attempt to parse the output of the test suite. I have no examples of the latter, but I've seen the former.

Also, this removes a ruby 1.9-style hash so things continue to work in ruby
1.8.
