### PR TITLE
Fix context support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # HEAD
 
+* Fix context support for validation matchers and disallowed values.
+
 * Add a `counter_cache` submatcher for `belongs_to` associations
 
 * Add a rescue_from matcher for Rails controllers which checks that the correct

--- a/lib/shoulda/matchers/active_model/disallow_value_matcher.rb
+++ b/lib/shoulda/matchers/active_model/disallow_value_matcher.rb
@@ -15,6 +15,11 @@ module Shoulda # :nodoc:
           self
         end
 
+        def on(context)
+          @allow_matcher.on(context)
+          self
+        end
+
         def with_message(message)
           @allow_matcher.with_message(message)
           self

--- a/lib/shoulda/matchers/active_model/validation_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validation_matcher.rb
@@ -58,6 +58,7 @@ module Shoulda # :nodoc:
           matcher = AllowValueMatcher.
             new(value).
             for(@attribute).
+            on(@context).
             with_message(message)
 
           if strict?
@@ -71,6 +72,7 @@ module Shoulda # :nodoc:
           matcher = DisallowValueMatcher.
             new(value).
             for(@attribute).
+            on(@context).
             with_message(message)
 
           if strict?

--- a/spec/shoulda/matchers/active_model/disallow_value_matcher_spec.rb
+++ b/spec/shoulda/matchers/active_model/disallow_value_matcher_spec.rb
@@ -15,6 +15,24 @@ describe Shoulda::Matchers::ActiveModel::DisallowValueMatcher do
     end
   end
 
+  context "an attribute with a context-dependent validation" do
+    context "without the validation context" do
+      it "does not match" do
+        validating_format(:with => /abc/, :on => :customisable).should_not matcher("xyz").for(:attr)
+      end
+    end
+
+    context "with the validation context" do
+      it "disallows a bad value" do
+        validating_format(:with => /abc/, :on => :customisable).should matcher("xyz").for(:attr).on(:customisable)
+      end
+
+      it "does not match a good value" do
+        validating_format(:with => /abc/, :on => :customisable).should_not matcher("abcde").for(:attr).on(:customisable)
+      end
+    end
+  end
+
   context 'an attribute with a format validation and a custom message' do
     it 'does not match if the value and message are both correct' do
       validating_format(:with => /abc/, :message => 'good message').

--- a/spec/shoulda/matchers/active_model/validate_presence_of_matcher_spec.rb
+++ b/spec/shoulda/matchers/active_model/validate_presence_of_matcher_spec.rb
@@ -120,6 +120,20 @@ describe Shoulda::Matchers::ActiveModel::ValidatePresenceOfMatcher do
     end
   end
 
+  context "an attribute with a context-dependent validation" do
+    context "without the validation context" do
+      it "does not match" do
+        validating_presence(:on => :customisable).should_not matcher
+      end
+    end
+
+    context "with the validation context" do
+      it "matches" do
+        validating_presence(:on => :customisable).should matcher.on(:customisable)
+      end
+    end
+  end
+
   def matcher
     validate_presence_of(:attr)
   end


### PR DESCRIPTION
Initially context support was developed back for shoulda matchers 1.x. When porting it forwards, the spec coverage was not sufficient to indicate that disallowed values and validation matchers did not support setting context, quickly revealed when I upgraded shoulda matchers in our codebase.

This patch specs and fixes context support for disallowed values and validation matchers.
