### PR TITLE
Numericality validation dups subject ...

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_numericality_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_numericality_of_matcher.rb
@@ -122,7 +122,7 @@ module Shoulda # :nodoc:
         end
 
         def failing_submatchers
-          @failing_submatchers ||= @submatchers.select { |matcher| !matcher.matches?(@subject.dup) }
+          @failing_submatchers ||= @submatchers.select { |matcher| !matcher.matches?(@subject) }
         end
 
         def allowed_types

--- a/spec/shoulda/matchers/active_model/validate_numericality_of_matcher_spec.rb
+++ b/spec/shoulda/matchers/active_model/validate_numericality_of_matcher_spec.rb
@@ -121,6 +121,21 @@ describe Shoulda::Matchers::ActiveModel::ValidateNumericalityOfMatcher do
     end
   end
 
+  context 'when stubbed' do
+
+    it 'should retain stubs on submatchers' do
+      subject = define_model :example, :attr => :string do
+        validates_numericality_of :attr, :odd => true
+        before_validation :set_attr!
+        def set_attr!; self.attr = 5 end
+      end.new
+
+      subject.stubs(:set_attr!)
+      subject.should matcher.odd
+    end
+
+  end
+
   def validating_numericality(options = {})
     define_model :example, :attr => :string do
       validates_numericality_of :attr, options


### PR DESCRIPTION
... which causes unexpected behaviour with e.g. stubs or other object-specific customisations (please see attached spec)
