### PR TITLE
removed permit example from ActionController Matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ Matchers to test common patterns:
 
 ```ruby
 describe PostsController, "#show" do
-  it { should permit(:title, :body).for(:create) }
 
   context "for a fictional user" do
     before do


### PR DESCRIPTION
It was extracted from the 2.0 changes.
