### PR TITLE
fix is_equal_to submatcher for validates_numericality_of

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # HEAD
 
+* Fix `is_equal_to` submatcher bug for `validates_numericality_of`
+
 * Fix context support for validation matchers and disallowed values.
 
 * Add a `counter_cache` submatcher for `belongs_to` associations

--- a/lib/shoulda/matchers/active_model/comparison_matcher.rb
+++ b/lib/shoulda/matchers/active_model/comparison_matcher.rb
@@ -31,7 +31,7 @@ module Shoulda # :nodoc:
           case @operator
             when :> then [@value, @value - 1].sample
             when :>= then @value - 1
-            when :== then @value
+            when :== then @value + 1
             when :< then [@value, @value + 1].sample
             when :<= then @value + 1
           end

--- a/spec/shoulda/matchers/active_model/comparison_matcher_spec.rb
+++ b/spec/shoulda/matchers/active_model/comparison_matcher_spec.rb
@@ -21,6 +21,11 @@ describe Shoulda::Matchers::ActiveModel::ComparisonMatcher do
     it { instance_without_validations.should_not matcher.is_less_than_or_equal_to(2) }
   end
 
+  context 'is_equal_to' do
+    it { instance_with_validations(:equal_to => 0).should matcher.is_equal_to(0) }
+    it { instance_without_validations.should_not matcher.is_equal_to(0) }
+  end
+
   def instance_with_validations(options = {})
     define_model :example, :attr => :string do
       validates_numericality_of :attr, options


### PR DESCRIPTION
I wasn't able to get the specs running locally, but this should work.

The `value_to_compare` was wrong for the `==` operator and there wasn't a spec to catch it.
