### PR TITLE
Specify bundle install for travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 script: "bundle exec rake spec cucumber"
 
+install:
+  "bundle install"
+
 rvm:
   - 1.9.2
   - 1.9.3


### PR DESCRIPTION
- Thanks to @sikachu!

Travis will now runs `bundle install --deployment` if it detects that
the project has `Gemfile.lock`. However, there's a problem in Bundler
deployment install that cause it not installing `bundler` gem into
`vendor/bundle` directory, which causes `require 'bundler'` to fail.
