### PR TITLE
Fix rspec 2.14 deprecation warnings

### DIFF
--- a/spec/shoulda/matchers/active_model/allow_value_matcher_spec.rb
+++ b/spec/shoulda/matchers/active_model/allow_value_matcher_spec.rb
@@ -110,7 +110,7 @@ describe Shoulda::Matchers::ActiveModel::AllowValueMatcher do
       matcher = described_class.new('foo').for(:attr)
       matcher.description
 
-      expect { matcher.matches?(model) }.not_to raise_error(NoMethodError)
+      expect { matcher.matches?(model) }.not_to raise_error
     end
   end
 

--- a/spec/shoulda/matchers/active_model/ensure_length_of_matcher_spec.rb
+++ b/spec/shoulda/matchers/active_model/ensure_length_of_matcher_spec.rb
@@ -118,7 +118,7 @@ describe Shoulda::Matchers::ActiveModel::EnsureLengthOfMatcher do
       it "does not raise an exception" do
         expect {
           validating_length(:maximum => 4).should ensure_length_of(:attr).is_at_most(4)
-        }.to_not raise_exception(I18n::MissingInterpolationArgument)
+        }.to_not raise_exception
       end
     end
 
@@ -132,7 +132,7 @@ describe Shoulda::Matchers::ActiveModel::EnsureLengthOfMatcher do
       it "does not raise an exception" do
         expect {
           validating_length(:minimum => 4).should ensure_length_of(:attr).is_at_least(4)
-        }.to_not raise_exception(I18n::MissingInterpolationArgument)
+        }.to_not raise_exception
       end
     end
 
@@ -146,7 +146,7 @@ describe Shoulda::Matchers::ActiveModel::EnsureLengthOfMatcher do
       it "does not raise an exception" do
         expect {
           validating_length(:is => 4).should ensure_length_of(:attr).is_equal_to(4)
-        }.to_not raise_exception(I18n::MissingInterpolationArgument)
+        }.to_not raise_exception
       end
     end
   end


### PR DESCRIPTION
This is a preemptive fix for deprecation warnings when running the test suite after upgrading to rspec 2.14. shoulda-matchers is not currently using rspec 2.14 but I upgraded on a branch of my own, which is how I came across these warnings. They're only relevant to the test suite.

As it happens, the only deprecation warning that appears is "expect { }.not_to raise_error(SpecificErrorClass)" (see rspec/rspec-expectations#231). Easy fix
