### PR TITLE
Add UUID support to validates_uniqueness_of matcher

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_uniqueness_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_uniqueness_of_matcher.rb
@@ -197,6 +197,8 @@ module Shoulda # :nodoc:
             '0'
           elsif column.type == :datetime
             DateTime.now
+          elsif column.type == :uuid
+            SecureRandom.uuid
           else
             0
           end

--- a/spec/shoulda/matchers/active_model/validate_uniqueness_of_matcher_spec.rb
+++ b/spec/shoulda/matchers/active_model/validate_uniqueness_of_matcher_spec.rb
@@ -168,6 +168,41 @@ describe Shoulda::Matchers::ActiveModel::ValidateUniquenessOfMatcher do
       end
     end
 
+    context 'when the scoped attribute is a uuid' do
+      it 'accepts' do
+        validating_scoped_uniqueness([:scope1], :uuid, :scope1 => SecureRandom.uuid).
+          should matcher.scoped_to(:scope1)
+      end
+
+      context 'with an existing record that conflicts with scope.next' do
+        it 'accepts' do
+          validating_scoped_uniqueness_with_conflicting_next(:scope1, :uuid, :scope1 => SecureRandom.uuid).
+            should matcher.scoped_to(:scope1)
+        end
+      end
+
+      context 'with a nil value' do
+        it 'accepts' do
+          validating_scoped_uniqueness([:scope1], :uuid, :scope1 => nil).
+            should matcher.scoped_to(:scope1)
+        end
+      end
+
+      context 'when too narrow of a scope is specified' do
+        it 'rejects' do
+          validating_scoped_uniqueness([:scope1, :scope2], :uuid, :scope1 => SecureRandom.uuid, :scope2 => SecureRandom.uuid).
+            should_not matcher.scoped_to(:scope1, :scope2, :other)
+        end
+      end
+
+      context 'with an existing record that conflicts with scope.next' do
+        it 'accepts' do
+          validating_scoped_uniqueness_with_conflicting_next(:scope1, :scope1 => 1).
+            should matcher.scoped_to(:scope1)
+        end
+      end
+    end
+
     def create_existing_record(attributes = {})
       @existing ||= create_record(attributes)
     end


### PR DESCRIPTION
Since PostgreSQL is very strict in regard to column types validates_uniqueness_of needs to support :uuid as a column type to generate a valid test value. This pull request adds the necessary column type detection and respective tests.
