### PR TITLE
Add Rails 4.0 tests to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,12 @@ matrix:
     - rvm: rbx-19mode
     - rvm: jruby-19mode
   include:
+    - rvm: 1.9.3
+      gemfile: gemfiles/4.0.gemfile
     - rvm: 2.0.0
       gemfile: gemfiles/3.2.gemfile
+    - rvm: 2.0.0
+      gemfile: gemfiles/4.0.gemfile
     - rvm: rbx-19mode
       gemfile: gemfiles/3.2.gemfile
     - rvm: jruby-19mode


### PR DESCRIPTION
Updates .travis.yml to test against Rails 4.0 on MRI 1.9.3 and 2.0.0.
