### PR TITLE
Fix case where allow_value matcher ignores some values

### DIFF
--- a/lib/shoulda/matchers/active_model/allow_value_matcher.rb
+++ b/lib/shoulda/matchers/active_model/allow_value_matcher.rb
@@ -63,6 +63,16 @@ module Shoulda # :nodoc:
           self
         end
 
+        def does_not_match?(instance)
+          self.instance = instance
+
+          values_to_match.all? do |value|
+            self.value = value
+            instance.send("#{attribute_to_set}=", value)
+            errors_match?
+          end
+        end
+
         def matches?(instance)
           self.instance = instance
 

--- a/spec/shoulda/matchers/active_model/allow_value_matcher_spec.rb
+++ b/spec/shoulda/matchers/active_model/allow_value_matcher_spec.rb
@@ -42,6 +42,24 @@ describe Shoulda::Matchers::ActiveModel::AllowValueMatcher do
       validating_format(:with => /abc/).
         should_not allow_value('xyz', 'zyx', nil, []).for(:attr)
     end
+
+    context 'using #should_not' do
+      it 'rejects a good value that is after a bad value' do
+        expect {
+          validating_format(:with => /abc/).
+            should_not allow_value('xyz', 'abc').for(:attr)
+        }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+      end
+    end
+
+    context 'using #should' do
+      it 'rejects a bad value that is after a good value' do
+        expect {
+          validating_format(:with => /abc/).
+            should allow_value('abc', 'xyz').for(:attr)
+        }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+      end
+    end
   end
 
   context 'an attribute with a validation and a custom message' do
@@ -121,10 +139,6 @@ describe Shoulda::Matchers::ActiveModel::AllowValueMatcher do
 
     it "rejects several bad values (#{bad_values.map(&:inspect).join(', ')})" do
       model.should_not allow_value(*bad_values).for(:attr)
-    end
-
-    it "rejects a mix of both good and bad values" do
-      model.should_not allow_value('12345', *bad_values).for(:attr)
     end
   end
 


### PR DESCRIPTION
This fixes #343, #175

When using `#should`:
```
# This passes (everything ok)
validating_format(:with => /abc/).
  should allow_value('abc').for(:attr)

# This fails (everything ok)
validating_format(:with => /abc/).
  should allow_value('bcd').for(:attr)

# This fails (everything ok)
validating_format(:with => /abc/).
  should allow_value('abc', 'bcd').for(:attr)
```

But when using `#should_not`:
```
# This passes (everything ok)
validating_format(:with => /abc/).
  should_not allow_value('bcd').for(:attr)

# This fails (everything ok)
validating_format(:with => /abc/).
  should_not allow_value('abc').for(:attr)

# This passes (it shouldn't because of the last value)
validating_format(:with => /abc/).
  should_not allow_value('bcd', 'abc').for(:attr)
```

My pull request fixes the last case.