### PR TITLE
Make ValidateNumericalityOfMatcher support contexts

### DIFF
--- a/lib/shoulda/matchers/active_model/odd_even_number_matcher.rb
+++ b/lib/shoulda/matchers/active_model/odd_even_number_matcher.rb
@@ -21,6 +21,12 @@ module Shoulda # :nodoc:
           end
         end
 
+        def on(context)
+          @context = context
+          @disallow_value_matcher = @disallow_value_matcher.on(@context)
+          self
+        end
+
         def matches?(subject)
           @disallow_value_matcher.matches?(subject)
         end

--- a/lib/shoulda/matchers/active_model/only_integer_matcher.rb
+++ b/lib/shoulda/matchers/active_model/only_integer_matcher.rb
@@ -11,6 +11,12 @@ module Shoulda # :nodoc:
             with_message(:not_an_integer)
         end
 
+        def on(context)
+          @context = context
+          @disallow_value_matcher = @disallow_value_matcher.on(@context)
+          self
+        end
+
         def matches?(subject)
           @disallow_value_matcher.matches?(subject)
         end

--- a/lib/shoulda/matchers/active_model/validate_numericality_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_numericality_of_matcher.rb
@@ -31,44 +31,50 @@ module Shoulda # :nodoc:
           add_disallow_value_matcher
         end
 
+        def on(context)
+          @context = context
+          @submatchers.each { |submatcher| submatcher.on(@context) }
+          self
+        end
+
         def only_integer
-          add_submatcher(OnlyIntegerMatcher.new(@attribute))
+          add_submatcher(OnlyIntegerMatcher.new(@attribute).on(@context))
           self
         end
 
         def is_greater_than(value)
-          add_submatcher(ComparisonMatcher.new(value, :>).for(@attribute))
+          add_submatcher(ComparisonMatcher.new(value, :>).for(@attribute).on(@context))
           self
         end
 
         def is_greater_than_or_equal_to(value)
-          add_submatcher(ComparisonMatcher.new(value, :>=).for(@attribute))
+          add_submatcher(ComparisonMatcher.new(value, :>=).for(@attribute).on(@context))
           self
         end
 
         def is_equal_to(value)
-          add_submatcher(ComparisonMatcher.new(value, :==).for(@attribute))
+          add_submatcher(ComparisonMatcher.new(value, :==).for(@attribute).on(@context))
           self
         end
 
         def is_less_than(value)
-          add_submatcher(ComparisonMatcher.new(value, :<).for(@attribute))
+          add_submatcher(ComparisonMatcher.new(value, :<).for(@attribute).on(@context))
           self
         end
 
         def is_less_than_or_equal_to(value)
-          add_submatcher(ComparisonMatcher.new(value, :<=).for(@attribute))
+          add_submatcher(ComparisonMatcher.new(value, :<=).for(@attribute).on(@context))
           self
         end
 
         def odd
-          odd_number_matcher = OddEvenNumberMatcher.new(@attribute, :odd => true)
+          odd_number_matcher = OddEvenNumberMatcher.new(@attribute, :odd => true).on(@context)
           add_submatcher(odd_number_matcher)
           self
         end
 
         def even
-          even_number_matcher = OddEvenNumberMatcher.new(@attribute, :even => true)
+          even_number_matcher = OddEvenNumberMatcher.new(@attribute, :even => true).on(@context)
           add_submatcher(even_number_matcher)
           self
         end
@@ -100,6 +106,7 @@ module Shoulda # :nodoc:
         def add_disallow_value_matcher
           disallow_value_matcher = DisallowValueMatcher.new(NON_NUMERIC_VALUE).
             for(@attribute).
+            on(@context).
             with_message(:not_a_number)
 
           add_submatcher(disallow_value_matcher)

--- a/spec/shoulda/matchers/active_model/validate_numericality_of_matcher_spec.rb
+++ b/spec/shoulda/matchers/active_model/validate_numericality_of_matcher_spec.rb
@@ -121,6 +121,32 @@ describe Shoulda::Matchers::ActiveModel::ValidateNumericalityOfMatcher do
     end
   end
 
+  context "with a context-dependent validation" do
+    context "without the validation context" do
+      specify { validating_numericality(:on => :customisable).should_not matcher }
+      specify { validating_numericality(:only_integer => true, :on => :customisable).should_not matcher.only_integer }
+      specify { validating_numericality(:greater_than => 10, :on => :customisable).should_not matcher.is_greater_than(10) }
+      specify { validating_numericality(:greater_than_or_equal_to => 10, :on => :customisable).should_not matcher.is_greater_than_or_equal_to(10) }
+      specify { validating_numericality(:equal_to => 10, :on => :customisable).should_not matcher.is_equal_to(10) }
+      specify { validating_numericality(:less_than => 10, :on => :customisable).should_not matcher.is_less_than(10) }
+      specify { validating_numericality(:less_than_or_equal_to => 10, :on => :customisable).should_not matcher.is_less_than_or_equal_to(10) }
+      specify { validating_numericality(:odd => true, :on => :customisable).should_not matcher.odd }
+      specify { validating_numericality(:even => true, :on => :customisable).should_not matcher.even }
+    end
+
+    context "with the validation context" do
+      specify { validating_numericality(:on => :customisable).should matcher.on(:customisable) }
+      specify { validating_numericality(:only_integer => true, :on => :customisable).should matcher.on(:customisable).only_integer }
+      specify { validating_numericality(:greater_than => 10, :on => :customisable).should matcher.on(:customisable).is_greater_than(10) }
+      specify { validating_numericality(:greater_than_or_equal_to => 10, :on => :customisable).should matcher.on(:customisable).is_greater_than_or_equal_to(10) }
+      specify { validating_numericality(:equal_to => 10, :on => :customisable).should matcher.on(:customisable).is_equal_to(10) }
+      specify { validating_numericality(:less_than => 10, :on => :customisable).should matcher.on(:customisable).is_less_than(10) }
+      specify { validating_numericality(:less_than_or_equal_to => 10, :on => :customisable).should matcher.on(:customisable).is_less_than_or_equal_to(10) }
+      specify { validating_numericality(:odd => true, :on => :customisable).should matcher.on(:customisable).odd }
+      specify { validating_numericality(:even => true, :on => :customisable).should matcher.on(:customisable).even }
+    end
+  end
+
   context 'when the subject is stubbed' do
     it 'retains stubs on submatchers' do
       subject = define_model :example, :attr => :string do


### PR DESCRIPTION
Extension of #246 to support contexts in the validate_numericality_of matchers, which I didn't realise used a separate matcher class.

Fixes issue raised by @anujbiyani in the comments of the previous pull request.
