### PR TITLE
Added "should accept_nested_attributes_for" example on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Matchers to test associations:
 describe Post do
   it { should belong_to(:user) }
   it { should have_many(:tags).through(:taggings) }
+  it { should accept_nested_attributes_for(:comments) }
 end
 
 describe User do


### PR DESCRIPTION
As the title said. :smirk:
I thought an example to this (i guess often) used feature is missing in the ActiveRecord-section on README.md
