### PR TITLE
Correct behavior of with_message with ensures_length_of

### DIFF
--- a/lib/shoulda/matchers/active_model/ensure_length_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/ensure_length_of_matcher.rb
@@ -68,10 +68,17 @@ module Shoulda # :nodoc:
           end
           self
         end
-        alias_method :with_message, :with_short_message
 
         def with_long_message(message)
           if message
+            @long_message = message
+          end
+          self
+        end
+
+        def with_message(message)
+          if message
+            @short_message = message
             @long_message = message
           end
           self

--- a/spec/shoulda/matchers/active_model/ensure_length_of_matcher_spec.rb
+++ b/spec/shoulda/matchers/active_model/ensure_length_of_matcher_spec.rb
@@ -98,6 +98,13 @@ describe Shoulda::Matchers::ActiveModel::EnsureLengthOfMatcher do
     end
   end
 
+  context 'an attribute with a custom equal validation' do
+    it 'accepts ensuring the correct exact length' do
+      validating_length(:is => 4, :message => 'foobar').
+        should ensure_length_of(:attr).is_equal_to(4).with_message(/foo/)
+    end
+  end
+
   context 'an attribute without a length validation' do
     it 'rejects ensuring a minimum length' do
       define_model(:example, :attr => :string).new.


### PR DESCRIPTION
Using a matcher for example...

``` ruby
it { should ensure_length_of(:some_attr).is_equal_to(4).with_message("some message") }
```

... used to validate the wrong message when testing the upper bound, because only @short_message was set as the given message.
