### PR TITLE
Route accept string

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 * Fix Rails/Test::Unit integration to ensure that the test case classes we are
   re-opening actually exist.
 
+* Route matchers now accepts a string in the `to` method
+
 # v 2.4.0
 
 * Fix a bug with the `validate_numericality_of` matcher that would not allow the

--- a/lib/shoulda/matchers/action_controller.rb
+++ b/lib/shoulda/matchers/action_controller.rb
@@ -1,4 +1,5 @@
 require 'shoulda/matchers/action_controller/filter_param_matcher'
+require 'shoulda/matchers/action_controller/route_params'
 require 'shoulda/matchers/action_controller/set_the_flash_matcher'
 require 'shoulda/matchers/action_controller/render_with_layout_matcher'
 require 'shoulda/matchers/action_controller/respond_with_matcher'

--- a/lib/shoulda/matchers/action_controller/route_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/route_matcher.rb
@@ -13,15 +13,19 @@ module Shoulda # :nodoc:
       #
       #   it { should route(:get, '/posts').
       #                 to(:controller => :posts, :action => :index) }
+      #   it { should route(:get, '/posts').to('posts#index') }
       #   it { should route(:get, '/posts/new').to(:action => :new) }
       #   it { should route(:post, '/posts').to(:action => :create) }
       #   it { should route(:get, '/posts/1').to(:action => :show, :id => 1) }
+      #   it { should route(:get, '/posts/1').to('posts#show', :id => 1) }
       #   it { should route(:get, '/posts/1/edit').to(:action => :edit, :id => 1) }
       #   it { should route(:put, '/posts/1').to(:action => :update, :id => 1) }
       #   it { should route(:delete, '/posts/1').
       #                 to(:action => :destroy, :id => 1) }
       #   it { should route(:get, '/users/1/posts/1').
       #                 to(:action => :show, :id => 1, :user_id => 1) }
+      #   it { should route(:get, '/users/1/posts/1').
+      #                 to('posts#show', :id => 1, :user_id => 1) }
       def route(method, path)
         RouteMatcher.new(method, path, self)
       end
@@ -35,8 +39,8 @@ module Shoulda # :nodoc:
 
         attr_reader :failure_message_for_should, :failure_message_for_should_not
 
-        def to(params)
-          @params = stringify_params(params)
+        def to(*args)
+          @params = RouteParams.new(args).normalize
           self
         end
 
@@ -60,19 +64,6 @@ module Shoulda # :nodoc:
           @params[:controller] ||= controller.controller_path
         end
 
-        def stringify_params(params)
-          params.each do |key, value|
-            params[key] = stringify(value)
-          end
-        end
-
-        def stringify(value)
-          if value.is_a?(Array)
-            value.map(&:to_param)
-          else
-            value.to_param
-          end
-        end
 
         def route_recognized?
           begin

--- a/lib/shoulda/matchers/action_controller/route_params.rb
+++ b/lib/shoulda/matchers/action_controller/route_params.rb
@@ -1,0 +1,47 @@
+module Shoulda # :nodoc:
+  module Matchers
+    module ActionController # :nodoc:
+      class RouteParams
+        def initialize(args)
+          @args = args
+        end
+
+        def normalize
+          if controller_and_action_given_as_string?
+            extract_params_from_string
+          else
+            stringify_params
+          end
+        end
+
+        private
+
+        attr_reader :args
+
+        def controller_and_action_given_as_string?
+          args[0].is_a?(String)
+        end
+
+        def extract_params_from_string
+          params = args[1] || {}
+          controller, action = args[0].split('#')
+          params.merge!(:controller => controller, :action => action)
+        end
+
+        def stringify_params
+          args[0].each do |key, value|
+            args[0][key] = stringify(value)
+          end
+        end
+
+        def stringify(value)
+          if value.is_a?(Array)
+            value.map(&:to_param)
+          else
+            value.to_param
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/shoulda/matchers/action_controller/route_matcher_spec.rb
+++ b/spec/shoulda/matchers/action_controller/route_matcher_spec.rb
@@ -54,6 +54,11 @@ describe Shoulda::Matchers::ActionController::RouteMatcher, type: :controller do
         to(:action => 'other', :id => '1')
     end
 
+    it "accepts a string as first parameter" do
+      route_examples_to_examples.should route(:get, '/examples/1').
+        to("examples#example", id: '1')
+    end
+
     def route_examples_to_examples
       define_routes do
         get 'examples/:id', :to => 'examples#example'

--- a/spec/shoulda/matchers/action_controller/route_params_spec.rb
+++ b/spec/shoulda/matchers/action_controller/route_params_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe Shoulda::Matchers::ActionController::RouteParams do
+
+  describe "#normalize" do
+
+    context "when the route parameters is a hash" do
+      it "stringifies the values in the hash" do
+        build_route_params(:controller => :examples, :action => 'example', :id => '1').normalize.
+          should eq({ :controller => "examples", :action => "example", :id => "1" })
+      end
+    end
+
+    context "when the route parameters is a string and a hash" do
+      it "produces a hash of route parameters" do
+        build_route_params("examples#example", id: '1').normalize.
+          should eq({ :controller => "examples", :action => "example", :id => "1" })
+      end
+    end
+
+    context "when the route params is a string" do
+      it "produces a hash of route params" do
+        build_route_params("examples#index").normalize.
+          should eq({ :controller => "examples", :action => "index"})
+      end
+    end
+  end
+
+  def build_route_params(*params)
+    Shoulda::Matchers::ActionController::RouteParams.new(params)
+  end
+end
+


### PR DESCRIPTION
Add to the route matcher the possibility to pass a string like:

``` ruby
it { should route(:get, '/posts').to('posts#index') } 
```

like in the [rspec-rails](https://www.relishapp.com/rspec/rspec-rails/v/2-14/docs/routing-specs/route-to-matcher).
