### PR TITLE
ensure_inclusion_of works with a decimal column

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
   string instead of only a hash (e.g. `route(...).to('posts#index')` instead of
   `route(...).to(controller: 'posts', action: 'index')`).
 
+* The `ensure_inclusion_of` now works with a decimal column.
+
 # v 2.4.0
 
 * Fix a bug with the `validate_numericality_of` matcher that would not allow the

--- a/lib/shoulda/matchers/active_model/ensure_inclusion_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/ensure_inclusion_of_matcher.rb
@@ -24,6 +24,7 @@ module Shoulda # :nodoc:
       class EnsureInclusionOfMatcher < ValidationMatcher # :nodoc:
         ARBITRARY_OUTSIDE_STRING = 'shouldamatchersteststring'
         ARBITRARY_OUTSIDE_FIXNUM = 123456789
+        ARBITRARY_OUTSIDE_DECIMAL = 0.123456789
 
         def initialize(attribute)
           super(attribute)
@@ -160,6 +161,8 @@ module Shoulda # :nodoc:
           case @subject.send(@attribute.to_s)
           when Fixnum
             ARBITRARY_OUTSIDE_FIXNUM
+          when BigDecimal
+            ARBITRARY_OUTSIDE_DECIMAL 
           else
             ARBITRARY_OUTSIDE_STRING
           end

--- a/spec/shoulda/matchers/active_model/ensure_inclusion_of_matcher_spec.rb
+++ b/spec/shoulda/matchers/active_model/ensure_inclusion_of_matcher_spec.rb
@@ -18,6 +18,16 @@ describe Shoulda::Matchers::ActiveModel::EnsureInclusionOfMatcher do
     end
   end
 
+  context 'with an decimal column' do
+    it 'can verify decimal values' do
+      model = define_model(:example, :attr => :decimal) do
+        validates_inclusion_of :attr, :in => [0.0, 0.1]
+      end.new
+
+      model.should ensure_inclusion_of(:attr).in_array([0.0, 0.1])
+    end
+  end
+
   context 'with true/false values' do
     it 'can verify outside values to ensure the negative case' do
       define_model(:example, :attr => :string).new.


### PR DESCRIPTION
In the last Rails Rumble got a error when using the `ensure_inclusion_of` on a decimal column. This PR fix it :four_leaf_clover:
