### PR TITLE
Add comprehensive examples to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ your test framework so you can use them right away.
 
 Different matchers apply to different parts of Rails:
 
-* [ActiveModel](#activemodel)
-* [ActiveRecord](#activerecord)
-* [ActionController](#actioncontroller)
+* [ActiveModel](#activemodel-matchers)
+* [ActiveRecord](#activerecord-matchers)
+* [ActionController](#actioncontroller-matchers)
 
 ### ActiveModel Matchers
 
-*Jump to: [allow_mass_assignment_of](#allow_mass_assignment_of), [allow_value / disallow_value](#allow_value / disallow_value), [ensure_inclusion_of](#ensure_inclusion_of), [ensure_exclusion_of](#ensure_exclusion_of), [ensure_length_of](#ensure_length_of), [have_secure_password](#have_secure_password), [validate_acceptance_of](#validate_acceptance_of), [validate_confirmation_of](#validate_confirmation_of), [validate_numericality_of](#validate_numericality_of), [validate_presence_of](#validate_presence_of), [validate_uniqueness_of](#validate_uniqueness_of)*
+*Jump to: [allow_mass_assignment_of](#allow_mass_assignment_of), [allow_value / disallow_value](#allow_value--disallow_value), [ensure_inclusion_of](#ensure_inclusion_of), [ensure_exclusion_of](#ensure_exclusion_of), [ensure_length_of](#ensure_length_of), [have_secure_password](#have_secure_password), [validate_acceptance_of](#validate_acceptance_of), [validate_confirmation_of](#validate_confirmation_of), [validate_numericality_of](#validate_numericality_of), [validate_presence_of](#validate_presence_of), [validate_uniqueness_of](#validate_uniqueness_of)*
 
 #### allow_mass_assignment_of
 


### PR DESCRIPTION
We've seen that some people get confused on how allow_value and validates_uniqueness_of work. We've talked about adding a note to the README that talks about these caveats, and concluded that people don't read so it wouldn't be that helpful. However, I think people do read -- when they want to know how something works, or they want to do something and they want to know if the tool they're using can do that and how it does that. It got me thinking -- we have a simple rundown of the API that shoulda-matchers provides, but we don't have extensive examples, and we don't have a place to talk about caveats should they appear. I don't think the API documentation is the right place for this as it's supposed to be succinct. So it seems like we need some sort of examples section.

I am certainly open to opinions about this, though. We don't really do this for other projects so this is sort of a new thing. For instance, if having examples is okay, do we want to put them in the README or should we make an examples/ directory?
