### PR TITLE
Remove #for from validation matchers

### DIFF
--- a/lib/shoulda/matchers/active_model/allow_value_matcher.rb
+++ b/lib/shoulda/matchers/active_model/allow_value_matcher.rb
@@ -19,11 +19,11 @@ module Shoulda # :nodoc:
       #   it { should_not allow_value('bad').for(:isbn) }
       #   it { should allow_value('isbn 1 2345 6789 0').for(:isbn) }
       #
-      def allow_value(*values)
+      def allow_value_for(attribute, *values)
         if values.empty?
           raise ArgumentError, 'need at least one argument'
         else
-          AllowValueMatcher.new(*values)
+          AllowValueMatcher.new(attribute, *values)
         end
       end
 
@@ -33,16 +33,12 @@ module Shoulda # :nodoc:
         attr_accessor :attribute_with_message
         attr_accessor :options
 
-        def initialize(*values)
+        def initialize(attribute, *values)
+          self.attribute_to_set = attribute
+          self.attribute_to_check_message_against = attribute
           self.values_to_match = values
           self.message_finder_factory = ValidationMessageFinder
           self.options = {}
-        end
-
-        def for(attribute)
-          self.attribute_to_set = attribute
-          self.attribute_to_check_message_against = attribute
-          self
         end
 
         def on(context)

--- a/lib/shoulda/matchers/active_model/comparison_matcher.rb
+++ b/lib/shoulda/matchers/active_model/comparison_matcher.rb
@@ -6,15 +6,11 @@ module Shoulda # :nodoc:
       #                 is_greater_than(6).
       #                 less_than(20)...(and so on) }
       class ComparisonMatcher < ValidationMatcher
-        def initialize(value, operator)
+        def initialize(attribute, value, operator)
+          @attribute = attribute
           @value = value
           @operator = operator
           @message = nil
-        end
-
-        def for(attribute)
-          @attribute = attribute
-          self
         end
 
         def matches?(subject)

--- a/lib/shoulda/matchers/active_model/disallow_value_matcher.rb
+++ b/lib/shoulda/matchers/active_model/disallow_value_matcher.rb
@@ -2,17 +2,12 @@ module Shoulda # :nodoc:
   module Matchers
     module ActiveModel # :nodoc:
       class DisallowValueMatcher # :nodoc:
-        def initialize(value)
-          @allow_matcher = AllowValueMatcher.new(value)
+        def initialize(attribute, value)
+          @allow_matcher = AllowValueMatcher.new(attribute, value)
         end
 
         def matches?(subject)
           !@allow_matcher.matches?(subject)
-        end
-
-        def for(attribute)
-          @allow_matcher.for(attribute)
-          self
         end
 
         def on(context)

--- a/lib/shoulda/matchers/active_model/odd_even_number_matcher.rb
+++ b/lib/shoulda/matchers/active_model/odd_even_number_matcher.rb
@@ -11,12 +11,12 @@ module Shoulda # :nodoc:
           options[:even]  ||= false
 
           if options[:odd] && !options[:even]
-            @disallow_value_matcher = DisallowValueMatcher.new(NON_ODD_NUMBER_VALUE).
-              for(@attribute).
+            @disallow_value_matcher =
+              DisallowValueMatcher.new(@attribute, NON_ODD_NUMBER_VALUE).
               with_message(:odd)
           else
-            @disallow_value_matcher = DisallowValueMatcher.new(NON_EVEN_NUMBER_VALUE).
-              for(@attribute).
+            @disallow_value_matcher =
+              DisallowValueMatcher.new(@attribute, NON_EVEN_NUMBER_VALUE).
               with_message(:even)
           end
         end

--- a/lib/shoulda/matchers/active_model/only_integer_matcher.rb
+++ b/lib/shoulda/matchers/active_model/only_integer_matcher.rb
@@ -6,8 +6,8 @@ module Shoulda # :nodoc:
 
         def initialize(attribute)
           @attribute = attribute
-          @disallow_value_matcher = DisallowValueMatcher.new(NON_INTEGER_VALUE).
-            for(attribute).
+          @disallow_value_matcher =
+            DisallowValueMatcher.new(attribute, NON_INTEGER_VALUE).
             with_message(:not_an_integer)
         end
 

--- a/lib/shoulda/matchers/active_model/validate_numericality_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_numericality_of_matcher.rb
@@ -37,27 +37,27 @@ module Shoulda # :nodoc:
         end
 
         def is_greater_than(value)
-          add_submatcher(ComparisonMatcher.new(value, :>).for(@attribute))
+          add_submatcher(ComparisonMatcher.new(@attribute, value, :>))
           self
         end
 
         def is_greater_than_or_equal_to(value)
-          add_submatcher(ComparisonMatcher.new(value, :>=).for(@attribute))
+          add_submatcher(ComparisonMatcher.new(@attribute, value, :>=))
           self
         end
 
         def is_equal_to(value)
-          add_submatcher(ComparisonMatcher.new(value, :==).for(@attribute))
+          add_submatcher(ComparisonMatcher.new(@attribute, value, :==))
           self
         end
 
         def is_less_than(value)
-          add_submatcher(ComparisonMatcher.new(value, :<).for(@attribute))
+          add_submatcher(ComparisonMatcher.new(@attribute, value, :<))
           self
         end
 
         def is_less_than_or_equal_to(value)
-          add_submatcher(ComparisonMatcher.new(value, :<=).for(@attribute))
+          add_submatcher(ComparisonMatcher.new(@attribute, value, :<=))
           self
         end
 
@@ -98,8 +98,8 @@ module Shoulda # :nodoc:
         private
 
         def add_disallow_value_matcher
-          disallow_value_matcher = DisallowValueMatcher.new(NON_NUMERIC_VALUE).
-            for(@attribute).
+          disallow_value_matcher =
+            DisallowValueMatcher.new(@attribute, NON_NUMERIC_VALUE).
             with_message(:not_a_number)
 
           add_submatcher(disallow_value_matcher)

--- a/lib/shoulda/matchers/active_model/validation_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validation_matcher.rb
@@ -58,8 +58,7 @@ module Shoulda # :nodoc:
 
         def allow_value_matcher(value, message)
           matcher = AllowValueMatcher.
-            new(value).
-            for(@attribute).
+            new(@attribute, value).
             on(@context).
             with_message(message)
 
@@ -72,8 +71,7 @@ module Shoulda # :nodoc:
 
         def disallow_value_matcher(value, message)
           matcher = DisallowValueMatcher.
-            new(value).
-            for(@attribute).
+            new(@attribute, value).
             on(@context).
             with_message(message)
 

--- a/spec/shoulda/matchers/active_model/allow_value_matcher_spec.rb
+++ b/spec/shoulda/matchers/active_model/allow_value_matcher_spec.rb
@@ -3,20 +3,20 @@ require 'spec_helper'
 describe Shoulda::Matchers::ActiveModel::AllowValueMatcher do
   context "#description" do
     it 'describes itself with multiple values' do
-      matcher = allow_value('foo', 'bar').for(:baz)
+      matcher = allow_value_for(:baz, 'foo', 'bar')
 
       matcher.description.should eq 'allow baz to be set to any of ["foo", "bar"]'
     end
 
     it 'describes itself with a single value' do
-      matcher = allow_value('foo').for(:baz)
+      matcher = allow_value_for(:baz, 'foo')
 
       matcher.description.should eq 'allow baz to be set to "foo"'
     end
 
     if active_model_3_2?
       it 'describes itself with a strict validation' do
-        strict_matcher = allow_value('xyz').for(:attr).strict
+        strict_matcher = allow_value_for(:attr, 'xyz').strict
 
         strict_matcher.description.
           should eq %q(doesn't raise when attr is set to "xyz")
@@ -26,45 +26,45 @@ describe Shoulda::Matchers::ActiveModel::AllowValueMatcher do
 
   context 'an attribute with a validation' do
     it 'allows a good value' do
-      validating_format(:with => /abc/).should allow_value('abcde').for(:attr)
+      validating_format(:with => /abc/).should allow_value_for(:attr, 'abcde')
     end
 
     it 'rejects a bad value' do
-      validating_format(:with => /abc/).should_not allow_value('xyz').for(:attr)
+      validating_format(:with => /abc/).should_not allow_value_for(:attr, 'xyz')
     end
 
     it 'allows several good values' do
       validating_format(:with => /abc/).
-        should allow_value('abcde', 'deabc').for(:attr)
+        should allow_value_for(:attr, 'abcde', 'deabc')
     end
 
     it 'rejects several bad values' do
       validating_format(:with => /abc/).
-        should_not allow_value('xyz', 'zyx', nil, []).for(:attr)
+        should_not allow_value_for(:attr, 'xyz', 'zyx', nil, [])
     end
   end
 
   context 'an attribute with a validation and a custom message' do
     it 'allows a good value' do
       validating_format(:with => /abc/, :message => 'bad value').
-        should allow_value('abcde').for(:attr).with_message(/bad/)
+        should allow_value_for(:attr, 'abcde').with_message(/bad/)
     end
 
     it 'rejects a bad value' do
       validating_format(:with => /abc/, :message => 'bad value').
-        should_not allow_value('xyz').for(:attr).with_message(/bad/)
+        should_not allow_value_for(:attr, 'xyz').with_message(/bad/)
     end
   end
 
   context 'an attribute where the message occurs on another attribute' do
     it 'allows a good value' do
       record_with_custom_validation.should \
-        allow_value('good value').for(:attr).with_message(/some message/, :against => :attr2)
+        allow_value_for(:attr, 'good value').with_message(/some message/, :against => :attr2)
     end
 
     it 'rejects a bad value' do
       record_with_custom_validation.should_not \
-        allow_value('bad value').for(:attr).with_message(/some message/, :against => :attr2)
+        allow_value_for(:attr, 'bad value').with_message(/some message/, :against => :attr2)
     end
 
     def record_with_custom_validation
@@ -83,17 +83,17 @@ describe Shoulda::Matchers::ActiveModel::AllowValueMatcher do
   context "an attribute with a context-dependent validation" do
     context "without the validation context" do
       it "allows a bad value" do
-        validating_format(:with => /abc/, :on => :customisable).should allow_value("xyz").for(:attr)
+        validating_format(:with => /abc/, :on => :customisable).should allow_value_for(:attr, "xyz")
       end
     end
 
     context "with the validation context" do
       it "allows a good value" do
-        validating_format(:with => /abc/, :on => :customisable).should allow_value("abcde").for(:attr).on(:customisable)
+        validating_format(:with => /abc/, :on => :customisable).should allow_value_for(:attr, "abcde").on(:customisable)
       end
 
       it "rejects a bad value" do
-        validating_format(:with => /abc/, :on => :customisable).should_not allow_value("xyz").for(:attr).on(:customisable)
+        validating_format(:with => /abc/, :on => :customisable).should_not allow_value_for(:attr, "xyz").on(:customisable)
       end
     end
   end
@@ -110,28 +110,28 @@ describe Shoulda::Matchers::ActiveModel::AllowValueMatcher do
     bad_values = [nil, '', 'abc', '0', '50001', '123456', []]
 
     it 'allows a good value' do
-      model.should allow_value('12345').for(:attr)
+      model.should allow_value_for(:attr, '12345')
     end
 
     bad_values.each do |bad_value|
       it "rejects a bad value (#{bad_value.inspect})" do
-        model.should_not allow_value(bad_value).for(:attr)
+        model.should_not allow_value_for(:attr, bad_value)
       end
     end
 
     it "rejects several bad values (#{bad_values.map(&:inspect).join(', ')})" do
-      model.should_not allow_value(*bad_values).for(:attr)
+      model.should_not allow_value_for(:attr, *bad_values)
     end
 
     it "rejects a mix of both good and bad values" do
-      model.should_not allow_value('12345', *bad_values).for(:attr)
+      model.should_not allow_value_for(:attr, '12345', *bad_values)
     end
   end
 
   context 'with a single value' do
     it 'allows you to call description before calling matches?' do
       model = define_model(:example, :attr => :string).new
-      matcher = described_class.new('foo').for(:attr)
+      matcher = allow_value_for(:attr, 'foo')
       matcher.description
 
       expect { matcher.matches?(model) }.not_to raise_error
@@ -140,7 +140,7 @@ describe Shoulda::Matchers::ActiveModel::AllowValueMatcher do
 
   context 'with no values' do
     it 'raises an error' do
-      expect { allow_value.for(:baz) }.
+      expect { allow_value_for(:baz) }.
         to raise_error(ArgumentError, /at least one argument/)
     end
   end
@@ -149,16 +149,16 @@ describe Shoulda::Matchers::ActiveModel::AllowValueMatcher do
     context 'an attribute with a strict format validation' do
       it 'strictly rejects a bad value' do
         validating_format(:with => /abc/, :strict => true).
-          should_not allow_value('xyz').for(:attr).strict
+          should_not allow_value_for(:attr, 'xyz').strict
       end
 
       it 'strictly allows a bad value with a different message' do
         validating_format(:with => /abc/, :strict => true).
-          should allow_value('xyz').for(:attr).with_message(/abc/).strict
+          should allow_value_for(:attr, 'xyz').with_message(/abc/).strict
       end
 
       it 'provides a useful negative failure message' do
-        matcher = allow_value('xyz').for(:attr).strict.with_message(/abc/)
+        matcher = allow_value_for(:attr, 'xyz').strict.with_message(/abc/)
 
         matcher.matches?(validating_format(:with => /abc/, :strict => true))
 

--- a/spec/shoulda/matchers/active_model/comparison_matcher_spec.rb
+++ b/spec/shoulda/matchers/active_model/comparison_matcher_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Shoulda::Matchers::ActiveModel::ComparisonMatcher do
   it_behaves_like 'a numerical submatcher' do
-    subject {  Shoulda::Matchers::ActiveModel::ComparisonMatcher.new(0, :>) }
+    subject {  Shoulda::Matchers::ActiveModel::ComparisonMatcher.new(:attr, 0, :>) }
   end
 
   context 'is_greater_than' do

--- a/spec/shoulda/matchers/active_model/disallow_value_matcher_spec.rb
+++ b/spec/shoulda/matchers/active_model/disallow_value_matcher_spec.rb
@@ -2,33 +2,34 @@ require 'spec_helper'
 
 describe Shoulda::Matchers::ActiveModel::DisallowValueMatcher do
   it 'does not allow any types' do
-    matcher('abcde').allowed_types.should eq ''
+    matcher = described_class.new(:doesnt_matter, 'abcde')
+    matcher.allowed_types.should eq ''
   end
 
   context 'an attribute with a format validation' do
     it 'does not match if the value is allowed' do
-      validating_format(:with => /abc/).should_not matcher('abcde').for(:attr)
+      validating_format(:with => /abc/).should_not disallow_value_for(:attr, 'abcde')
     end
 
     it 'matches if the value is not allowed' do
-      validating_format(:with => /abc/).should matcher('xyz').for(:attr)
+      validating_format(:with => /abc/).should disallow_value_for(:attr, 'xyz')
     end
   end
 
   context "an attribute with a context-dependent validation" do
     context "without the validation context" do
       it "does not match" do
-        validating_format(:with => /abc/, :on => :customisable).should_not matcher("xyz").for(:attr)
+        validating_format(:with => /abc/, :on => :customisable).should_not disallow_value_for(:attr, "xyz")
       end
     end
 
     context "with the validation context" do
       it "disallows a bad value" do
-        validating_format(:with => /abc/, :on => :customisable).should matcher("xyz").for(:attr).on(:customisable)
+        validating_format(:with => /abc/, :on => :customisable).should disallow_value_for(:attr, "xyz").on(:customisable)
       end
 
       it "does not match a good value" do
-        validating_format(:with => /abc/, :on => :customisable).should_not matcher("abcde").for(:attr).on(:customisable)
+        validating_format(:with => /abc/, :on => :customisable).should_not disallow_value_for(:attr, "abcde").on(:customisable)
       end
     end
   end
@@ -36,14 +37,14 @@ describe Shoulda::Matchers::ActiveModel::DisallowValueMatcher do
   context 'an attribute with a format validation and a custom message' do
     it 'does not match if the value and message are both correct' do
       validating_format(:with => /abc/, :message => 'good message').
-        should_not matcher('abcde').for(:attr).with_message('good message')
+        should_not disallow_value_for(:attr, 'abcde').with_message('good message')
     end
 
     it "delegates its failure message to its allow matcher's negative failure message" do
       allow_matcher = stub_everything(:failure_message_for_should_not => 'allow matcher failure')
       Shoulda::Matchers::ActiveModel::AllowValueMatcher.stubs(:new).returns(allow_matcher)
 
-      matcher = matcher('abcde').for(:attr).with_message('good message')
+      matcher = disallow_value_for(:attr, 'abcde').with_message('good message')
       matcher.matches?(validating_format(:with => /abc/, :message => 'good message'))
 
       matcher.failure_message_for_should.should eq 'allow matcher failure'
@@ -51,19 +52,19 @@ describe Shoulda::Matchers::ActiveModel::DisallowValueMatcher do
 
     it 'matches if the message is correct but the value is not' do
       validating_format(:with => /abc/, :message => 'good message').
-        should matcher('xyz').for(:attr).with_message('good message')
+        should disallow_value_for(:attr, 'xyz').with_message('good message')
     end
   end
 
   context 'an attribute where the message occurs on another attribute' do
     it 'matches if the message is correct but the value is not' do
       record_with_custom_validation.should \
-        matcher('bad value').for(:attr).with_message(/some message/, :against => :attr2)
+        disallow_value_for(:attr, 'bad value').with_message(/some message/, :against => :attr2)
     end
 
     it 'does not match if the value and message are both correct' do
       record_with_custom_validation.should_not \
-        matcher('good value').for(:attr).with_message(/some message/, :against => :attr2)
+        disallow_value_for(:attr, 'good value').with_message(/some message/, :against => :attr2)
     end
 
     def record_with_custom_validation
@@ -79,7 +80,7 @@ describe Shoulda::Matchers::ActiveModel::DisallowValueMatcher do
     end
   end
 
-  def matcher(value)
-    described_class.new(value)
+  def disallow_value_for(attribute, value)
+    described_class.new(attribute, value)
   end
 end


### PR DESCRIPTION
Certain classes for validation matchers support a #for method to set the
attribute that the matcher operates on. This is bad API design, because
it means that it is possible for a developer to accidentally (or
purposefully) never call #for and yet still use the matcher (which would
result in the matcher blowing up). Because of this, the attribute should
be required in the initializer for the matcher.

Related to this, #allow_value also supports an optional attribute, which
should be required. Simply moving `.for(...)` to the first argument to
\#allow_value wouldn't read very well, so we rename it to
\#allow_value_for.

---

Obviously, this is a **backward-incompatible change**, but I wanted to get you guys' opinion on this.