### PR TITLE
allow_value_matcher - change to should_not behavior 

### DIFF
--- a/lib/shoulda/matchers/active_model/allow_value_matcher.rb
+++ b/lib/shoulda/matchers/active_model/allow_value_matcher.rb
@@ -73,6 +73,15 @@ module Shoulda # :nodoc:
           end
         end
 
+        def does_not_match?(instance)
+          self.instance = instance
+          values_to_match.all? do |value|
+            self.value = value
+            instance.send("#{attribute_to_set}=", value)
+            errors_match?
+          end
+        end
+
         def failure_message_for_should
           "Did not expect #{expectation}, got error: #{matched_error}"
         end

--- a/spec/shoulda/matchers/active_model/allow_value_matcher_spec.rb
+++ b/spec/shoulda/matchers/active_model/allow_value_matcher_spec.rb
@@ -42,6 +42,7 @@ describe Shoulda::Matchers::ActiveModel::AllowValueMatcher do
       validating_format(:with => /abc/).
         should_not allow_value('xyz', 'zyx', nil, []).for(:attr)
     end
+
   end
 
   context 'an attribute with a validation and a custom message' do
@@ -123,9 +124,18 @@ describe Shoulda::Matchers::ActiveModel::AllowValueMatcher do
       model.should_not allow_value(*bad_values).for(:attr)
     end
 
-    it "rejects a mix of both good and bad values" do
-      model.should_not allow_value('12345', *bad_values).for(:attr)
+    it "reject(positive match) mixed good and bad values" do
+      expect {
+        model.should allow_value('12345', *bad_values).for(:attr)
+      }.to raise_error /got error/
     end
+
+    it "reject(negative match) mixed good and bad values" do
+      expect {
+        model.should_not allow_value('12345', *bad_values).for(:attr)
+      }.to raise_error /got no error/
+    end
+
   end
 
   context 'with a single value' do


### PR DESCRIPTION
Change should_not case passes if ANY argument generates an error
to pass only if ALL arguments generate an error
