### PR TITLE
RFC: Add matcher protocol and a couple of example uses

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # HEAD
 
+* Add `shared_example` to define the matcher protocol. The tests for all new
+  matchers should include `it_behaves_like 'a matcher'`.
+
 * Fix `ensure_length_of` so that it uses the right message to validate when
   `is_equal_to` is specified in conjunction with a custom message.
 

--- a/spec/shoulda/matchers/action_controller/filter_param_matcher_spec.rb
+++ b/spec/shoulda/matchers/action_controller/filter_param_matcher_spec.rb
@@ -1,6 +1,11 @@
 require 'spec_helper'
 
 describe Shoulda::Matchers::ActionController::FilterParamMatcher do
+
+  it_behaves_like 'a matcher' do
+    let(:subject) { filter_param(:yolo) }
+  end
+
   it 'accepts filtering a filtered parameter' do
     filter(:secret)
 

--- a/spec/shoulda/matchers/action_controller/redirect_to_matcher_spec.rb
+++ b/spec/shoulda/matchers/action_controller/redirect_to_matcher_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe Shoulda::Matchers::ActionController::RedirectToMatcher do
+  it_behaves_like 'a matcher' do
+    let (:subject) { redirect_to("/some/url") }
+  end
+
   context 'a controller that redirects' do
     it 'accepts redirecting to that url' do
       controller_redirecting_to('/some/url').should redirect_to('/some/url')

--- a/spec/support/shared_examples/matcher_protocol.rb
+++ b/spec/support/shared_examples/matcher_protocol.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+shared_examples 'a matcher' do
+
+  it 'implements the matches? method' do
+    subject.should respond_to(:matches?).with(1).arguments
+  end
+
+  it 'implements the failure_message method' do
+    subject.should respond_to(:failure_message_for_should).with(0).arguments
+  end
+
+  it 'implements the negative_failure_message method' do
+    subject.should respond_to(:failure_message_for_should_not).with(0).arguments
+  end
+
+  it 'implements the description method' do
+    subject.should respond_to(:description).with(0).arguments
+  end
+end


### PR DESCRIPTION
Would you be interested in adding the shared_example defined below so that developers can easily test whether their matchers at least implement the protocol. I've only added the behavior to a few specs but if folks think this is a good idea, I'll go ahead and add them to all the existing specs before finalizing this PR.

The back story is that I spent a while debugging a matcher that did not implement the `description` method. The observed behavior in that case is that any `should` expressions somehow turn into `should_eventually` expressions and get deferred.
