### PR TITLE
Fixed README syntax error for #allow_destroy in :accepts_nested_attributes_for matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,7 +558,7 @@ end
 # RSpec
 describe Car do
   it { should accept_nested_attributes_for(:doors) }
-  it { should accept_nested_attributes_for(:mirrors).allow_destroy }
+  it { should accept_nested_attributes_for(:mirrors).allow_destroy(true) }
   it { should accept_nested_attributes_for(:windows).limit(3) }
   it { should accept_nested_attributes_for(:engine).update_only }
 end


### PR DESCRIPTION
The example in the README had an error:

``` ruby
it { should accept_nested_attributes_for(:mirrors).allow_destroy }
```

it throws an error `ArgumentError: wrong number of arguments (0 for 1)`

Since the signature of the `allow_destroy` now requires a parameter and can test both cases, the README should be updated to the following:

``` ruby
it { should accept_nested_attributes_for(:mirrors).allow_destroy(true) }
```
