### PR TITLE
Note the required appraisal step for installation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@ We love pull requests. Here's a quick guide:
 1. Fork the repo.
 
 2. Run the tests. We only take pull requests with passing tests, and it's great
-to know that you have a clean slate: `bundle && rake`
+to know that you have a clean slate: `bundle && bundle exec rake appraisal:install && bundle exec rake`
 
 3. Add a test for your change. Only refactoring and documentation changes
 require no new tests. If you are adding functionality or fixing a bug, we need


### PR DESCRIPTION
I'm working on fixing a bug just now, and the steps in CONTRIBUTING.md weren't quite complete: running `bundle && rake` fails because this project requires the appraisal setup. It took me five minutes to find out how to do this.

So I've updated the documentation to include the `bundle exec rake appraisal:install` step, and also to change `rake` to `bundle exec rake`.
