### PR TITLE
Use ActiveSupport delegation over Ruby Forwardable

### DIFF
--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -1,4 +1,4 @@
-require 'forwardable'
+require 'active_support/core_ext/module/delegation'
 
 module Shoulda # :nodoc:
   module Matchers


### PR DESCRIPTION
The delegation style found in the AssociationMatcher is an ActiveSupport style; requiring `forwardable` without extending it does not add delegation support.

Came across this in a unit test that did not have the ActiveSupport extensions loaded.
