### PR TITLE
Updates RailsShim to be explicit about which Rails pieces it needs

### DIFF
--- a/lib/shoulda/matchers/rails_shim.rb
+++ b/lib/shoulda/matchers/rails_shim.rb
@@ -2,7 +2,7 @@ module Shoulda # :nodoc:
   module Matchers
     class RailsShim # :nodoc:
       def self.layouts_ivar
-        if rails_major_version >= 4
+        if action_pack_major_version >= 4
           '@_layouts'
         else
           '@layouts'
@@ -10,7 +10,7 @@ module Shoulda # :nodoc:
       end
 
       def self.flashes_ivar
-        if rails_major_version >= 4
+        if action_pack_major_version >= 4
           :@flashes
         else
           :@used
@@ -18,7 +18,7 @@ module Shoulda # :nodoc:
       end
 
       def self.clean_scope(klass)
-        if rails_major_version == 4
+        if active_record_major_version == 4
           klass.all
         else
           klass.scoped
@@ -26,15 +26,23 @@ module Shoulda # :nodoc:
       end
 
       def self.validates_confirmation_of_error_attribute(matcher)
-        if rails_major_version == 4
+        if active_model_major_version == 4
           matcher.confirmation_attribute
         else
           matcher.attribute
         end
       end
 
-      def self.rails_major_version
-        Rails::VERSION::MAJOR
+      def self.active_record_major_version
+        ::ActiveRecord::VERSION::MAJOR
+      end
+
+      def self.active_model_major_version
+        ::ActiveModel::VERSION::MAJOR
+      end
+
+      def self.action_pack_major_version
+        ::ActionPack::VERSION::MAJOR
       end
     end
   end

--- a/spec/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -665,7 +665,7 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher do
   def define_association_with_conditions(model, macro, name, conditions, other_options={})
     args = []
     options = {}
-    if Shoulda::Matchers::RailsShim.rails_major_version == 4
+    if Shoulda::Matchers::RailsShim.active_record_major_version == 4
       args << lambda { where(conditions) }
     else
       options[:conditions] = conditions
@@ -677,7 +677,7 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher do
   def define_association_with_order(model, macro, name, order, other_options={})
     args = []
     options = {}
-    if Shoulda::Matchers::RailsShim.rails_major_version == 4
+    if Shoulda::Matchers::RailsShim.active_record_major_version == 4
       args << lambda { order(order) }
     else
       options[:order] = order


### PR DESCRIPTION
RailsShim currently checks against a Rails version to decide how to respond to certain functionality, but this is not a good idea. `shoulda-matchers` can be used without Rails -- for instance, in a Rack or Padrino application that happens to use ActiveModel models.

Without this patch, a Rack application that happens to use an ActiveModel model but which doesn't actually use Rails will fail if it uses anything that calls anything that hits RailsShim. Consider this trivial example:

``` ruby
# dummy_model.rb
require 'active_model'

class DummyModel
  include ActiveModel::Model
  attr_accessor :password
  attr_accessor :password_confirmation
end

# dummy_model_spec.rb
require 'spec_helper'

describe DummyModel do
  it { should validate_confirmation_of :password }
end
```

This will fail, since `validate_confirmation_of` checks RailsShim:

```
  1) DummyModel should require password_confirmation to match password
     Failure/Error: it { should validate_confirmation_of :password }
     NameError:
       uninitialized constant Shoulda::Matchers::RailsShim::Rails
     # ./spec/models/dummy_model_spec.rb:4:in `block (2 levels) in <top (required)>'
```

It's better if, instead, these shim methods only check the versions of the pieces they need, rather than creating an implicit dependency on Rails as a whole.
