### PR TITLE
Set I18n.enforce_available_locales correctly

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,5 +24,3 @@ RSpec.configure do |config|
   config.include Shoulda::Matchers::ActionController,
                  example_group: { file_path: /action_controller/ }
 end
-
-I18n.enforce_available_locales = false

--- a/spec/support/test_application.rb
+++ b/spec/support/test_application.rb
@@ -56,7 +56,30 @@ class TestApplication
   end
 
   def generate
+    rails_new
+    fix_available_locales_warning
+  end
+
+  def rails_new
     `rails new #{ROOT_DIR} --skip-bundle`
+  end
+
+  def fix_available_locales_warning
+    # See here for more on this:
+    # http://stackoverflow.com/questions/20361428/rails-i18n-validation-deprecation-warning
+
+    filename = File.join(ROOT_DIR, 'config/application.rb')
+
+    lines = File.read(filename).split("\n")
+    lines.insert(-3, <<EOT)
+if I18n.respond_to?(:enforce_available_locales=)
+  I18n.enforce_available_locales = false
+end
+EOT
+
+    File.open(filename, 'w') do |f|
+      f.write(lines.join("\n"))
+    end
   end
 
   def load_environment


### PR DESCRIPTION
This setting is only available for I18n v0.6.9, so setting it for all versions of Rails or I18n versions may not work.
