### PR TITLE
Handle ensure_inclusion_of for boolean columns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,15 @@
   the error message reported does not say the matcher accepts integer values if
   you didn't specify that.
 
+* Fix `ensure_inclusion_of` so that you can use it against a boolean column
+  (and pass boolean values to `in_array`). There are two caveats:
+
+  * You should not test that your attribute allows both true and false
+    (`.in_array([true, false]`); there's no way to test that it doesn't accept
+    anything other than that.
+  * You cannot test that your attribute allows nil (`.in_array([nil])`) if
+    the column does not allow null values.
+
 # v 2.5.0
 
 * Fix Rails/Test::Unit integration to ensure that the test case classes we are

--- a/lib/shoulda/matchers.rb
+++ b/lib/shoulda/matchers.rb
@@ -1,6 +1,8 @@
-require 'shoulda/matchers/version'
 require 'shoulda/matchers/assertion_error'
+require 'shoulda/matchers/error'
 require 'shoulda/matchers/rails_shim'
+require 'shoulda/matchers/warn'
+require 'shoulda/matchers/version'
 
 if defined?(RSpec)
   require 'shoulda/matchers/integrations/rspec'

--- a/lib/shoulda/matchers/active_model/errors.rb
+++ b/lib/shoulda/matchers/active_model/errors.rb
@@ -2,6 +2,7 @@ module Shoulda # :nodoc:
   module Matchers
     module ActiveModel # :nodoc:
       class CouldNotDetermineValueOutsideOfArray < RuntimeError; end
+      class NonNullableBooleanError < Shoulda::Matchers::Error; end
     end
   end
 end

--- a/lib/shoulda/matchers/error.rb
+++ b/lib/shoulda/matchers/error.rb
@@ -1,0 +1,5 @@
+module Shoulda
+  module Matchers
+    class Error < StandardError; end
+  end
+end

--- a/lib/shoulda/matchers/warn.rb
+++ b/lib/shoulda/matchers/warn.rb
@@ -1,0 +1,7 @@
+module Shoulda
+  module Matchers
+    def self.warn(msg)
+      Kernel.warn "Warning from shoulda-matchers:\n\n#{msg}"
+    end
+  end
+end

--- a/spec/support/capture_helpers.rb
+++ b/spec/support/capture_helpers.rb
@@ -1,0 +1,19 @@
+module Kernel
+  unless method_defined?(:capture)
+    def capture(stream)
+      stream = stream.to_s
+      captured_stream = Tempfile.new(stream)
+      stream_io = eval("$#{stream}")
+      origin_stream = stream_io.dup
+      stream_io.reopen(captured_stream)
+
+      yield
+
+      stream_io.rewind
+      return captured_stream.read
+    ensure
+      captured_stream.unlink
+      stream_io.reopen(origin_stream)
+    end
+  end
+end


### PR DESCRIPTION
This is a fix for the long-standing #291.

Currently, using `ensure_inclusion_of` against a boolean column doesn't work. We can assert that the column allows boolean values, but what about values that should be rejected? Well, it depends on what you give to `ensure_inclusion_of`. Here's how it works now:
- `ensure_inclusion_of(:attr).in_array([true])` asserts that false is rejected
- `ensure_inclusion_of(:attr).in_array([false])` asserts that true is rejected
- `ensure_inclusion_of(:attr).in_array([true, false])` does not assert that anything is rejected, instead informing the developer how this sort of expectation is not fully testable (anything other than true, false, or nil will be converted to false).
- `ensure_inclusion_of(:attr).in_array([nil])`, when the column is nullable, does not assert that anything is rejected, either, also printing a warning
- `ensure_inclusion_of(:attr).in_array([nil])`, when the column is non-nullable, raises an error because this expectation is not testable in any way, as setting a boolean column to nil this way will get converted to false.
