### PR TITLE
fix warning about loading minitest/unit

### DIFF
--- a/lib/shoulda/matchers/assertion_error.rb
+++ b/lib/shoulda/matchers/assertion_error.rb
@@ -7,7 +7,7 @@ module Shoulda
       # Test::Unit has been loaded already, so we use it
       AssertionError = Test::Unit::AssertionFailedError
     elsif Gem.ruby_version >= Gem::Version.new("1.9")
-      require 'minitest/unit'
+      require 'minitest/autorun'
       AssertionError = MiniTest::Assertion
     else
       raise 'No unit test library available'


### PR DESCRIPTION
When loading minitest/unit in a Rails 4.1.0.rc1 app in ruby 2.1 with rspec-rails 3.0.0.beta2, the following warning occurs:

Warning: you should require 'minitest/autorun' instead.
Warning: or add 'gem "minitest"' before 'require "minitest/autorun"'

This patch appears to fix it.
