### PR TITLE
Make optional the required argument in have_db_index(...).unique

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # HEAD
 
+* Change `have_db_index(...).unique(unique)` so that the `unique` argument
+  is optional, allowing for the shorter `have_db_index(...).unique` syntax.
+
 * Association matchers now test that the model being referred to (either
   implicitly or explicitly, using `:class_name`) actually exists.
 

--- a/lib/shoulda/matchers/active_record/have_db_index_matcher.rb
+++ b/lib/shoulda/matchers/active_record/have_db_index_matcher.rb
@@ -27,7 +27,7 @@ module Shoulda # :nodoc:
           @options = {}
         end
 
-        def unique(unique)
+        def unique(unique = true)
           @options[:unique] = unique
           self
         end

--- a/spec/shoulda/matchers/active_record/have_db_index_matcher_spec.rb
+++ b/spec/shoulda/matchers/active_record/have_db_index_matcher_spec.rb
@@ -52,6 +52,10 @@ describe Shoulda::Matchers::ActiveRecord::HaveDbIndexMatcher do
     expect(have_db_index(:user_id).unique(true).description).to match(/a unique index/)
   end
 
+  it 'describes a unique index as unique when no argument is given' do
+    expect(have_db_index(:user_id).unique.description).to match(/a unique index/)
+  end
+
   it 'describes a non-unique index as non-unique' do
     expect(have_db_index(:user_id).unique(false).description).to match(/a non-unique index/)
   end


### PR DESCRIPTION
I was caught out when I skipped the argument in `have_db_index(...).unique` because I thought the method declaration may have been similar to `validates_uniqueness_of(...).case_insensitive` (although `case_insensitive` defaults to _true_ always.) – so I've made this change.

There are some other places where similar changes could be made, which would further improve consistency, but I'll hold off making further changes until I get your thoughts.
