### PR TITLE
Update docs for validate_numericality_of matcher

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_numericality_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_numericality_of_matcher.rb
@@ -17,7 +17,7 @@ module Shoulda # :nodoc:
       #   it { should validate_numericality_of(:age).only_integer }
       #   it { should validate_numericality_of(:frequency).odd }
       #   it { should validate_numericality_of(:frequency).even }
-      #   it { should validate_numericality_of(:rank).less_than_or_equal_to(10).allow_nil }
+      #   it { should validate_numericality_of(:rank).is_less_than_or_equal_to(10).allow_nil }
       #
       def validate_numericality_of(attr)
         ValidateNumericalityOfMatcher.new(attr)


### PR DESCRIPTION
Typo in the `is_less_than_or_equal_to` method
