### PR TITLE
Remove warning under Minitest 5

### DIFF
--- a/lib/shoulda/matchers.rb
+++ b/lib/shoulda/matchers.rb
@@ -4,6 +4,20 @@ require 'shoulda/matchers/rails_shim'
 require 'shoulda/matchers/warn'
 require 'shoulda/matchers/version'
 
+require 'shoulda/matchers/independent'
+
+if defined?(ActiveModel)
+  require 'shoulda/matchers/active_model'
+end
+
+if defined?(ActiveRecord)
+  require 'shoulda/matchers/active_record'
+end
+
+if defined?(ActionController)
+  require 'shoulda/matchers/action_controller'
+end
+
 if defined?(RSpec)
   require 'shoulda/matchers/integrations/rspec'
 end

--- a/lib/shoulda/matchers/integrations/nunit_test_case_detection.rb
+++ b/lib/shoulda/matchers/integrations/nunit_test_case_detection.rb
@@ -1,0 +1,36 @@
+module Shoulda
+  module Matchers
+    module Integrations
+      module NUnitTestCaseDetection
+        def self.possible_test_case_constants
+          [
+            -> { ActiveSupport::TestCase },
+            -> { Minitest::Test },
+            -> { MiniTest::Unit::TestCase },
+            -> { Test::Unit::TestCase }
+          ]
+        end
+
+        def self.resolve_constant(future_constant)
+          future_constant.call
+        rescue NameError
+          nil
+        end
+
+        def self.detected_test_case_constants
+          possible_test_case_constants.
+            map { |future_constant| resolve_constant(future_constant) }.
+            compact
+        end
+
+        def self.test_case_constants
+          @_test_case_constants ||= detected_test_case_constants
+        end
+      end
+    end
+
+    def self.nunit_test_case_constants
+      Integrations::NUnitTestCaseDetection.test_case_constants
+    end
+  end
+end

--- a/lib/shoulda/matchers/integrations/rspec.rb
+++ b/lib/shoulda/matchers/integrations/rspec.rb
@@ -1,23 +1,19 @@
 # :enddoc:
-require 'rspec/core'
 
-RSpec.configure do |config|
-  require 'shoulda/matchers/independent'
-  config.include Shoulda::Matchers::Independent
+if RSpec.respond_to?(:configure)
+  RSpec.configure do |config|
+    config.include Shoulda::Matchers::Independent
 
-  if defined?(::ActiveRecord)
-    require 'shoulda/matchers/active_record'
-    require 'shoulda/matchers/active_model'
-    config.include Shoulda::Matchers::ActiveRecord
-    config.include Shoulda::Matchers::ActiveModel
+    if defined?(ActiveRecord)
+      config.include Shoulda::Matchers::ActiveRecord
+    end
 
-  elsif defined?(::ActiveModel)
-    require 'shoulda/matchers/active_model'
-    config.include Shoulda::Matchers::ActiveModel
-  end
+    if defined?(ActiveModel)
+      config.include Shoulda::Matchers::ActiveModel
+    end
 
-  if defined?(::ActionController)
-    require 'shoulda/matchers/action_controller'
-    config.include Shoulda::Matchers::ActionController
+    if defined?(ActionController)
+      config.include Shoulda::Matchers::ActionController
+    end
   end
 end

--- a/lib/shoulda/matchers/integrations/test_unit.rb
+++ b/lib/shoulda/matchers/integrations/test_unit.rb
@@ -1,26 +1,14 @@
 # :enddoc:
-require 'test/unit/testcase'
-require 'shoulda/matchers/independent'
+require 'shoulda/matchers/integrations/nunit_test_case_detection'
 
-module Test
-  module Unit
-    class TestCase
-      include Shoulda::Matchers::Independent
-      extend Shoulda::Matchers::Independent
-    end
-  end
-end
-
-if defined?(ActiveSupport::TestCase)
-  ActiveSupport::TestCase.class_eval do
+Shoulda::Matchers.nunit_test_case_constants.each do |constant|
+  constant.class_eval do
     include Shoulda::Matchers::Independent
     extend Shoulda::Matchers::Independent
   end
 end
 
-if defined?(ActionController) && defined?(ActionController::TestCase)
-  require 'shoulda/matchers/action_controller'
-
+if defined?(ActionController::TestCase)
   ActionController::TestCase.class_eval do
     include Shoulda::Matchers::ActionController
     extend Shoulda::Matchers::ActionController
@@ -31,17 +19,11 @@ if defined?(ActionController) && defined?(ActionController::TestCase)
   end
 end
 
-if defined?(ActiveRecord) && defined?(ActiveSupport::TestCase)
-  require 'shoulda/matchers/active_record'
-
+if defined?(ActiveSupport::TestCase)
   ActiveSupport::TestCase.class_eval do
     include Shoulda::Matchers::ActiveRecord
     extend Shoulda::Matchers::ActiveRecord
   end
-end
-
-if defined?(ActiveModel) && defined?(ActiveSupport::TestCase)
-  require 'shoulda/matchers/active_model'
 
   ActiveSupport::TestCase.class_eval do
     include Shoulda::Matchers::ActiveModel


### PR DESCRIPTION
This PR addresses #460, and copies some work I did for shoulda-context:
- https://github.com/thoughtbot/shoulda-context/blob/master/lib/shoulda/context/test_framework_detection.rb
- https://github.com/thoughtbot/shoulda-context/blob/master/lib/shoulda/context.rb#L18

---

Under Minitest 5 (or a Rails 4.1 project), you will get a warning

```
MiniTest::Unit::TestCase is now Minitest::Test.
```

when you attempt to run tests. This is because shoulda-matchers requires
'test/unit/testcase', even if Test::Unit is not being used.

It is not a good idea for shoulda-matchers to require _anything_ that
the user may not be using, whether it's Test::Unit or RSpec. We should
assume that by the time shoulda-matchers is required, the user has
already required all of whatever test framework they are using, not none
or even some of that framework.
