### PR TITLE
Fix `belong_to` used with polymorphic association

### DIFF
--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -91,7 +91,7 @@ module Shoulda # :nodoc:
 
       class AssociationMatcher # :nodoc:
         delegate :reflection, :model_class, :associated_class, :through?,
-          :join_table, to: :reflector
+          :join_table, :polymorphic?, to: :reflector
 
         def initialize(macro, name)
           @macro = macro
@@ -188,7 +188,7 @@ module Shoulda # :nodoc:
           @subject = subject
           association_exists? &&
             macro_correct? &&
-            class_exists? &&
+            (polymorphic? || class_exists?) &&
             foreign_key_exists? &&
             class_name_correct? &&
             autosave_correct? &&

--- a/lib/shoulda/matchers/active_record/association_matchers/model_reflection.rb
+++ b/lib/shoulda/matchers/active_record/association_matchers/model_reflection.rb
@@ -15,6 +15,10 @@ module Shoulda
             reflection.klass
           end
 
+          def polymorphic?
+            reflection.options[:polymorphic]
+          end
+
           def through?
             reflection.options[:through]
           end

--- a/lib/shoulda/matchers/active_record/association_matchers/model_reflector.rb
+++ b/lib/shoulda/matchers/active_record/association_matchers/model_reflector.rb
@@ -4,7 +4,7 @@ module Shoulda # :nodoc:
       module AssociationMatchers
         class ModelReflector
           delegate :associated_class, :through?, :join_table,
-            :association_relation, to: :reflection
+            :association_relation, :polymorphic?, to: :reflection
 
           def initialize(subject, name)
             @subject = subject

--- a/spec/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -30,7 +30,6 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher do
     end
 
     it 'accepts a polymorphic association' do
-      define_model :parent
       define_model :child, parent_type: :string, parent_id: :integer do
         belongs_to :parent, polymorphic: true
       end


### PR DESCRIPTION
This fixes #473.

---

For a polymorphic belongs_to association, the association doesn't
actually point to a class, it points to a concept, so we can't check
that the model it points to exists.
