### PR TITLE
Fix validate_numericality_of test failure in 2.6.0 (#483)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# 2.6.1
+
+* Fix `ComparisonMatcher` so that `validate_numericality_of` comparison matchers
+  work with large numbers (#483).
+
 # 2.6.0
 
 * The boolean argument to `have_db_index`'s `unique` option is now optional, for

--- a/lib/shoulda/matchers/active_model/numericality_matchers/comparison_matcher.rb
+++ b/lib/shoulda/matchers/active_model/numericality_matchers/comparison_matcher.rb
@@ -7,6 +7,9 @@ module Shoulda # :nodoc:
         #                 is_greater_than(6).
         #                 less_than(20)...(and so on) }
         class ComparisonMatcher < ValidationMatcher
+          DIFF_TO_COMPARE_PRECISION_CHANGE_NUMBER = 2**34
+          attr_reader :diff_to_compare
+
           def initialize(numericality_matcher, value, operator)
             unless numericality_matcher.respond_to? :diff_to_compare
               raise ArgumentError, 'numericality_matcher is invalid'
@@ -15,6 +18,7 @@ module Shoulda # :nodoc:
             @value = value
             @operator = operator
             @message = nil
+            @diff_to_compare = value.abs < DIFF_TO_COMPARE_PRECISION_CHANGE_NUMBER ? 0.000_001 : 1
           end
 
           def for(attribute)

--- a/spec/shoulda/matchers/active_model/numericality_matchers/comparison_matcher_spec.rb
+++ b/spec/shoulda/matchers/active_model/numericality_matchers/comparison_matcher_spec.rb
@@ -5,6 +5,12 @@ describe Shoulda::Matchers::ActiveModel::NumericalityMatchers::ComparisonMatcher
 
   it_behaves_like 'a numerical submatcher'
 
+  describe '#diff_to_compare' do
+    it { expect(subject.diff_to_compare).to eq 0.000_001 }
+    it { expect(described_class.new(matcher, 2**34, :>).diff_to_compare).to eq 1 }
+    it { expect(described_class.new(matcher, -2**34, :>).diff_to_compare).to eq 1 }
+  end
+
   context 'when initialized without correct numerical matcher' do
     it 'raises an argument error' do
       fake_matcher = matcher

--- a/spec/shoulda/matchers/active_model/validate_numericality_of_matcher_spec.rb
+++ b/spec/shoulda/matchers/active_model/validate_numericality_of_matcher_spec.rb
@@ -236,6 +236,28 @@ describe Shoulda::Matchers::ActiveModel::ValidateNumericalityOfMatcher do
     end
   end
 
+  context 'with large numbers' do
+    it do
+      expect(validating_numericality(greater_than: 100_000))
+        .to matcher.is_greater_than(100_000)
+    end
+
+    it do
+      expect(validating_numericality(less_than: 100_000))
+        .to matcher.is_less_than(100_000)
+    end
+
+    it do
+      expect(validating_numericality(greater_than_or_equal_to: 100_000))
+        .to matcher.is_greater_than_or_equal_to(100_000)
+    end
+
+    it do
+      expect(validating_numericality(less_than_or_equal_to: 100_000))
+        .to matcher.is_less_than_or_equal_to(100_000)
+    end
+  end
+
   context 'with a custom validation message' do
     it 'accepts when the messages match' do
       expect(validating_numericality(message: 'custom')).


### PR DESCRIPTION
Fixes #483 by using small percentages of the value to compare.
