### PR TITLE
Raise CouldNotSetPasswordError more safely

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,11 @@
 * Fix so that ActiveRecord matchers aren't included when ActiveRecord
   isn't defined (i.e. if you are using ActiveModel only).
 
+* Revert the behavior of `allow_value` changed in 2.6.0 (it will no longer raise
+  CouldNotClearAttribute). This was originally done as a part of a fix for
+  `validate_presence_of` when used in conjunction with `has_secure_password`.
+  That fix has been updated so that it does not affect `allow_value`.
+
 # 2.6.0
 
 * The boolean argument to `have_db_index`'s `unique` option is now optional, for

--- a/lib/shoulda/matchers/active_model/disallow_value_matcher.rb
+++ b/lib/shoulda/matchers/active_model/disallow_value_matcher.rb
@@ -1,7 +1,13 @@
+require 'forwardable'
+
 module Shoulda # :nodoc:
   module Matchers
     module ActiveModel # :nodoc:
       class DisallowValueMatcher # :nodoc:
+        extend Forwardable
+
+        def_delegators :allow_matcher, :_after_setting_value
+
         def initialize(value)
           @allow_matcher = AllowValueMatcher.new(value)
         end
@@ -39,6 +45,10 @@ module Shoulda # :nodoc:
           @allow_matcher.strict
           self
         end
+
+        private
+
+        attr_reader :allow_matcher
       end
     end
   end

--- a/lib/shoulda/matchers/active_model/errors.rb
+++ b/lib/shoulda/matchers/active_model/errors.rb
@@ -5,18 +5,6 @@ module Shoulda # :nodoc:
 
       class NonNullableBooleanError < Shoulda::Matchers::Error; end
 
-      class CouldNotClearAttribute < Shoulda::Matchers::Error
-        def self.create(actual_value)
-          super(actual_value: actual_value)
-        end
-
-        attr_accessor :actual_value
-
-        def message
-          "Expected value to be nil, but was #{actual_value.inspect}."
-        end
-      end
-
       class CouldNotSetPasswordError < Shoulda::Matchers::Error
         def self.create(model)
           super(model: model)

--- a/spec/shoulda/matchers/active_model/allow_value_matcher_spec.rb
+++ b/spec/shoulda/matchers/active_model/allow_value_matcher_spec.rb
@@ -24,6 +24,20 @@ describe Shoulda::Matchers::ActiveModel::AllowValueMatcher do
     end
   end
 
+  describe '#_after_setting_value' do
+    it 'sets a block which is yielded after each value is set on the attribute' do
+      attribute = :attr
+      record = define_model(:example, attribute => :string).new
+      matcher = described_class.new('a', 'b', 'c').for(attribute)
+      call_count = 0
+
+      matcher._after_setting_value { call_count += 1 }
+      matcher.matches?(record)
+
+      expect(call_count).to eq 3
+    end
+  end
+
   context 'an attribute with a validation' do
     it 'allows a good value' do
       expect(validating_format(with: /abc/)).to allow_value('abcde').for(:attr)


### PR DESCRIPTION
This is a fix for #479.

---

It seems that adding a restriction to allow_value to raise
CouldNotClearAttribute if nil cannot be set on the attribute in question
broke a lot of people's tests. Really the only reason we added this was
for validate_presence_of -- it rescued CouldNotClearAttribute and
re-raised it as CouldNotSetPasswordError, but only for passwords and
only if has_secure_password was being used. So, I've figured out another
way of performing this check inside of validate_presence_of only to
prevent tests that have nothing to do with from breaking unnecessarily.
