### PR TITLE
Fix the `permit` matcher to be less intrusive

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # 2.6.1
 
 * Fix `ComparisonMatcher` so that `validate_numericality_of` comparison matchers
-  work with large numbers (#483).
+  work with large numbers.
 
 * Fix so that ActiveRecord matchers aren't included when ActiveRecord
   isn't defined (i.e. if you are using ActiveModel only).
@@ -10,6 +10,9 @@
   CouldNotClearAttribute). This was originally done as a part of a fix for
   `validate_presence_of` when used in conjunction with `has_secure_password`.
   That fix has been updated so that it does not affect `allow_value`.
+
+* Fix `permit` so that it does not interfere with the existing `params` hash of
+  the controller you're testing.
 
 # 2.6.0
 

--- a/spec/support/controller_builder.rb
+++ b/spec/support/controller_builder.rb
@@ -59,9 +59,12 @@ module ControllerBuilder
   end
 
   def controller_for_resource_with_strong_parameters(options = {}, &block)
+    controller_name = 'Users'
+    block ||= -> { {} }
+
     define_model "User"
-    controller_class = define_controller "Users" do
-      define_method options.fetch(:action) do
+    controller_class = define_controller controller_name do
+      define_method options.fetch(:action, 'some_action') do
         @user = User.create(user_params)
         render nothing: true
       end
@@ -72,7 +75,10 @@ module ControllerBuilder
 
     setup_rails_controller_test(controller_class)
 
-    define_routes { resources :users }
+    collection_name = controller_name.
+      to_s.sub(/Controller$/, '').underscore.
+      to_sym
+    define_routes { resources(collection_name) }
 
     controller_class
   end


### PR DESCRIPTION
This is a fix for #482.

---

Within the `permit` matcher, we need to keep track of when #permit was
called and which arguments it was called with. Previously we did this by
overriding ActionController::Parameters#[] to return an instance of
StubbedParameters (which, when #permit was called on it, would then
track the call).

This has three problems:
- We're overriding something in a global class. We can simply override
  something on the controller that's being tested instead.
- Overriding #[] is kind of magical. How does this even end up doing
  what we want? Really we should just replace the entire params hash.
- Controller tests involve hitting actions on real controllers. Those
  actions may need to access the params hash. Completely changing how
  the params hash works prevents them from being able to do that.

To solve this, we override the params hash on the controller under test
with an instance of StubbedParameters, which decorates the original
params hash. We then override #permit to track the call, but then we let
it do its thing.
