### PR TITLE
Rewrite tests for ensure_inclusion_of

### DIFF
--- a/spec/shoulda/matchers/active_model/ensure_inclusion_of_matcher_spec.rb
+++ b/spec/shoulda/matchers/active_model/ensure_inclusion_of_matcher_spec.rb
@@ -515,15 +515,16 @@ describe Shoulda::Matchers::ActiveModel::EnsureInclusionOfMatcher do
         options: options.fetch(:column_options, {})
       }
       validation_options = options[:validation_options]
+      custom_validation = options[:custom_validation]
 
       model = define_model :example, attribute_name => column_options do
         if validation_options
           validates_inclusion_of attribute_name, validation_options
         end
 
-        if block
+        if custom_validation
           define_method :custom_validation do
-            instance_exec(attribute_name, &block)
+            instance_exec(attribute_name, &custom_validation)
           end
 
           validate :custom_validation
@@ -588,7 +589,7 @@ describe Shoulda::Matchers::ActiveModel::EnsureInclusionOfMatcher do
     low_message = 'too low'
     high_message = 'too high'
 
-    builder = build_object do |attribute|
+    builder = build_object custom_validation: ->(attribute) {
       value = __send__(attribute)
 
       if value < low_value
@@ -596,7 +597,7 @@ describe Shoulda::Matchers::ActiveModel::EnsureInclusionOfMatcher do
       elsif value > high_value
         errors.add(attribute, high_message)
       end
-    end
+    }
 
     expect_to_match(builder) do |matcher|
       matcher.


### PR DESCRIPTION
ensure_inclusion_of is pretty complex. Not only does it support two ways
of specifying valid values (in_array, in_range), but it also supports
multiple column types (string, integer, float, decimal, boolean).

When it comes to handling numbers and strings, ensure_inclusion_of has
very similar logic, and we can test these cases similarly.

We also do not have tests for handling regular Ruby attributes as
opposed to database columns (validates_inclusion_of works with both).
Those tests will be added in a future commit (related to #492), this commit
lays the groundwork for that.

---

NOTE: I realize there are many shared example groups here and that makes things pretty gnarly. I generally shy away from shared example groups unless I really need them, however it seemed like it was the simplest way to go about DRYing the code without writing a bunch of custom matchers or whatever. I am open to suggestions though.
