### PR TITLE
Fix several issues with strong parameters matcher

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# 2.6.1
+# HEAD
 
 * Fix `ComparisonMatcher` so that `validate_numericality_of` comparison matchers
   work with large numbers.
@@ -13,8 +13,21 @@
 
 * Fix callback matchers and correct test coverage.
 
-* Fix `permit` so that it does not interfere with the existing `params` hash of
-  the controller you're testing.
+* Fix `permit` so that it does not interfere with different usages of `params`
+  in your controller action. Specifically, this will not raise an error:
+  `params.fetch(:foo, {}).permit(:bar, :baz)` (the `permit` will have no
+  problems recognizing that :bar and :baz are permitted params).
+
+* Fix `permit` on Rails 4.1 to use PATCH by default for #update instead of PUT.
+  Previously you had to specify this manually.
+
+* Fix `permit` so that it track multiple calls to #permit in your controller
+  action. Previously only the last usage of #permit would be considered in
+  determining whether the matcher matched.
+
+* Fix `permit` so that if the route for your action requires params (such as id)
+  then you can now specify those params:
+  `permit(:first_name, :last_name).for(:update, params: { id: 42 })`.
 
 # 2.6.0
 

--- a/lib/shoulda/matchers/action_controller/strong_parameters_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/strong_parameters_matcher.rb
@@ -10,22 +10,25 @@ require 'active_support/hash_with_indifferent_access'
 module Shoulda
   module Matchers
     module ActionController
-      def permit(*attributes)
-        StrongParametersMatcher.new(self, attributes)
+      def permit(*params)
+        StrongParametersMatcher.new(params).in_context(self)
       end
 
       class StrongParametersMatcher
         attr_writer :stubbed_params
 
-        def initialize(context = nil, attributes)
-          @attributes = attributes
-          @context = context
-          @stubbed_params = NullStubbedParameters.new
+        def initialize(expected_permitted_params)
+          @action = nil
+          @verb = nil
+          @request_params = {}
+          @expected_permitted_params = expected_permitted_params
+          set_double_collection
         end
 
         def for(action, options = {})
           @action = action
-          @verb = options[:verb] || verb_for_action
+          @verb = options.fetch(:verb, default_verb)
+          @request_params = options.fetch(:params, {})
           self
         end
 
@@ -35,118 +38,80 @@ module Shoulda
         end
 
         def description
-          "permit #{verb.upcase} ##{action} to receive parameters #{attributes_as_sentence}"
+          "permit #{verb.upcase} ##{action} to receive parameters #{param_names_as_sentence}"
         end
 
         def matches?(controller)
           @controller = controller
-          simulate_controller_action && parameters_difference.empty?
-        end
+          ensure_action_and_verb_present!
 
-        def does_not_match?(controller)
-          @controller = controller
-          simulate_controller_action && parameters_intersection.empty?
+          double_collection.installing_all do
+            context.__send__(verb, action, request_params)
+          end
+
+          unpermitted_params.empty?
         end
 
         def failure_message
-          "Expected controller to permit #{parameters_difference.to_sentence}, but it did not."
+          "Expected controller to permit #{unpermitted_params.to_sentence}, but it did not."
         end
         alias failure_message_for_should failure_message
 
         def failure_message_when_negated
-          "Expected controller not to permit #{parameters_intersection.to_sentence}, but it did."
+          "Expected controller not to permit #{verified_permitted_params.to_sentence}, but it did."
         end
         alias failure_message_for_should_not failure_message_when_negated
 
         private
 
-        attr_reader :controller, :verb, :action, :attributes, :context
+        attr_reader :controller, :double_collection, :action, :verb,
+          :request_params, :expected_permitted_params, :context
 
-        def simulate_controller_action
-          ensure_action_and_verb_present!
-          stub_params
+        def set_double_collection
+          @double_collection =
+            Doublespeak::DoubleCollection.new(::ActionController::Parameters)
 
-          begin
-            context.send(verb, action)
-          ensure
-            unstub_params
-          end
-
-          verify_permit_call
+          @double_collection.stub(:require).to_return { |params| params }
+          @double_collection.proxy(:permit)
         end
 
-        def verify_permit_call
-          @stubbed_params.permit_was_called
+        def actual_permitted_params
+          double_collection.calls_on(:permit).inject([]) do |all_param_names, call|
+            all_param_names + call.args
+          end.flatten
         end
 
-        def parameters_difference
-          attributes - @stubbed_params.shoulda_permitted_params
+        def permit_called?
+          actual_permitted_params.any?
         end
 
-        def parameters_intersection
-          attributes & @stubbed_params.shoulda_permitted_params
+        def unpermitted_params
+          expected_permitted_params - actual_permitted_params
         end
 
-        def stub_params
-          matcher = self
-
-          controller.singleton_class.class_eval do
-            alias_method :__shoulda_original_params__, :params
-
-            define_method :params do
-              matcher.stubbed_params = StubbedParameters.new(__shoulda_original_params__)
-            end
-          end
-        end
-
-        def unstub_params
-          controller.singleton_class.class_eval do
-            alias_method :params, :__shoulda_original_params__
-          end
+        def verified_permitted_params
+          expected_permitted_params & actual_permitted_params
         end
 
         def ensure_action_and_verb_present!
           if action.blank?
             raise ActionNotDefinedError
           end
+
           if verb.blank?
             raise VerbNotDefinedError
           end
         end
 
-        def verb_for_action
-          verb_lookup = { create: :post, update: :put }
-          verb_lookup[action]
-        end
-
-        def attributes_as_sentence
-          attributes.map(&:inspect).to_sentence
-        end
-
-        class StubbedParameters < SimpleDelegator
-          attr_reader :permit_was_called, :shoulda_permitted_params
-
-          def initialize(original_params)
-            super(original_params)
-            @permit_was_called = false
-          end
-
-          def require(*args)
-            self
-          end
-
-          def permit(*args)
-            @shoulda_permitted_params = args
-            @permit_was_called = true
-            super(*args)
+        def default_verb
+          case action
+            when :create then :post
+            when :update then RailsShim.verb_for_update
           end
         end
 
-        class NullStubbedParameters < ActiveSupport::HashWithIndifferentAccess
-          def permit_was_called; false; end
-          def shoulda_permitted_params; self; end
-          def require(*); self; end
-          def permit(*); self; end
+        def param_names_as_sentence
+          expected_permitted_params.map(&:inspect).to_sentence
         end
 
         class ActionNotDefinedError < StandardError
@@ -157,8 +122,7 @@ module Shoulda
 
         class VerbNotDefinedError < StandardError
           def message
-            'You must specify an HTTP verb when using a non-RESTful action.' +
-            ' e.g. for(:authorize, verb: :post)'
+            'You must specify an HTTP verb when using a non-RESTful action. For example: for(:authorize, verb: :post)'
           end
         end
       end

--- a/lib/shoulda/matchers/rails_shim.rb
+++ b/lib/shoulda/matchers/rails_shim.rb
@@ -33,6 +33,14 @@ module Shoulda # :nodoc:
         end
       end
 
+      def self.verb_for_update
+        if action_pack_gte_4_1?
+          :patch
+        else
+          :put
+        end
+      end
+
       def self.active_record_major_version
         ::ActiveRecord::VERSION::MAJOR
       end
@@ -43,6 +51,14 @@ module Shoulda # :nodoc:
 
       def self.action_pack_major_version
         ::ActionPack::VERSION::MAJOR
+      end
+
+      def self.action_pack_gte_4_1?
+        Gem::Requirement.new('>= 4.1').satisfied_by?(action_pack_version)
+      end
+
+      def self.action_pack_version
+        Gem::Version.new(::ActionPack::VERSION::STRING)
       end
     end
   end

--- a/spec/support/rails_versions.rb
+++ b/spec/support/rails_versions.rb
@@ -10,6 +10,10 @@ module RailsVersions
   def rails_4_x?
     Gem::Requirement.new('~> 4.0').satisfied_by?(rails_version)
   end
+
+  def rails_gte_41?
+    Gem::Requirement.new('>= 4.1').satisfied_by?(rails_version)
+  end
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
This fixes #482 and #495.
- Instead of decorating controller params, use our "Doublespeak"
  mini-library to stub ActionController::Parameters. This prevents from
  interfering with the params object if it is used in various ways, i.e.
  if `params.fetch(...).permit(...)` is used instead of
  `params.require(...).permit(...)`.
- Fix compat with Rails 4.1, where the verb for #update is PATCH not
  PUT
- Track multiple calls to #permit within a given controller action
- Fix so that if the route for your action requires params (such as
  :id) then you can specify those params
