### PR TITLE
Within ValidateAbsenceOfMatcher, cast @attribute to String.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # HEAD
 
+* Typecast absence_of matcher's `@attribute` to String because
+  `ActiveRecord.columns_hash` returns Hash with String keys.
+
 * Fix `ComparisonMatcher` so that `validate_numericality_of` comparison matchers
   work with large numbers.
 
@@ -64,7 +67,7 @@
 * Change `validate_uniqueness_of(...)` so that it provides default values for
   non-nullable attributes.
 
-* Running `rake` now installs Appraisals before running the test suite. 
+* Running `rake` now installs Appraisals before running the test suite.
   (Additionally, we now manage Appraisals using the `appraisal` executable in
   Appraisal 1.0.0.)
 

--- a/lib/shoulda/matchers/active_model/validate_absence_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_absence_of_matcher.rb
@@ -44,8 +44,10 @@ module Shoulda # :nodoc:
             else
               obj
             end
-          elsif attribute_class == Fixnum
+          elsif [Fixnum, Float].include?(attribute_class)
             1
+          elsif attribute_class == BigDecimal
+            BigDecimal.new(1, 0)
           elsif !attribute_class || attribute_class == String
             'an arbitrary value'
           else
@@ -55,8 +57,8 @@ module Shoulda # :nodoc:
 
         def attribute_class
           @subject.class.respond_to?(:columns_hash) &&
-            @subject.class.columns_hash[@attribute].respond_to?(:klass) &&
-            @subject.class.columns_hash[@attribute].klass
+            @subject.class.columns_hash[@attribute.to_s].respond_to?(:klass) &&
+            @subject.class.columns_hash[@attribute.to_s].klass
         end
 
         def collection?

--- a/spec/shoulda/matchers/active_model/validate_absence_of_matcher_spec.rb
+++ b/spec/shoulda/matchers/active_model/validate_absence_of_matcher_spec.rb
@@ -10,6 +10,26 @@ describe Shoulda::Matchers::ActiveModel::ValidateAbsenceOfMatcher do
       it 'does not override the default message with a present' do
         expect(validating_absence_of(:attr)).to validate_absence_of(:attr).with_message(nil)
       end
+
+      context 'with different type of attribute' do
+        [:string,
+         :text,
+         :integer,
+         :float,
+         :decimal,
+         :datetime,
+         :timestamp,
+         :time,
+         :date,
+         :binary].each do |type|
+          context "with #{type} column" do
+            it 'accepts' do
+              expect(validating_absence_of(:attr, type: type)).
+                to validate_absence_of(:attr)
+            end
+          end
+        end
+      end
     end
 
     context 'a model without an absence validation' do
@@ -96,7 +116,9 @@ describe Shoulda::Matchers::ActiveModel::ValidateAbsenceOfMatcher do
     end
 
     def validating_absence_of(attr, options = {})
-      define_model :example, attr => :string do
+      attr_type = options.delete(:type) || :string
+
+      define_model :example, attr => attr_type do
         validates_absence_of attr, options
       end.new
     end


### PR DESCRIPTION
ActiveRecord.columns_hash returns Hash with String keys.
This is why `it { expect(offer).to validate_absence_of(:expired_at) }` is not working - setting 'an arbitrary value' to a time field is not working.

```
[1] pry(main)> rec = Model.new
=> #<Model id: nil, expired_at: nil>
[2] pry(main)> rec.expired_at
=> nil
[3] pry(main)> rec.expired_at = 'hi! this is me'
=> "hi! this is me"
[4] pry(main)> rec.expired_at
=> nil
```

this is why `validate_absence_of` can not find error...
