### PR TITLE
Speed up repeated execution of unit tests

### DIFF
--- a/spec/support/test_application.rb
+++ b/spec/support/test_application.rb
@@ -92,7 +92,7 @@ EOT
   end
 
   def install_gems
-    retrying('bundle install') do |command|
+    retrying('bundle install --local') do |command|
       Bundler.with_clean_env { `#{command}` }
     end
   end


### PR DESCRIPTION
In the Cucumber tests, we do not access the Internet to install test
dependencies -- we assume that you've already run `bundle install` or
`appraisal install` to install those dependencies. Change the RSpec
tests so that the same thing happens.
