### PR TITLE
Fix document about delegate_method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1385,14 +1385,14 @@ end
 describe Human do
   it { should delegate_method(:work).to(:robot) }
   it { should delegate_method(:protect).to(:robot).with_arguments('Sarah Connor') }
-  it { should delegate_method(:beep_boop).to(:robot).as(:speak) }
+  it { should delegate_method(:speak).to(:robot).as(:beep_boop) }
 end
 
 # Test::Unit
 class HumanTest < ActiveSupport::TestCase
   should delegate_method(:work).to(:robot)
   should delegate_method(:protect).to(:robot).with_arguments('Sarah Connor')
-  should delegate_method(:beep_boop).to(:robot).as(:speak)
+  should delegate_method(:speak).to(:robot).as(:beep_boop)
 end
 ```
 


### PR DESCRIPTION
Old spec fails with:

```
 Failure/Error: it { should delegate_method(:beep_boop).to(:robot).as(:speak) }
   Expected Human#beep_boop to delegate to Human#robot as #speak
   Calls on Human#robot: (none)
```
