### PR TITLE
Adding #supports_block_expectations? to matchers that accept blocks.

### DIFF
--- a/spec/support/fail_with_message_including_matcher.rb
+++ b/spec/support/fail_with_message_including_matcher.rb
@@ -1,4 +1,8 @@
 RSpec::Matchers.define :fail_with_message_including do |expected|
+  def supports_block_expectations?
+    true
+  end
+
   match do |block|
     @actual = nil
 

--- a/spec/support/fail_with_message_matcher.rb
+++ b/spec/support/fail_with_message_matcher.rb
@@ -1,4 +1,8 @@
 RSpec::Matchers.define :fail_with_message do |expected|
+  def supports_block_expectations?
+    true
+  end
+
   match do |block|
     @actual = nil
 


### PR DESCRIPTION
This is required for these matchers we use on RSpec 3.
