### PR TITLE
Remove redundant key value from `create_table`

### DIFF
--- a/spec/support/model_builder.rb
+++ b/spec/support/model_builder.rb
@@ -59,7 +59,7 @@ module ModelBuilder
 
     if columns.key?(:id) && columns[:id] == false
       columns.delete(:id)
-      create_table(table_name, id: false, &table_block)
+      create_table(table_name, &table_block)
     else
       create_table(table_name, &table_block)
     end


### PR DESCRIPTION
Before when we called `create_table` within `define_model` we would
delete a key value pair from the `columns` hash. Then we would supply
the same key value pair we deleted to `create_table`. This commit
removes that and makes sure that the deleted key value pair are not
supplied as `options` to `create_table`.
