### PR TITLE
Tweak failure message for allow_value

### DIFF
--- a/lib/shoulda/matchers/active_model/helpers.rb
+++ b/lib/shoulda/matchers/active_model/helpers.rb
@@ -4,12 +4,23 @@ module Shoulda
       # @private
       module Helpers
         def pretty_error_messages(obj)
-          obj.errors.map do |attribute, model|
-            msg = "#{attribute} #{model}"
-            if attribute.to_sym != :base && obj.respond_to?(attribute)
-              msg << " (#{obj.__send__(attribute).inspect})"
+          obj.errors.map do |attribute, message|
+            full_message = message.dup
+            parenthetical_parts = []
+
+            unless attribute.to_sym == :base
+              parenthetical_parts << "attribute: #{attribute.to_s.inspect}"
+
+              if obj.respond_to?(attribute)
+                parenthetical_parts << "value: #{obj.__send__(attribute).inspect}"
+              end
             end
-            msg
+
+            if parenthetical_parts.any?
+              full_message << " (#{parenthetical_parts.join(', ')})"
+            end
+
+            full_message
           end
         end
 

--- a/spec/shoulda/matchers/active_model/validation_message_finder_spec.rb
+++ b/spec/shoulda/matchers/active_model/validation_message_finder_spec.rb
@@ -67,7 +67,7 @@ describe Shoulda::Matchers::ActiveModel::ValidationMessageFinder do
 
       description = finder.messages_description
 
-      expected_messages = ['attr is invalid ("xyz")']
+      expected_messages = ['is invalid (attribute: "attr", value: "xyz")']
       expect(description).to eq "errors: #{expected_messages}"
     end
 
@@ -87,7 +87,7 @@ describe Shoulda::Matchers::ActiveModel::ValidationMessageFinder do
       end.new
       finder = Shoulda::Matchers::ActiveModel::ValidationMessageFinder.new(instance, :attribute)
 
-      expected_messages = ['association.association_attribute is invalid']
+      expected_messages = ['is invalid (attribute: "association.association_attribute")']
       expect(finder.messages_description).to eq "errors: #{expected_messages}"
     end
 


### PR DESCRIPTION
allow_value currently gives an error message that looks like this:

```
Expected errors to include "must be greater than 0" when amount is set to 0, got errors: ["amount must be greater than 0.0 (0)"]
```

This is confusing because the error message here is "must be greater than 0.0",
not "amount must be greater than 0.0".

With this commit the message changes to:

```
Expected errors to include "must be greater than 0" when amount is set to 0, got errors: ["must be greater than 0.0 (attribute: "amount", value: 0)"]
```
