### PR TITLE
Add support for HBTM `:join_table` option

### DIFF
--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -747,7 +747,7 @@ module Shoulda
       # @private
       class AssociationMatcher
         delegate :reflection, :model_class, :associated_class, :through?,
-          :join_table, :polymorphic?, to: :reflector
+          :join_table_name, :polymorphic?, to: :reflector
 
         def initialize(macro, name)
           @macro = macro

--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -747,7 +747,7 @@ module Shoulda
       # @private
       class AssociationMatcher
         delegate :reflection, :model_class, :associated_class, :through?,
-          :join_table_name, :polymorphic?, to: :reflector
+          :polymorphic?, to: :reflector
 
         def initialize(macro, name)
           @macro = macro
@@ -825,6 +825,7 @@ module Shoulda
         end
 
         def join_table(join_table_name)
+          @options[:join_table_name] = join_table_name
           self
         end
 
@@ -963,6 +964,10 @@ module Shoulda
         def join_table_matcher
           @join_table_matcher ||=
             AssociationMatchers::JoinTableMatcher.new(self, reflector)
+        end
+
+        def join_table_name
+          options[:join_table_name] || reflector.join_table_name
         end
 
         def class_exists?

--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -824,6 +824,10 @@ module Shoulda
           self
         end
 
+        def join_table(join_table_name)
+          self
+        end
+
         def description
           description = "#{macro_description} #{name}"
           description += " class_name => #{options[:class_name]}" if options.key?(:class_name)

--- a/lib/shoulda/matchers/active_record/association_matchers/join_table_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matchers/join_table_matcher.rb
@@ -8,8 +8,8 @@ module Shoulda
 
           alias :missing_option :failure_message
 
-          delegate :model_class, :join_table_name, :associated_class,
-            to: :association_matcher
+          delegate :model_class, :join_table_name, :associated_class, :options,
+            :name, :option_verifier, to: :association_matcher
 
           delegate :connection, to: :model_class
 
@@ -19,8 +19,22 @@ module Shoulda
           end
 
           def matches?(subject)
-            join_table_exists? &&
+            join_table_option_correct? &&
+              join_table_exists? &&
               join_table_has_correct_columns?
+          end
+
+          def join_table_option_correct?
+            if options.key?(:join_table_name)
+              if option_verifier.correct_for_string?(:join_table, options[:join_table_name])
+                true
+              else
+                @failure_message = "#{name} should use '#{options[:join_table_name]}' for :join_table option"
+                false
+              end
+            else
+              true
+            end
           end
 
           def join_table_exists?

--- a/lib/shoulda/matchers/active_record/association_matchers/join_table_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matchers/join_table_matcher.rb
@@ -8,7 +8,7 @@ module Shoulda
 
           alias :missing_option :failure_message
 
-          delegate :model_class, :join_table, :associated_class,
+          delegate :model_class, :join_table_name, :associated_class,
             to: :association_matcher
 
           delegate :connection, to: :model_class
@@ -24,7 +24,7 @@ module Shoulda
           end
 
           def join_table_exists?
-            if connection.tables.include?(join_table)
+            if connection.tables.include?(join_table_name)
               true
             else
               @failure_message = missing_table_message
@@ -60,16 +60,16 @@ module Shoulda
           end
 
           def actual_join_table_columns
-            connection.columns(join_table).map(&:name)
+            connection.columns(join_table_name).map(&:name)
           end
 
           def missing_table_message
-            "join table #{join_table} doesn't exist"
+            "join table #{join_table_name} doesn't exist"
           end
 
           def missing_columns_message
             missing = missing_columns.join(', ')
-            "join table #{join_table} missing #{column_label}: #{missing}"
+            "join table #{join_table_name} missing #{column_label}: #{missing}"
           end
 
           def column_label

--- a/lib/shoulda/matchers/active_record/association_matchers/model_reflection.rb
+++ b/lib/shoulda/matchers/active_record/association_matchers/model_reflection.rb
@@ -24,8 +24,8 @@ module Shoulda
             reflection.options[:through]
           end
 
-          def join_table
-            join_table =
+          def join_table_name
+            join_table_name =
               if has_and_belongs_to_many_name_table_name
                 has_and_belongs_to_many_name_table_name
               elsif reflection.respond_to?(:join_table)
@@ -34,7 +34,7 @@ module Shoulda
                 reflection.options[:join_table]
               end
 
-            join_table.to_s
+            join_table_name.to_s
           end
 
           def association_relation

--- a/lib/shoulda/matchers/active_record/association_matchers/model_reflector.rb
+++ b/lib/shoulda/matchers/active_record/association_matchers/model_reflector.rb
@@ -4,7 +4,7 @@ module Shoulda
       module AssociationMatchers
         # @private
         class ModelReflector
-          delegate :associated_class, :through?, :join_table,
+          delegate :associated_class, :through?, :join_table_name,
             :association_relation, :polymorphic?, :foreign_key,
             :association_foreign_key, to: :reflection
 

--- a/spec/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -732,46 +732,71 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher do
       end.to fail_with_message_including('missing columns: person_id, relative_id')
     end
 
-    it "rejects an association with a bad :join_table option" do
-      define_model :relative
-      join_table_name = 'people_and_their_families'
+    context "declaring the association with a :join_table option" do
 
-      define_model :person do
-        has_and_belongs_to_many(
-          :relatives, join_table: join_table_name
+      it "rejects an association with a bad :join_table option" do
+        define_model :relative
+
+        define_model :person do
+          has_and_belongs_to_many(
+            :relatives,
+            join_table: "people_and_their_families"
+          )
+        end
+
+        create_table("people_and_their_families", id: false) do |t|
+          t.references :person
+          t.references :relative
+        end
+
+        expect do
+          expect(Person.new).to(
+            have_and_belong_to_many(:relatives).join_table("family_tree")
+          )
+        end.to fail_with_message_including(
+         "relatives should use 'family_tree' for :join_table option"
         )
       end
 
-      create_table("people_relatives", id: false) do |t|
-        t.references :person
-        t.references :relative
+      it "rejects an association with a missing :join_table option" do
+        define_model :relative
+
+        define_model :person do
+          has_and_belongs_to_many(:relatives)
+        end
+
+        create_table("people_relatives", id: false) do |t|
+          t.references :person
+          t.references :relative
+        end
+
+        expect do
+          expect(Person.new).to(
+            have_and_belong_to_many(:relatives).join_table("family_tree")
+          )
+        end.to fail_with_message_including(
+         "relatives should use 'family_tree' for :join_table option"
+        )
       end
 
-      expect do
+
+      it "accepts an association with a valid :join_table option" do
+        define_model :relative
+        join_table_name = 'people_and_their_families'
+
+        define_model :person do
+          has_and_belongs_to_many(:relatives, join_table: join_table_name)
+        end
+
+        create_table(join_table_name, id: false) do |t|
+          t.references :person
+          t.references :relative
+        end
+
         expect(Person.new).to(
           have_and_belong_to_many(:relatives).join_table(join_table_name)
         )
-      end.to fail_with_message_including("#{join_table_name} doesn't exist")
-    end
-
-    it "accepts an association with a valid :join_table option" do
-      define_model :relative
-      join_table_name = 'people_and_their_families'
-
-      define_model :person do
-        has_and_belongs_to_many(
-          :relatives, join_table: join_table_name
-        )
       end
-
-      create_table(join_table_name, id: false) do |t|
-        t.references :person
-        t.references :relative
-      end
-
-      expect(Person.new).to(
-        have_and_belong_to_many(:relatives).join_table(join_table_name)
-      )
     end
 
     context 'using a custom foreign key' do

--- a/spec/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -732,6 +732,48 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher do
       end.to fail_with_message_including('missing columns: person_id, relative_id')
     end
 
+    it "rejects an association with a bad :join_table option" do
+      define_model :relative
+      join_table_name = 'people_and_their_families'
+
+      define_model :person do
+        has_and_belongs_to_many(
+          :relatives, join_table: join_table_name
+        )
+      end
+
+      create_table("people_relatives", id: false) do |t|
+        t.references :person
+        t.references :relative
+      end
+
+      expect do
+        expect(Person.new).to(
+          have_and_belong_to_many(:relatives).join_table(join_table_name)
+        )
+      end.to fail_with_message_including("#{join_table_name} doesn't exist")
+    end
+
+    it "accepts an association with a valid :join_table option" do
+      define_model :relative
+      join_table_name = 'people_and_their_families'
+
+      define_model :person do
+        has_and_belongs_to_many(
+          :relatives, join_table: join_table_name
+        )
+      end
+
+      create_table(join_table_name, id: false) do |t|
+        t.references :person
+        t.references :relative
+      end
+
+      expect(Person.new).to(
+        have_and_belong_to_many(:relatives).join_table(join_table_name)
+      )
+    end
+
     context 'using a custom foreign key' do
       it 'rejects an association with a join table with incorrect columns' do
         define_model :relative

--- a/spec/shoulda/matchers/active_record/association_matchers/model_reflection_spec.rb
+++ b/spec/shoulda/matchers/active_record/association_matchers/model_reflection_spec.rb
@@ -54,7 +54,7 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatchers::ModelReflection d
     end
   end
 
-  describe '#join_table' do
+  describe '#join_table_name' do
     context 'when the association was defined with a :join_table option' do
       it 'returns the value of the option' do
         create_table :foos, id: false do |t|
@@ -68,7 +68,7 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatchers::ModelReflection d
         delegate_reflection = country_model.reflect_on_association(:people)
         reflection = described_class.new(delegate_reflection)
 
-        expect(reflection.join_table).to eq 'foos'
+        expect(reflection.join_table_name).to eq 'foos'
       end
     end
 
@@ -81,7 +81,7 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatchers::ModelReflection d
         delegate_reflection = country_model.reflect_on_association(:people)
         reflection = described_class.new(delegate_reflection)
 
-        expect(reflection.join_table).to eq 'countries_people'
+        expect(reflection.join_table_name).to eq 'countries_people'
       end
     end
   end


### PR DESCRIPTION
In reference to Issue #547.

After renaming the method and adding tests for both the acceptance and rejection cases, I realized that the `AssocationMatcher` was already aware of any custom `:join_table` option that might have been passed to the association declaration.

So all I've done is add this method to `AssociationMatcher`:
``` ruby
def join_table(join_table_name)
  self
end
```

This was enough to make the tests pass, although it kinda feels like lying to the user. I see a few options:

1. Don't bother with adding and explicit `join_table` method to `AssociationMatcher` since it could potentially mislead users and the join table's existence will always be tested correctly.
2. Keep the `join_table` method since it adds parity with ActiveRecord's API and gives a signal to users (and their coworkers) that a custom join table is being used for the association.
3. Go forward with more explicit support for the `:join_table` option, similar to what is already being done for the `:foreign_key` option.

What do you think?