### PR TITLE
Allow delegate_method to be required independently

### DIFF
--- a/lib/shoulda/matchers/independent/delegate_matcher.rb
+++ b/lib/shoulda/matchers/independent/delegate_matcher.rb
@@ -230,7 +230,7 @@ module Shoulda
         end
 
         def ensure_target_method_is_present!
-          if target_method.blank?
+          if target_method.to_s.empty?
             raise TargetNotDefinedError
           end
         end


### PR DESCRIPTION
This allows the use of the delegate matcher without active support,
fix for issue #561.
- Change `blank?` to `to_s.empty?`
