### PR TITLE
Tweak warning to be descriptive, not prescriptive

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
@@ -251,17 +251,15 @@ module Shoulda
         ARBITRARY_OUTSIDE_DECIMAL = BigDecimal.new('0.123456789')
         BOOLEAN_ALLOWS_BOOLEAN_MESSAGE = <<EOT
 You are using `validate_inclusion_of` to assert that a boolean column allows
-boolean values and disallows non-boolean ones. Assuming you are using
-`validates_format_of` in your model, be aware that it is not possible to fully
-test this, and in fact the validation is superfluous, as boolean columns will
-automatically convert non-boolean values to boolean ones. Hence, you should
-consider removing this test and the corresponding validation.
+boolean values and disallows non-boolean ones. Be aware that it is not possible
+to fully test this, as boolean columns will automatically convert non-boolean
+values to boolean ones. Hence, you should consider removing this test.
 EOT
         BOOLEAN_ALLOWS_NIL_MESSAGE = <<EOT
 You are using `validate_inclusion_of` to assert that a boolean column allows nil.
 Be aware that it is not possible to fully test this, as anything other than
 true, false or nil will be converted to false. Hence, you should consider
-removing this test and the corresponding validation.
+removing this test.
 EOT
 
         def initialize(attribute)


### PR DESCRIPTION
This is a fix for #569, and a response to #512.

---

While we do advise against using the validates_inclusion_of or
validates_format_of validations with boolean columns, we won't judge
if you would like to do so.
