### PR TITLE
Typo fix in ensure_length_of documentation

### DIFF
--- a/lib/shoulda/matchers/active_model/ensure_length_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/ensure_length_of_matcher.rb
@@ -57,7 +57,7 @@ module Shoulda
       #
       # ##### is_equal_to
       #
-      # Use `is_at_equal` to test usage of the `:is` option. This asserts that
+      # Use `is_equal_to` to test usage of the `:is` option. This asserts that
       # the attribute can take a string which is exactly equal to the given
       # length and cannot take a string which is shorter or longer.
       #


### PR DESCRIPTION
Fixing incorrect method name in documentation.
