### PR TITLE
Improve failure message when `has_many` is missing

### DIFF
--- a/lib/shoulda/matchers/active_record/association_matchers/option_verifier.rb
+++ b/lib/shoulda/matchers/active_record/association_matchers/option_verifier.rb
@@ -35,7 +35,7 @@ module Shoulda
               method_name = "actual_value_for_#{name}"
               if respond_to?(method_name, true)
                 __send__(method_name)
-              else
+              elsif reflection.present?
                 reflection.options[name]
               end
             end

--- a/spec/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -325,6 +325,18 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher do
       expect(matcher.failure_message).to match(/through relationships, but got it through conceptions/)
     end
 
+    it 'rejects an association that is chained by a missing :through option' do
+      define_model :child
+
+      define_model :parent
+
+      matcher = have_many(:children).through(:relationships).source(:child)
+      expect(matcher.matches?(Parent.new)).to eq false
+      expect(matcher.failure_message).to match(
+        /Expected Parent to have a has_many association called children/
+      )
+    end
+
     it 'accepts an association with a valid :dependent option' do
       expect(having_many_children(dependent: :destroy)).
         to have_many(:children).dependent(:destroy)


### PR DESCRIPTION
When test driving, writing an expectation such as

``` ruby
it { should have_many(:children).through(:relationships).source(:child) }
```

used to provide the not-so-helpful error message

```
Failure/Error: it { should have_many(:children).through(:relationships).source(:child) }

     NoMethodError:

       undefined method `options' for nil:NilClass
```

The improved error message is

```
Expected Parent to have a has_many association called children (no association
called children, children does not have any relationship to relationships,
children should have child as source option)
```
