### PR TITLE
Fix 'delegate_method_matcher.rb' link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ complex, and error-prone.
 
 ### Independent Matchers
 
-* **[delegate_method](lib/shoulda/matchers/independent/delegate_matcher.rb)**
+* **[delegate_method](lib/shoulda/matchers/independent/delegate_method_matcher.rb)**
   tests that an object forwards messages to other, internal objects by way of
   delegation.
 


### PR DESCRIPTION
This is in accordance to commit #b695c2f97854767
