### PR TITLE
Fix validate_inclusion_of + with_message

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,9 @@
   referenced is namespaced, the matcher will correctly resolve the class before
   checking it against the association's `class_name`. ([#537])
 
+* Fix `validate_inclusion_of` used with `with_message` so that it fails if given
+  a message that does not match the message on the validation. ([#598])
+
 ### Features
 
 * Add ability to test `:primary_key` option on associations. ([#597])
@@ -47,6 +50,7 @@
 [#593]: https://github.com/thoughtbot/shoulda-matchers/pull/593
 [#597]: https://github.com/thoughtbot/shoulda-matchers/pull/597
 [#537]: https://github.com/thoughtbot/shoulda-matchers/pull/537
+[#598]: https://github.com/thoughtbot/shoulda-matchers/pull/598
 
 # 2.7.0
 

--- a/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
@@ -409,7 +409,9 @@ EOT
             end
           end
 
-          !allows_value_of(*values_outside_of_array)
+          !values_outside_of_array.any? do |value|
+            allows_value_of(value, @low_message)
+          end
         end
 
         def values_outside_of_array

--- a/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb
@@ -188,8 +188,6 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher do
       end
 
       it 'does not match when validation uses the default message instead of given message' do
-        skip 'does not work'
-
         builder = build_object_allowing(valid_values)
 
         expect_not_to_match_on_values(builder, valid_values) do |matcher|
@@ -198,8 +196,6 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher do
       end
 
       it 'does not match when validation uses a message but it is not same as given' do
-        skip 'does not work'
-
         builder = build_object_allowing(valid_values, message: 'a different message')
 
         expect_not_to_match_on_values(builder, valid_values) do |matcher|
@@ -218,8 +214,6 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher do
       end
 
       it 'does not match when validation uses the default message instead of given message' do
-        skip 'does not work'
-
         builder = build_object_allowing(valid_values)
 
         expect_not_to_match_on_values(builder, valid_values) do |matcher|
@@ -228,8 +222,6 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher do
       end
 
       it 'does not match when validation uses a message but it does not match regex' do
-        skip 'does not work'
-
         builder = build_object_allowing(valid_values, message: 'a different message')
 
         expect_not_to_match_on_values(builder, valid_values) do |matcher|


### PR DESCRIPTION
This is a fix for #595.

---

It did not fail if the given message did not match the message on the
validation itself.
