### PR TITLE
Add syntactic sugar #with_prefix for delegate_method

### DIFF
--- a/lib/shoulda/matchers/independent/delegate_method_matcher.rb
+++ b/lib/shoulda/matchers/independent/delegate_method_matcher.rb
@@ -105,6 +105,35 @@ module Shoulda
       #         with_arguments(expedited: true)
       #     end
       #
+      # ##### with_prefix
+      # Use `with_prefix` to assert that the delegation is done via the
+      # different name as specified in the code.
+      #
+      #     class Page < ActiveRecord::Base
+      #       belongs_to :site
+      #       delegate :name, to: :site, prefix: true
+      #     end
+      #
+      #     class Site < ActiveRecord::Base
+      #       has_many :pages
+      #     end
+      #
+      #     # RSpec
+      #     describe Page do
+      #       it do
+      #         should delegate_method(:name).
+      #           to(:site).
+      #           with_prefix
+      #       end
+      #     end
+      #
+      #     # Test::Unit
+      #     class PageTest < Test::Unit::TestCase
+      #       should delegate_method(:name).
+      #         to(:site).
+      #         with_prefix
+      #     end
+      #
       # @return [DelegateMethodMatcher]
       #
       def delegate_method(delegating_method)
@@ -170,7 +199,7 @@ module Shoulda
           self
         end
 
-        def with_prefix(prefix_string=nil)
+        def with_prefix(prefix_string = nil)
           if prefix_string
             @delegating_method = :"#{ prefix_string }_#{ method_on_target }"
           else

--- a/spec/unit/shoulda/matchers/independent/delegate_method_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/independent/delegate_method_matcher_spec.rb
@@ -35,11 +35,11 @@ describe Shoulda::Matchers::Independent::DelegateMethodMatcher do
 
       context 'with #prefix option' do
         context 'when no prefix is provided' do
-          it 'should abc' do
+          it 'should delegate as (target_method)_(method_on_target)' do
             define_model(:country) do
               def hello; 'hello' end
             end
-            person_model = define_model(:person, country_id: :integer) do
+            define_model(:person, country_id: :integer) do
               belongs_to :country
               delegate :hello, to: :country, prefix: true
             end
@@ -48,11 +48,11 @@ describe Shoulda::Matchers::Independent::DelegateMethodMatcher do
           end
         end
         context 'when prefix is supplied' do
-          it 'should abc' do
+          it 'should delegate as (prefix_supplied)_(method_on_target)' do
             define_model(:country) do
               def hello; 'hello' end
             end
-            person_model = define_model(:person, country_id: :integer) do
+            define_model(:person, country_id: :integer) do
               belongs_to :country
               delegate :hello, to: :country, prefix: 'county'
             end


### PR DESCRIPTION
Provide the shoulda-matchers capability to use the matchers as provided in this [gist](https://gist.github.com/joeytheman/0fe021821e4c62f552ce).
