### PR TITLE
add true option for dependent matcher and test all options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ pkg
 tags
 test/*/log/*.log
 tmp
+.ruby-version

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ pkg
 tags
 test/*/log/*.log
 tmp
-.ruby-version

--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -162,6 +162,12 @@ module Shoulda
       #       should belong_to(:world).dependent(:destroy)
       #     end
       #
+      # To test that any :dependent option was specified, pass true.
+      #     # RSpec
+      #     describe Person do
+      #       it { should belong_to(:world).dependent(true) }
+      #     end
+      #
       # ##### counter_cache
       #
       # Use `counter_cache` to assert that the `:counter_cache` option was
@@ -993,7 +999,7 @@ module Shoulda
         end
 
         def macro_supports_primary_key?
-          macro == :belongs_to || 
+          macro == :belongs_to ||
             ([:has_many, :has_one].include?(macro) && !through?)
         end
 

--- a/lib/shoulda/matchers/active_record/association_matchers/dependent_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matchers/dependent_matcher.rb
@@ -34,14 +34,14 @@ module Shoulda
             @option_verifier ||= OptionVerifier.new(subject)
           end
 
-          def correct_for?(dependent=dependent)
+          def correct_for?(dependent)
             case dependent
             when true, false then option_verifier.correct_for_boolean?(:dependent, dependent)
             else option_verifier.correct_for_string?(:dependent, dependent)
             end
           end
 
-          def missing_option_for(name=name, dependent=dependent)
+          def missing_option_for(name, dependent)
             "#{name} should have #{dependent == true ? "a" : dependent} dependency"
           end
 

--- a/lib/shoulda/matchers/active_record/association_matchers/dependent_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matchers/dependent_matcher.rb
@@ -18,11 +18,10 @@ module Shoulda
 
           def matches?(subject)
             self.subject = ModelReflector.new(subject, name)
-
-            if option_verifier.correct_for_string?(:dependent, dependent)
+            if correct_for?(dependent)
               true
             else
-              self.missing_option = "#{name} should have #{dependent} dependency"
+              self.missing_option = missing_option_for(name, dependent)
               false
             end
           end
@@ -34,6 +33,18 @@ module Shoulda
           def option_verifier
             @option_verifier ||= OptionVerifier.new(subject)
           end
+
+          def correct_for?(dependent=dependent)
+            case dependent
+            when true, false then option_verifier.correct_for_boolean?(:dependent, dependent)
+            else option_verifier.correct_for_string?(:dependent, dependent)
+            end
+          end
+
+          def missing_option_for(name=name, dependent=dependent)
+            "#{name} should have #{dependent == true ? "a" : dependent} dependency"
+          end
+
         end
       end
     end

--- a/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -646,21 +646,21 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
     end
 
     it 'accepts an association with a valid :dependent option' do
-      dependent_options(Rails.version).each do |option|
+      dependent_options.each do |option|
         expect(having_one_detail(dependent: option)).
           to have_one(:detail).dependent(option)
       end
     end
 
     it 'accepts any dependent option if true' do
-      dependent_options(Rails.version).each do |option|
+      dependent_options.each do |option|
         expect(having_one_detail(dependent: option)).
           to have_one(:detail).dependent(true)
       end
     end
 
     it 'rejects any dependent options if false' do
-      dependent_options(Rails.version).each do |option|
+      dependent_options.each do |option|
         expect(having_one_detail(dependent: option)).
           to_not have_one(:detail).dependent(false)
       end
@@ -1138,8 +1138,8 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
     model.__send__(macro, name, *args)
   end
 
-  def dependent_options(rails_version)
-    case rails_version
+  def dependent_options
+    case Rails.version
     when /\A3/
       [:destroy, :delete, :nullify, :restrict]
     when /\A4/

--- a/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -1,16 +1,5 @@
 require 'unit_spec_helper'
 
-def each_dependent_option(rails_version)
-  case rails_version
-  when /\A3/
-    [:destroy, :delete, :nullify, :restrict]
-  when /\A4/
-    [:destroy, :delete, :nullify, :restrict_with_exception, :restrict_with_error]
-  end.each do |option|
-    yield option
-  end
-end
-
 describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
   context 'belong_to' do
     it 'accepts a good association with the default foreign key' do
@@ -656,22 +645,22 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
       expect(Person.new).not_to have_one(:detail)
     end
 
-    each_dependent_option(Rails.version) do |option|
-      it 'accepts an association with a valid :dependent option' do
+    it 'accepts an association with a valid :dependent option' do
+      dependent_options(Rails.version).each do |option|
         expect(having_one_detail(dependent: option)).
-        to have_one(:detail).dependent(option)
+          to have_one(:detail).dependent(option)
       end
     end
 
     it 'accepts any dependent option if true' do
-      each_dependent_option(Rails.version) do |option|
+      dependent_options(Rails.version).each do |option|
         expect(having_one_detail(dependent: option)).
           to have_one(:detail).dependent(true)
       end
     end
 
     it 'rejects any dependent options if false' do
-      each_dependent_option(Rails.version) do |option|
+      dependent_options(Rails.version).each do |option|
         expect(having_one_detail(dependent: option)).
           to_not have_one(:detail).dependent(false)
       end
@@ -1147,5 +1136,14 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
     end
     args << options
     model.__send__(macro, name, *args)
+  end
+
+  def dependent_options(rails_version)
+    case rails_version
+    when /\A3/
+      [:destroy, :delete, :nullify, :restrict]
+    when /\A4/
+      [:destroy, :delete, :nullify, :restrict_with_exception, :restrict_with_error]
+    end
   end
 end


### PR DESCRIPTION
Added test to ensure that all valid `:dependent` options are permitted to fix #393. Also added a `true` option that accepts any `:dependent` option. This is useful when you're testing that all `has_many` or `has_one` relationships have a `:dependent` option set.