### PR TITLE
Fix enum attribute name verification

### DIFF
--- a/lib/shoulda/matchers/active_record/define_enum_for_matcher.rb
+++ b/lib/shoulda/matchers/active_record/define_enum_for_matcher.rb
@@ -99,16 +99,12 @@ module Shoulda
           hashify(options[:expected_enum_values]).with_indifferent_access
         end
 
-        def enum_method
-          attribute_name.to_s.pluralize
-        end
-
         def actual_enum_values
-          model.class.send(enum_method)
+          model.class.send(attribute_name.to_s.pluralize)
         end
 
         def enum_defined?
-          model.class.respond_to?(enum_method)
+          model.defined_enums.keys.include?(attribute_name.to_s)
         end
 
         def enum_values_match?

--- a/spec/unit/shoulda/matchers/active_record/define_enum_for_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/define_enum_for_matcher_spec.rb
@@ -4,11 +4,11 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
   if active_record_supports_enum?
     it "rejects a record when checking for enum's plural attribute name" do
       message = "Expected #{record_with_array_values.class} to define :#{enum_attribute.to_s.pluralize} as an enum"
-      
+
       expect do
-        expect(record_with_array_values).to define_enum_for(enum_attribute.to_s.pluralize)  
+        expect(record_with_array_values).to define_enum_for(enum_attribute.to_s.pluralize)
       end.to fail_with_message(message)
-    end      
+    end
 
     describe "with only the attribute name specified" do
       it "accepts a record where the attribute is defined as an enum" do

--- a/spec/unit/shoulda/matchers/active_record/define_enum_for_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/define_enum_for_matcher_spec.rb
@@ -2,6 +2,14 @@ require "unit_spec_helper"
 
 describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
   if active_record_supports_enum?
+    it "rejects a record when checking for enum's plural attribute name" do
+      message = "Expected #{record_with_array_values.class} to define :#{enum_attribute.to_s.pluralize} as an enum"
+      
+      expect do
+        expect(record_with_array_values).to define_enum_for(enum_attribute.to_s.pluralize)  
+      end.to fail_with_message(message)
+    end      
+
     describe "with only the attribute name specified" do
       it "accepts a record where the attribute is defined as an enum" do
         expect(record_with_array_values).to define_enum_for(enum_attribute)


### PR DESCRIPTION
Hello guys !

I noticed today that we're making the enum definition verification based on the plural name of the attribute. The following test pass currently:

```ruby
# model
class Foo
  enum status: [:active, :inactive]
end

# spec
describe Foo do
  it { is_expected.to define_enum_for(:statuses) }
end
```

This is kind of awkward (the enum was defined for the status attribute not statuses), but still makes sense idiomatically speaking (we're indeed defining a set of statuses). This is happening because of the following verification of our matcher:

```ruby
# define_enum_for_matcher.rb
def enum_method
  attribute_name.to_s.pluralize
end

def enum_defined?
  model.class.respond_to?(enum_method)
end
```

The problem with this approach is that we're not verifying if the enum was actually defined. The `enum_defined?` method is only verifying if the class of the object under test responds to a method that has the plural name of the enum attribute present on the matcher. So, we could screw things up a little bit by doing the following (I tested it, and it passes !):

```ruby
# model
class Foo
  def self.statuses
  end
end

# Those specs passes even if no enum was defined !
describe Foo do
  it { is_expected.to define_enum_for(:status) }
  it { is_expected.to define_enum_for(:statuses) }
end
```

So, to sum up. I wrote a failing spec about the issue and fixed it, making the `enum_defined?` verification based on the actual enums defined for the object under test. I also deleted a method that is not needed anymore.

I hope it's all ok :)
