### PR TITLE
Remove small caps on section header

### DIFF
--- a/source/stylesheets/landing/_index.scss
+++ b/source/stylesheets/landing/_index.scss
@@ -290,7 +290,6 @@ nav {
   font-weight: 500;
   padding: em(35) 0;
   text-align: center;
-  font-variant: small-caps;
 }
 
 .tabs {


### PR DESCRIPTION
Unfortunately, Brandon Grotesque doesn't have proper small caps, so it makes the large caps look much heavier than the small caps. I personally think that it looks much better without them.

![](http://screenshots.philtr.net/6autHTAuEN.png)