### PR TITLE
Inclusion validation message with %{value}

### DIFF
--- a/spec/unit/shoulda/matchers/active_model/validate_exclusion_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_exclusion_of_matcher_spec.rb
@@ -52,6 +52,11 @@ describe Shoulda::Matchers::ActiveModel::ValidateExclusionOfMatcher, type: :mode
       expect(validating_exclusion(in: 2..4, message: 'not good')).
         to validate_exclusion_of(:attr).in_range(2..4).with_message(/not good/)
     end
+
+    it 'accepts ensuring the correct range with %{value}' do
+      expect(validating_exclusion(in: 2..4, message: '%{value} is not good')).
+        to validate_exclusion_of(:attr).in_range(2..4).with_message(/ is not good/)
+    end
   end
 
   context 'an attribute with custom range validations' do

--- a/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb
@@ -212,6 +212,14 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
         end
       end
 
+      it 'matches when validation uses given message with %{value}' do
+        builder = build_object_allowing(valid_values, message: '%{value} is not included')
+
+        expect_to_match_on_values(builder, valid_values) do |matcher|
+          matcher.with_message('%{value} is not included')
+        end
+      end
+
       it 'does not match when validation uses the default message instead of given message' do
         builder = build_object_allowing(valid_values)
 


### PR DESCRIPTION
After updating from `2.7.0` to `2.8.0` I started to have fails with the following spec:

``` ruby
class Image < ActiveRecord::Base
  validates :content_type, presence: true,
    inclusion: {
      in: %w(image/gif image/jpg image/jpeg image/pjpeg image/png image/svg+xml image/vnd.djvu),
      message: "%{value} is not a valid image mime type"
    }
end
```

``` ruby
it do
    is_expected.to validate_inclusion_of(:content_type).
      in_array(%w(image/gif image/jpg image/jpeg image/pjpeg image/png image/svg+xml image/vnd.djvu)).
      with_message('%{value} is not a valid image mime type')
end
```

``` sh
Failures:

  1) Image validations should ensure inclusion of content_type in ["image/gif", "image/jpg", "image/jpeg", "image/pjpeg", "image/png", "image/svg+xml", "image/vnd.djvu"]
     Failure/Error: is_expected.to validate_inclusion_of(:content_type).
       ["image/gif", "image/jpg", "image/jpeg", "image/pjpeg", "image/png", "image/svg+xml", "image/vnd.djvu"] doesn't match array in validation
     # ./spec/models/image_spec.rb:10:in `block (3 levels) in <top (required)>'
```

I added failing spec for `validate_inclusion_of` matcher to show the bug. I'd like to have some tips how to fix it and complete this pull request.
