### PR TITLE
Raise an error if no Appraisal is specified

### DIFF
--- a/spec/acceptance_spec_helper.rb
+++ b/spec/acceptance_spec_helper.rb
@@ -1,3 +1,9 @@
+require_relative 'support/tests/current_bundle'
+
+Tests::CurrentBundle.instance.assert_appraisal!
+
+#---
+
 require 'rspec/core'
 
 Dir[ File.join(File.expand_path('../support/acceptance/**/*.rb', __FILE__)) ].sort.each do |file|

--- a/spec/support/tests/current_bundle.rb
+++ b/spec/support/tests/current_bundle.rb
@@ -1,0 +1,47 @@
+require 'bundler'
+require 'appraisal'
+
+module Tests
+  class CurrentBundle
+    AppraisalNotSpecified = Class.new(ArgumentError)
+
+    include Singleton
+
+    def assert_appraisal!
+      unless appraisal?
+        message = <<EOT
+
+
+Please run tests starting with `appraisal <appraisal_name>`.
+Possible appraisals are: #{possible_appraisals}
+
+EOT
+        raise AppraisalNotSpecified, message
+      end
+    end
+
+    private
+
+    def possible_appraisals
+      appraisals = []
+
+      Appraisal::File.each do |appraisal|
+        appraisals << appraisal.name
+      end
+
+      appraisals
+    end
+
+    def path
+      Bundler.default_gemfile
+    end
+
+    def appraisal?
+      path.dirname == root.join('gemfiles')
+    end
+
+    def root
+      Pathname.new('../../../..').expand_path(__FILE__)
+    end
+  end
+end

--- a/spec/unit_spec_helper.rb
+++ b/spec/unit_spec_helper.rb
@@ -1,3 +1,9 @@
+require_relative 'support/tests/current_bundle'
+
+Tests::CurrentBundle.instance.assert_appraisal!
+
+#---
+
 require File.expand_path('../support/unit/rails_application', __FILE__)
 
 def monkey_patch_minitest_to_do_nothing


### PR DESCRIPTION
If you attempt to run tests without specifying an Appraisal, then you
will be going off of the main Gemfile. The Gemfile is not guaranteed to
contain all of the dependencies necessary to run tests, so it is very
likely that you'll get an obscure error somewhere. Instead of letting
this happen, raise a specific error.