### PR TITLE
Rewrite tests for validate_uniqueness_of

### DIFF
--- a/.hound_config/ruby.yml
+++ b/.hound_config/ruby.yml
@@ -3,3 +3,10 @@ StringLiterals:
 
 AlignParameters:
   EnforcedStyle: with_fixed_indentation
+
+CollectionMethods:
+  PreferredMethods:
+    find: detect
+    reduce: inject
+    collect: map
+    find_all: select

--- a/spec/support/unit/helpers/active_record_versions.rb
+++ b/spec/support/unit/helpers/active_record_versions.rb
@@ -12,5 +12,13 @@ module UnitTests
     def active_record_can_raise_range_error?
       active_record_version >= 4.2
     end
+
+    def active_record_supports_enum?
+      defined?(::ActiveRecord::Enum)
+    end
+
+    def active_record_supports_has_secure_password?
+      active_record_version >= 3.1
+    end
   end
 end

--- a/spec/support/unit/helpers/model_builder.rb
+++ b/spec/support/unit/helpers/model_builder.rb
@@ -68,7 +68,11 @@ module UnitTests
 
       define_model_class(class_name).tap do |model|
         if block
-          model.class_eval(&block)
+          if block.arity == 0
+            model.class_eval(&block)
+          else
+            block.call(model)
+          end
         end
 
         model.table_name = table_name

--- a/spec/support/unit/helpers/rails_versions.rb
+++ b/spec/support/unit/helpers/rails_versions.rb
@@ -20,9 +20,5 @@ module UnitTests
     def rails_gte_4_1?
       rails_version >= 4.1
     end
-
-    def active_record_supports_enum?
-      defined?(::ActiveRecord::Enum)
-    end
   end
 end


### PR DESCRIPTION
* The main problem I had with the old tests is that information that
  the reader didn't need to care about was not properly abstracted away.
  For instance, a helper method used by almost all tests will always
  create a model called Example, and will always use an attribute called
  "attr" (on which the validation is present). However, in some tests
  the class or attribute is referred to directly. The reader shouldn't
  have to care about either of these things, since they are constant --
  the tests should be readable enough so that this information is not
  necessary to understand the case being tested against.

* Speaking of this helper method, some of the tests used it and some
  didn't. Some defined their own helper methods to represent a
  particular case (`case_sensitive: true`, `allow_nil`, etc.). This is
  now fixed so that all but two tests use the same helper method to
  define a model. This model is completely customizable -- one can
  specify the type of the attribute being validated, the names and types
  of scoped attributes, etc.

* The tests around scoped attributes and different types are all
  basically the same, so they are now compressed into a shared context.

* Related to this, we no longer have to worry about setting a proper
  value for a scope attribute. One had to know which type that attribute
  had and come up with a reasonable default for that type. Now there is
  a helper method that worries about this automatically.

* Finally, we remove tests around case_insensitive against an integer
  attribute (these don't make any sense, and don't work).