### PR TITLE
Uniqueness: Support UUID columns that end in "f"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,16 @@
   * `set_session['key'].to(nil)` will no longer pass when the key in question
     has not been set yet.
 
+### Bug fixes
+
+* So far the tests for the gem have been running against only SQLite. Now they
+  run against PostgreSQL, too. As a result we were able to fix some
+  Postgres-related bugs:
+
+  * Fix `validate_uniqueness_of` + `scoped_to` so that when one of the scope
+    attributes is a UUID column that ends in an "f", the matcher is able to
+    generate a proper "next" value without erroring.
+
 # 2.8.0
 
 ### Deprecations

--- a/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
@@ -35,8 +35,8 @@ describe Shoulda::Matchers::ActiveRecord::ValidateUniquenessOfMatcher, type: :mo
     context "when more than one record exists that has the next version of the attribute's value" do
       it 'accepts' do
         value1 = dummy_value_for(value_type)
-        value2 = next_version_of(value1)
-        value3 = next_version_of(value2)
+        value2 = next_version_of(value1, value_type)
+        value3 = next_version_of(value2, value_type)
         model = define_model_validating_uniqueness(
           scopes: [ build_attribute(name: :scope) ],
         )
@@ -633,8 +633,10 @@ describe Shoulda::Matchers::ActiveRecord::ValidateUniquenessOfMatcher, type: :mo
     end
   end
 
-  def next_version_of(value)
-    if value.is_a?(Time)
+  def next_version_of(value, value_type)
+    if value_type == :uuid
+      SecureRandom.uuid
+    elsif value_type == :time
       value + 1
     elsif value.respond_to?(:next)
       value.next


### PR DESCRIPTION
Fixes #402 and #587.

---

This commit fixes the uniqueness matcher so that when qualified with
`scoped_to` and one of the scopes is a UUID column that happens to end
in an "f", the matcher is able to generate a proper next value during
testing and doesn't error.