### PR TITLE
Uniqueness: Fix when scope set to nil beforehand

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,22 +25,18 @@
 
 * So far the tests for the gem have been running against only SQLite. Now they
   run against PostgreSQL, too. As a result we were able to fix some
-  Postgres-related bugs:
+  Postgres-related bugs, specifically around `validate_uniqueness_of`:
 
-  * Fix `validate_uniqueness_of` + `scoped_to` so that when one of the scope
-    attributes is a UUID column that ends in an "f", the matcher is able to
+  * When scoped to a UUID column that ends in an "f", the matcher is able to
     generate a proper "next" value without erroring. ([#402], [#587], [#662])
 
-  * Fix `validate_uniqueness_of` so that it works with scope attributes that are
-    PostgreSQL array columns. Please note that this is only supported for
-    Rails 4.2 and greater, as versions before this cannot handle array columns
-    correctly, particularly in conjunction with the uniqueness validator.
-    ([#554])
+  * Support scopes that are PostgreSQL array columns. Please note that this is
+    only supported for Rails 4.2 and greater, as versions before this cannot
+    handle array columns correctly, particularly in conjunction with the
+    uniqueness validator. ([#554])
 
-[#402]: https://github.com/thoughtbot/shoulda-matchers/pull/402
-[#587]: https://github.com/thoughtbot/shoulda-matchers/pull/587
-[#662]: https://github.com/thoughtbot/shoulda-matchers/pull/662
-[#554]: https://github.com/thoughtbot/shoulda-matchers/pull/554
+  * Fix so that when scoped to a text column and the scope is set to nil before
+    running it through the matcher, the matcher does not fail. ([#521], [#607])
 
 * Fix `define_enum_for` so that it actually tests that the attribute is present
   in the list of defined enums, as you could fool it by merely defining a class
@@ -48,7 +44,13 @@
   vein, passing a pluralized version of the attribute name to `define_enum_for`
   would erroneously pass, and now it fails. ([#641])
 
+[#402]: https://github.com/thoughtbot/shoulda-matchers/pull/402
+[#587]: https://github.com/thoughtbot/shoulda-matchers/pull/587
+[#662]: https://github.com/thoughtbot/shoulda-matchers/pull/662
+[#554]: https://github.com/thoughtbot/shoulda-matchers/pull/554
 [#641]: https://github.com/thoughtbot/shoulda-matchers/pull/641
+[#521]: https://github.com/thoughtbot/shoulda-matchers/pull/521
+[#607]: https://github.com/thoughtbot/shoulda-matchers/pull/607
 
 # 2.8.0
 

--- a/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
+++ b/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
@@ -304,7 +304,6 @@ module Shoulda
             instance.__send__("#{@attribute}=", value_for_new_record(options))
             ensure_secure_password_set(instance)
             instance.save(validate: false)
-            pp all_records: @subject.class.all
             @created_record = instance
           end
         end
@@ -407,20 +406,20 @@ module Shoulda
 
         def dummy_scalar_value_for(column)
           case column.type
-          when :string
-            '0'
+          when :integer
+            0
+          when :date
+            Date.today
           when :datetime
             DateTime.now
           when :uuid
             SecureRandom.uuid
           else
-            0
+            'dummy value'
           end
         end
 
         def next_value_for(scope, previous_value)
-          column = column_for(scope)
-
           if previous_value.is_a?(Array)
             [ next_scalar_value_for(scope, previous_value[0]) ]
           else

--- a/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
+++ b/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
@@ -397,7 +397,7 @@ module Shoulda
         def dummy_value_for(scope)
           column = column_for(scope)
 
-          if column.array
+          if column.respond_to?(:array) && column.array
             [ dummy_scalar_value_for(column) ]
           else
             dummy_scalar_value_for(column)

--- a/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
@@ -17,6 +17,14 @@ describe Shoulda::Matchers::ActiveRecord::ValidateUniquenessOfMatcher, type: :mo
           )
           expect(record).to validate_uniqueness.scoped_to(:scope1, :scope2)
         end
+
+        it 'still accepts if the scope is unset beforehand' do
+          record = build_record_validating_uniqueness(
+            scopes: [ build_attribute(name: :scope, value: nil) ]
+          )
+
+          expect(record).to validate_uniqueness.scoped_to(:scope)
+        end
       end
 
       context 'when the subject is an existing record' do
@@ -29,6 +37,14 @@ describe Shoulda::Matchers::ActiveRecord::ValidateUniquenessOfMatcher, type: :mo
           )
 
           expect(record).to validate_uniqueness.scoped_to(:scope1, :scope2)
+        end
+
+        it 'still accepts if the scope is unset beforehand' do
+          record = create_record_validating_uniqueness(
+            scopes: [ build_attribute(name: :scope, value: nil) ]
+          )
+
+          expect(record).to validate_uniqueness.scoped_to(:scope)
         end
       end
     end


### PR DESCRIPTION
Fixes #521.

Although the tests already passed before for the simple case, this likely also fixes #607.

---

Switch the order of how the column type is detected so that string comes
last. This fixes a bug where if the scope was a text column but was set
to nil before running the matcher, the matcher would fail.