### PR TITLE
Cache Bundler on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 sudo: false
+cache: bundler
 script: "bundle exec rake"
 
 branches:


### PR DESCRIPTION
With Container based CI, public projects can cache the results of
`bundle install`