### PR TITLE
Permit matcher now supports subparameters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -52,6 +52,16 @@
   vein, passing a pluralized version of the attribute name to `define_enum_for`
   would erroneously pass, and now it fails. ([#641])
 
+* Fix `permit` so that it does not break the functionality of
+  ActionController::Parameters#require. ([#648], [#675])
+
+### Features
+
+* Add `on` qualifier to `permit`. This allows you to make an assertion that
+  a restriction was placed on a slice of the `params` hash and not the entire
+  `params` hash. Although we don't require you to use this qualifier, we do
+  recommend it, as it's a more precise check. ([#675])
+
 [#402]: https://github.com/thoughtbot/shoulda-matchers/pull/402
 [#587]: https://github.com/thoughtbot/shoulda-matchers/pull/587
 [#662]: https://github.com/thoughtbot/shoulda-matchers/pull/662
@@ -59,6 +69,8 @@
 [#641]: https://github.com/thoughtbot/shoulda-matchers/pull/641
 [#521]: https://github.com/thoughtbot/shoulda-matchers/pull/521
 [#607]: https://github.com/thoughtbot/shoulda-matchers/pull/607
+[#648]: https://github.com/thoughtbot/shoulda-matchers/pull/648
+[#675]: https://github.com/thoughtbot/shoulda-matchers/pull/675
 
 # 2.8.0
 

--- a/lib/shoulda/matchers/doublespeak.rb
+++ b/lib/shoulda/matchers/doublespeak.rb
@@ -13,6 +13,16 @@ module Shoulda
         def world
           @_world ||= World.new
         end
+
+        def debugging_enabled?
+          ENV['DEBUG_DOUBLESPEAK'] == '1'
+        end
+
+        def debug(&block)
+          if debugging_enabled?
+            puts block.call
+          end
+        end
       end
     end
   end

--- a/spec/unit/shoulda/matchers/action_controller/permit_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/action_controller/permit_matcher_spec.rb
@@ -1,16 +1,86 @@
 require 'unit_spec_helper'
 
 describe Shoulda::Matchers::ActionController::PermitMatcher, type: :controller do
+  shared_examples 'basic tests' do
+    it 'accepts a subset of the permitted attributes' do
+      define_controller_with_strong_parameters(action: :create) do |ctrl|
+        params_with_conditional_require(ctrl.params).permit(:name, :age)
+      end
+
+      expect(controller).to permit_with_conditional_params(
+        permit(:name).for(:create)
+      )
+    end
+
+    it 'accepts all of the permitted attributes' do
+      define_controller_with_strong_parameters(action: :create) do |ctrl|
+        params_with_conditional_require(ctrl.params).permit(:name, :age)
+      end
+
+      expect(controller).to permit_with_conditional_params(
+        permit(:name, :age).for(:create)
+      )
+    end
+
+    it 'rejects attributes that have not been permitted' do
+      define_controller_with_strong_parameters(action: :create) do |ctrl|
+        params_with_conditional_require(ctrl.params).permit(:name)
+      end
+
+      expect(controller).not_to permit_with_conditional_params(
+        permit(:name, :admin).for(:create)
+      )
+    end
+
+    it 'rejects when #permit has not been called' do
+      define_controller_with_strong_parameters(action: :create)
+
+      expect(controller).not_to permit_with_conditional_params(
+        permit(:name).for(:create)
+      )
+    end
+
+    it 'tracks multiple calls to #permit' do
+      sets_of_attributes = [
+        [:eta, :diner_id],
+        [:phone_number, :address_1, :address_2, :city, :state, :zip]
+      ]
+
+      params = {
+        order: { some: 'value' },
+        diner: { some: 'value' }
+      }
+
+      define_controller_with_strong_parameters(action: :create) do |ctrl|
+        params_with_conditional_require(ctrl.params, :order).
+          permit(sets_of_attributes[0])
+
+        params_with_conditional_require(ctrl.params, :diner).
+          permit(sets_of_attributes[1])
+      end
+
+      expect(controller).to permit_with_conditional_params(
+        permit(*sets_of_attributes[0]).for(:create),
+        params
+      )
+
+      expect(controller).to permit_with_conditional_params(
+        permit(*sets_of_attributes[1]).for(:create),
+        params
+      )
+    end
+  end
+
   it 'requires an action' do
     assertion = -> { expect(controller).to permit(:name) }
 
-    define_controller_for_resource_with_strong_parameters
+    define_controller_with_strong_parameters
 
     expect(&assertion).to raise_error(described_class::ActionNotDefinedError)
   end
 
   it 'requires a verb for a non-restful action' do
-    define_controller_for_resource_with_strong_parameters
+    define_controller_with_strong_parameters
 
     assertion = lambda do
       expect(controller).to permit(:name).for(:authorize)
@@ -19,54 +89,64 @@ describe Shoulda::Matchers::ActionController::PermitMatcher, type: :controller d
     expect(&assertion).to raise_error(described_class::VerbNotDefinedError)
   end
 
-  it 'accepts a subset of the permitted attributes' do
-    define_controller_for_resource_with_strong_parameters(action: :create) do
-      params.require(:user).permit(:name, :age)
-    end
+  context 'when operating on the entire params hash' do
+    include_context 'basic tests' do
+      def permit_with_conditional_params(permit, _params = {})
+        permit
+      end
 
-    expect(controller).to permit(:name).for(:create)
+      def params_with_conditional_require(params, *filters)
+        params
+      end
+    end
   end
 
-  it 'accepts all of the permitted attributes' do
-    define_controller_for_resource_with_strong_parameters(action: :create) do
-      params.require(:user).permit(:name, :age)
+  context 'when operating on a slice of the params hash' do
+    include_context 'basic tests' do
+      def permit_with_conditional_params(permit, params = nil)
+        params ||= { user: { some: 'value' } }
+        permit.add_params(params)
+      end
+
+      def params_with_conditional_require(params, *filters)
+        if filters.none?
+          filters = [:user]
+        end
+
+        params.require(*filters)
+      end
     end
 
-    expect(controller).to permit(:name, :age).for(:create)
-  end
+    it 'rejects if asserting that parameters were not permitted, but on the wrong slice' do
+      define_controller_with_strong_parameters(action: :create) do
+        params.require(:order).permit(:eta, :diner_id)
+      end
 
-  it 'rejects attributes that have not been permitted' do
-    define_controller_for_resource_with_strong_parameters(action: :create) do
-      params.require(:user).permit(:name)
+      expect(controller).
+        not_to permit(:eta, :diner_id).
+        for(:create, params: { order: { some: 'value' } }).
+        on(:something_else)
     end
-
-    expect(controller).not_to permit(:name, :admin).for(:create)
-  end
-
-  it 'rejects when #permit has not been called' do
-    define_controller_for_resource_with_strong_parameters(action: :create)
-
-    expect(controller).not_to permit(:name).for(:create)
   end
 
   it 'can be used more than once in the same test' do
-    define_controller_for_resource_with_strong_parameters(action: :create) do
-      params.require(:user).permit(:name)
+    define_controller_with_strong_parameters(action: :create) do
+      params.permit(:name)
     end
 
     expect(controller).to permit(:name).for(:create)
     expect(controller).not_to permit(:admin).for(:create)
   end
 
-  it 'works with routes that require extra params' do
+  it 'allows extra parameters to be passed to the action if it requires them' do
     options = {
       controller_name: 'Posts',
       action: :show,
       routes: -> { get '/posts/:slug', to: 'posts#show' }
     }
 
-    define_controller_for_resource_with_strong_parameters(options) do
-      params.require(:user).permit(:name)
+    define_controller_with_strong_parameters(options) do
+      params.permit(:name)
     end
 
     expect(controller).
@@ -75,8 +155,8 @@ describe Shoulda::Matchers::ActionController::PermitMatcher, type: :controller d
   end
 
   it 'works with #update specifically' do
-    define_controller_for_resource_with_strong_parameters(action: :update) do
-      params.require(:user).permit(:name)
+    define_controller_with_strong_parameters(action: :update) do
+      params.permit(:name)
     end
 
     expect(controller).
@@ -84,27 +164,12 @@ describe Shoulda::Matchers::ActionController::PermitMatcher, type: :controller d
       for(:update, params: { id: 1 })
   end
 
-  it 'tracks multiple calls to #permit' do
-    sets_of_attributes = [
-      [:eta, :diner_id],
-      [:phone_number, :address_1, :address_2, :city, :state, :zip]
-    ]
-
-    define_controller_for_resource_with_strong_parameters(action: :create) do
-      params.require(:order).permit(sets_of_attributes[0])
-      params.require(:diner).permit(sets_of_attributes[1])
-    end
-
-    expect(controller).to permit(*sets_of_attributes[0]).for(:create)
-    expect(controller).to permit(*sets_of_attributes[1]).for(:create)
-  end
-
   describe '#matches?' do
     it 'does not raise an error when #fetch was used instead of #require (issue #495)' do
       matcher = permit(:eta, :diner_id).for(:create)
       matching = -> { matcher.matches?(controller) }
 
-      define_controller_for_resource_with_strong_parameters(action: :create) do
+      define_controller_with_strong_parameters(action: :create) do
         params.fetch(:order, {}).permit(:eta, :diner_id)
       end
 
@@ -120,12 +185,12 @@ describe Shoulda::Matchers::ActionController::PermitMatcher, type: :controller d
           params: { user: { some: 'params' } }
         )
 
-        define_controller_for_resource_with_strong_parameters(action: :create) do
+        define_controller_with_strong_parameters(action: :create) do
           params[:foo] = 'bar'
           actual_foo_param = params[:foo]
           actual_user_params = params[:user]
 
-          params.require(:user).permit(:name)
+          params.permit(:name)
         end
 
         matcher.matches?(controller)
@@ -134,11 +199,32 @@ describe Shoulda::Matchers::ActionController::PermitMatcher, type: :controller d
         expect(actual_foo_param).to eq 'bar'
       end
 
+      it 'still allows #require to return a slice of the params' do
+        expected_user_params = { 'foo' => 'bar' }
+        actual_user_params = nil
+        matcher = permit(:name).for(
+          :update,
+          params: { id: 1, user: expected_user_params }
+        )
+
+        define_controller_with_strong_parameters(action: :update) do
+          actual_user_params = params.require(:user)
+          begin
+            actual_user_params.permit(:name)
+          rescue
+          end
+        end
+
+        matcher.matches?(controller)
+
+        expect(actual_user_params).to eq expected_user_params
+      end
+
       it 'does not permanently stub the params hash' do
         matcher = permit(:name).for(:create)
         params_access = -> { controller.params.require(:user) }
 
-        define_controller_for_resource_with_strong_parameters(action: :create)
+        define_controller_with_strong_parameters(action: :create)
 
         matcher.matches?(controller)
 
@@ -167,36 +253,38 @@ describe Shoulda::Matchers::ActionController::PermitMatcher, type: :controller d
     it 'returns the correct string' do
       options = { action: :create, method: :post }
 
-      define_controller_for_resource_with_strong_parameters(options) do
+      define_controller_with_strong_parameters(options) do
         params.permit(:name, :age)
       end
 
       matcher = described_class.new([:name, :age, :height]).for(:create)
-      expect(matcher.description).
-        to eq 'permit POST #create to receive parameters :name, :age, and :height'
+      expect(matcher.description).to eq(
+        '(on POST #create) restrict parameters to :name, :age, and :height'
+      )
     end
 
     context 'when a verb is specified' do
       it 'returns the correct string' do
         options = { action: :some_action }
 
-        define_controller_for_resource_with_strong_parameters(options) do
+        define_controller_with_strong_parameters(options) do
           params.permit(:name, :age)
         end
 
         matcher = described_class.
           new([:name]).
           for(:some_action, verb: :put)
-        expect(matcher.description).
-          to eq 'permit PUT #some_action to receive parameters :name'
+        expect(matcher.description).to eq(
+          '(on PUT #some_action) restrict parameters to :name'
+        )
       end
     end
   end
 
   describe 'positive failure message' do
     it 'includes all missing attributes' do
-      define_controller_for_resource_with_strong_parameters(action: :create) do
-        params.require(:user).permit(:name, :age)
+      define_controller_with_strong_parameters(action: :create) do
+        params.permit(:name, :age)
       end
 
       assertion = lambda do
@@ -205,25 +293,31 @@ describe Shoulda::Matchers::ActionController::PermitMatcher, type: :controller d
           for(:create)
       end
 
-      expect(&assertion).to fail_with_message(
-        'Expected controller to permit city and country, but it did not.'
-      )
+      message =
+        "Expected POST #create to restrict parameters to " +
+        ":name, :age, :city, and :country,\n" +
+        "but the restricted parameters were :name and :age instead."
+
+      expect(&assertion).to fail_with_message(message)
     end
   end
 
   describe 'negative failure message' do
     it 'includes all attributes that should not have been permitted but were' do
-      define_controller_for_resource_with_strong_parameters(action: :create) do
-        params.require(:user).permit(:name, :age)
+      define_controller_with_strong_parameters(action: :create) do
+        params.permit(:name, :age)
       end
 
       assertion = lambda do
         expect(controller).not_to permit(:name, :age).for(:create)
       end
 
-      expect(&assertion).to fail_with_message(
-        'Expected controller not to permit name and age, but it did.'
-      )
+      message =
+        "Expected POST #create not to restrict parameters to " +
+        ":name and :age,\n" +
+        "but it did."
+
+      expect(&assertion).to fail_with_message(message)
     end
   end
 
@@ -283,10 +377,7 @@ describe Shoulda::Matchers::ActionController::PermitMatcher, type: :controller d
     Class.new(StandardError)
   end
 
-  def define_controller_for_resource_with_strong_parameters(
-    options = {},
-    &action_body
-  )
+  def define_controller_with_strong_parameters(options = {}, &action_body)
     model_name = options.fetch(:model_name, 'User')
     controller_name = options.fetch(:controller_name, 'UsersController')
     collection_name = controller_name.
@@ -300,7 +391,11 @@ describe Shoulda::Matchers::ActionController::PermitMatcher, type: :controller d
     controller_class = define_controller(controller_name) do
       define_method action_name do
         if action_body
-          instance_eval(&action_body)
+          if action_body.arity == 0
+            instance_eval(&action_body)
+          else
+            action_body.call(self)
+          end
         end
 
         render nothing: true


### PR DESCRIPTION
This fixes #648.

----

Previously we were taking ActionController::Parameters and completely
overriding #require, forcing it to return `self`, i.e, the entire
ActionController::Parameters object. This meant that we broke its
functionality, which is to return a slice of the params hash instead.
The consequence of this is that attempting to call #permit on a slice of
the params hash obtained via #require would not work:

``` ruby
params = ActionController::Parameters.new(
  { "course" => { "foo" => "bar" } }
)
params.require(:course)
params.require(:course).permit(:foo)
```

This commit fixes the permit matcher so that #require is proxied
instead, retaining the existing behavior.

This commit also adds a qualifier, #on, for asserting that your action
places a restriction on a slice of the params hash. The `permit` matcher
will properly track calls on child `params` instances. For example:

``` ruby
class UsersController < ActionController::Base
  def create
    User.create!(user_params)
    ...
  end

  private

  def user_params
    params.require(:user).permit(:name, :age)
  end
end

describe UsersController do
  it { should permit(:name, :age).for(:create).on(:user) }
end
```

If this fails, you'll get the following error message:

```
Expected POST #create to restrict parameters for :user to :name and :age,
but restricted parameters were :first_name and :last_name.
```