### PR TITLE
validate_after_scope_change? use compact before  retrieving max

### DIFF
--- a/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
+++ b/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
@@ -386,7 +386,7 @@ module Shoulda
           else
             all_records = @subject.class.all
             @options[:scopes].all? do |scope|
-              previous_value = all_records.map(&scope).max
+              previous_value = all_records.map(&scope).compact.max
 
               next_value =
                 if previous_value.blank?

--- a/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
@@ -664,6 +664,21 @@ describe Shoulda::Matchers::ActiveRecord::ValidateUniquenessOfMatcher, type: :mo
     end
   end
 
+  context 'when the scope_to is used and existing records contain nil values on scoped attribute' do
+    it 'still works' do
+      model = define_model_validating_uniqueness(
+          scopes: [name: :scope1])
+
+      create_record_from(model, attribute_name: 'uniq 1', scope1: 'uniq 1')
+      create_record_from(model, attribute_name: 'rec with nil desc', scope1: nil)
+      record = build_record_from(model, attribute_name: 'this should be ok', scope1: 'this should be ok')
+
+      expect(record).
+        to validate_uniqueness.
+        scoped_to(:scope1)
+    end
+  end
+
   let(:model_attributes) { {} }
 
   def default_attribute


### PR DESCRIPTION
Otherwise produces error "ArgumentError: comparison of NilClass with String failed" if the resultant contains a combinations of strings and nils.