### PR TITLE
Add doc of `on` qualifier on all matchers that inherit from ValidationMatcher

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_absence_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_absence_of_matcher.rb
@@ -23,6 +23,27 @@ module Shoulda
       #
       # #### Qualifiers
       #
+      # ##### on
+      #
+      # Use `on` if your validation applies only under a certain context.
+      #
+      #     class Artillery
+      #       include ActiveModel::Model
+      #       attr_accessor :arms
+      #
+      #       validates_absence_of :arms, on: :create
+      #     end
+      #
+      #     # RSpec
+      #     describe Artillery do
+      #       it { should validate_absence_of(:arms).on(:create) }
+      #     end
+      #
+      #     # Test::Unit
+      #     class ArtilleryTest < ActiveSupport::TestCase
+      #       should validate_absence_of(:arms).on(:create)
+      #     end
+      #
       # ##### with_message
       #
       # Use `with_message` if you are using a custom validation message.

--- a/lib/shoulda/matchers/active_model/validate_acceptance_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_acceptance_of_matcher.rb
@@ -23,6 +23,30 @@ module Shoulda
       #
       # #### Qualifiers
       #
+      # ##### on
+      #
+      # Use `on` if your validation applies only under a certain context.
+      #
+      #     class Registration
+      #       include ActiveModel::Model
+      #       attr_accessor :terms_of_service
+      #
+      #       validates_acceptance_of :terms_of_service, on: :create
+      #     end
+      #
+      #     # RSpec
+      #     describe Registration do
+      #       it do
+      #         should validate_acceptance_of(:terms_of_service).
+      #           on(:create)
+      #       end
+      #     end
+      #
+      #     # Test::Unit
+      #     class RegistrationTest < ActiveSupport::TestCase
+      #       should validate_acceptance_of(:terms_of_service).on(:create)
+      #     end
+      #
       # ##### with_message
       #
       # Use `with_message` if you are using a custom validation message.

--- a/lib/shoulda/matchers/active_model/validate_confirmation_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_confirmation_of_matcher.rb
@@ -23,6 +23,27 @@ module Shoulda
       #
       # #### Qualifiers
       #
+      # ##### on
+      #
+      # Use `on` if your validation applies only under a certain context.
+      #
+      #     class User
+      #       include ActiveModel::Model
+      #       attr_accessor :password
+      #
+      #       validates_confirmation_of :password, on: :create
+      #     end
+      #
+      #     # RSpec
+      #     describe User do
+      #       it { should validate_confirmation_of(:password).on(:create) }
+      #     end
+      #
+      #     # Test::Unit
+      #     class UserTest < ActiveSupport::TestCase
+      #       should validate_confirmation_of(:password).on(:create)
+      #     end
+      #
       # ##### with_message
       #
       # Use `with_message` if you are using a custom validation message.

--- a/lib/shoulda/matchers/active_model/validate_exclusion_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_exclusion_of_matcher.rb
@@ -54,6 +54,35 @@ module Shoulda
       #
       # #### Qualifiers
       #
+      # ##### on
+      #
+      # Use `on` if your validation applies only under a certain context.
+      #
+      #     class Game
+      #       include ActiveModel::Model
+      #       attr_accessor :weapon
+      #
+      #       validates_exclusion_of :weapon,
+      #         in: ['pistol', 'paintball gun', 'stick'],
+      #         on: :create
+      #     end
+      #
+      #     # RSpec
+      #     describe Game do
+      #       it do
+      #         should validate_exclusion_of(:weapon).
+      #           in_array(['pistol', 'paintball gun', 'stick']).
+      #           on(:create)
+      #       end
+      #     end
+      #
+      #     # Test::Unit
+      #     class GameTest < ActiveSupport::TestCase
+      #       should validate_exclusion_of(:weapon).
+      #         in_array(['pistol', 'paintball gun', 'stick']).
+      #         on(:create)
+      #     end
+      #
       # ##### with_message
       #
       # Use `with_message` if you are using a custom validation message.

--- a/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
@@ -67,6 +67,33 @@ module Shoulda
       #
       # #### Qualifiers
       #
+      # Use `on` if your validation applies only under a certain context.
+      #
+      #     class Issue
+      #       include ActiveModel::Model
+      #       attr_accessor :severity
+      #
+      #       validates_inclusion_of :severity,
+      #         in: %w(low medium high),
+      #         on: :create
+      #     end
+      #
+      #     # RSpec
+      #     describe Issue do
+      #       it do
+      #         should validate_inclusion_of(:severity).
+      #           in_array(%w(low medium high)).
+      #           on(:create)
+      #       end
+      #     end
+      #
+      #     # Test::Unit
+      #     class IssueTest < ActiveSupport::TestCase
+      #       should validate_inclusion_of(:severity).
+      #         in_array(%w(low medium high)).
+      #         on(:create)
+      #     end
+      #
       # ##### with_message
       #
       # Use `with_message` if you are using a custom validation message.

--- a/lib/shoulda/matchers/active_model/validate_length_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_length_of_matcher.rb
@@ -7,6 +7,31 @@ module Shoulda
       #
       # #### Qualifiers
       #
+      # Use `on` if your validation applies only under a certain context.
+      #
+      #     class User
+      #       include ActiveModel::Model
+      #       attr_accessor :password
+      #
+      #       validates_length_of :password, minimum: 10, on: :create
+      #     end
+      #
+      #     # RSpec
+      #     describe User do
+      #       it do
+      #         should validate_length_of(:password).
+      #           is_at_least(10).
+      #           on(:create)
+      #       end
+      #     end
+      #
+      #     # Test::Unit
+      #     class UserTest < ActiveSupport::TestCase
+      #       should validate_length_of(:password).
+      #         is_at_least(10).
+      #         on(:create)
+      #     end
+      #
       # ##### is_at_least
       #
       # Use `is_at_least` to test usage of the `:minimum` option. This asserts

--- a/lib/shoulda/matchers/active_model/validate_length_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_length_of_matcher.rb
@@ -135,9 +135,9 @@ module Shoulda
       #
       #     class User
       #       include ActiveModel::Model
-      #       attr_accessor :api_token
+      #       attr_accessor :password
       #
-      #       validates_length_of :api_token,
+      #       validates_length_of :password,
       #         minimum: 10,
       #         message: "Password isn't long enough"
       #     end

--- a/lib/shoulda/matchers/active_model/validate_numericality_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_numericality_of_matcher.rb
@@ -23,6 +23,30 @@ module Shoulda
       #
       # #### Qualifiers
       #
+      # ##### on
+      #
+      # Use `on` if your validation applies only under a certain context.
+      #
+      #     class Person
+      #       include ActiveModel::Model
+      #       attr_accessor :number_of_dependents
+      #
+      #       validates_numericality_of :number_of_dependents, on: :create
+      #     end
+      #
+      #     # RSpec
+      #     describe Person do
+      #       it do
+      #         should validate_numericality_of(:number_of_dependents).
+      #           on(:create)
+      #       end
+      #     end
+      #
+      #     # Test::Unit
+      #     class PersonTest < ActiveSupport::TestCase
+      #       should validate_numericality_of(:number_of_dependents).on(:create)
+      #     end
+      #
       # ##### only_integer
       #
       # Use `only_integer` to test usage of the `:only_integer` option. This

--- a/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
+++ b/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
@@ -88,6 +88,22 @@ module Shoulda
       #
       # #### Qualifiers
       #
+      # Use `on` if your validation applies only under a certain context.
+      #
+      #     class Post < ActiveRecord::Base
+      #       validates_uniqueness_of :title, on: :create
+      #     end
+      #
+      #     # RSpec
+      #     describe Post do
+      #       it { should validate_uniqueness_of(:title).on(:create) }
+      #     end
+      #
+      #     # Test::Unit
+      #     class PostTest < ActiveSupport::TestCase
+      #       should validate_uniqueness_of(:title).on(:create)
+      #     end
+      #
       # ##### with_message
       #
       # Use `with_message` if you are using a custom validation message.


### PR DESCRIPTION
The `Shoulda::Matchers::ActiveModel::ValidationMatcher` defines the `on` qualifier. This PR add documentation of the `on` qualifier on all matchers that inherit from `ValidationMatcher`.