### PR TITLE
Fix typo in `rescue_from` description.

### DIFF
--- a/lib/shoulda/matchers/action_controller/rescue_from_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/rescue_from_matcher.rb
@@ -54,7 +54,7 @@ module Shoulda
         end
 
         def description
-          description = "rescues from #{exception}"
+          description = "rescue from #{exception}"
           description << " with ##{expected_method}" if expected_method
           description
         end


### PR DESCRIPTION
Changes the description message into the imperative mood.

Now RSpec’s output makes more sense:

```
ApplicationController
  should rescue from ActiveRecord::RecordInvalid
```