### PR TITLE
Return a better error message when call validate_exclusion_of without a qualifier

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_exclusion_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_exclusion_of_matcher.rb
@@ -158,6 +158,13 @@ module Shoulda
               disallows_maximum_value
           elsif @array
             disallows_all_values_in_array?
+          else
+            message = <<-EOT.strip_heredoc
+              You need to use the `in_array` or `in_range` qualifiers, eg.
+              * should validate_exclusion_of(:state).in_array(%w(open resolved unresolved))
+              * should validate_exclusion_of(:state).in_range(1..5)
+            EOT
+            raise ArgumentError, message
           end
         end
 

--- a/spec/unit/shoulda/matchers/active_model/validate_exclusion_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_exclusion_of_matcher_spec.rb
@@ -87,6 +87,15 @@ describe Shoulda::Matchers::ActiveModel::ValidateExclusionOfMatcher, type: :mode
     end
   end
 
+  context 'without the in_array or in_range qualifier' do
+    it 'raise a error when the qualifier is missing' do
+      expect do
+        expect(validating_exclusion(in: 2..5)).
+          to validate_exclusion_of(:attr)
+      end.to raise_error(ArgumentError, /`in_array` or `in_range` qualifiers/)
+    end
+  end
+
   def validating_exclusion(options)
     define_model(:example, attr: :integer) do
       validates_exclusion_of :attr, options


### PR DESCRIPTION
The `validate_exclusion_of` has the same misbehavior of the `validate_inclusion_of` as described here https://github.com/thoughtbot/shoulda-matchers/issues/579

This PR adds a better error message.
