### PR TITLE
Return a error message when call validate_length_of without a qualifier

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_length_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_length_of_matcher.rb
@@ -291,6 +291,14 @@ module Shoulda
         end
 
         def matches?(subject)
+          if @options.empty?
+            message = <<-EOT.strip_heredoc
+              You need to use at least one qualifier, eg.
+              * should validate_length_of(:bio).is_at_least(15)
+              * should validate_length_of(:status_update).is_at_most(140)
+            EOT
+            raise ArgumentError, message
+          end
           super(subject)
           translate_messages!
           lower_bound_matches? && upper_bound_matches?

--- a/spec/unit/shoulda/matchers/active_model/validate_length_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_length_of_matcher_spec.rb
@@ -161,6 +161,15 @@ describe Shoulda::Matchers::ActiveModel::ValidateLengthOfMatcher, type: :model d
     end
   end
 
+  context 'without a qualifier' do
+    it 'raise a error when the qualifier is missing' do
+      expect do
+        expect(validating_length(minimum: 4)).
+          to validate_length_of(:attr)
+      end.to raise_error(ArgumentError, /at least one qualifier/)
+    end
+  end
+
   def validating_length(options = {})
     define_model(:example, attr: :string) do
       validates_length_of :attr, options


### PR DESCRIPTION
The `validate_length_of` returns a false positive when called without a qualifier, example:

It is positive when the model does not define a validation.

``` ruby
expect(validating_length).to validate_length_of(:attr)
```

It is positive when the attribute does not exist in the model.

``` ruby
expect(validating_length(minimum: 4)).to validate_length_of(:bar)
```

This PR raises a error message when the matcher is called without a qualifier, follows the same logic of the https://github.com/thoughtbot/shoulda-matchers/pull/705 and https://github.com/thoughtbot/shoulda-matchers/pull/708
