### PR TITLE
Return a better error message when call route without a qualifier

### DIFF
--- a/lib/shoulda/matchers/action_controller/route_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/route_matcher.rb
@@ -95,6 +95,7 @@ module Shoulda
           @method  = method
           @path    = path
           @context = context
+          @params = {}
         end
 
         attr_reader :failure_message, :failure_message_when_negated
@@ -113,6 +114,14 @@ module Shoulda
         end
 
         def matches?(controller)
+          if @params.empty?
+            message = <<-EOT.strip_heredoc
+              You need to use the `to` qualifier, eg.
+              * should route(:get, '/posts').to(action: :index)
+              * should route(:get, '/posts/1').to(action: :show, id: 1)
+            EOT
+            raise ArgumentError, message
+          end
           guess_controller!(controller)
           route_recognized?
         end

--- a/spec/unit/shoulda/matchers/action_controller/route_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/action_controller/route_matcher_spec.rb
@@ -35,6 +35,13 @@ describe 'Shoulda::Matchers::ActionController::RouteMatcher', type: :controller 
           to(action: 'index')
       end
 
+      it 'raises a error when called without the `to` qualifier' do
+        expect do
+          expect(controller_with_defined_routes).
+            to route(:get, "/#{controller_path}")
+        end.to raise_error(ArgumentError, /qualifier/)
+      end
+
       context 'when route has parameters' do
         it 'accepts a non-string parameter' do
           expect(controller_with_defined_routes).


### PR DESCRIPTION
This PR raises a error message when the matcher is called without a qualifier, follows the same logic of the #705, #708 and #709.
