### PR TITLE
Allow the use of matchers from multiple libs, for non rails projects.

### DIFF
--- a/lib/shoulda/matchers/integrations/configuration.rb
+++ b/lib/shoulda/matchers/integrations/configuration.rb
@@ -11,6 +11,7 @@ module Shoulda
 
         def initialize(configuration, &block)
           @test_frameworks = Set.new
+          @libraries = Set.new
 
           test_framework :missing_test_framework
           library :missing_library
@@ -24,11 +25,11 @@ module Shoulda
         end
 
         def library(name)
-          @library = Integrations.find_library!(name)
+          @libraries << Integrations.find_library!(name)
         end
 
         def apply
-          if no_test_frameworks_added? && library_not_set?
+          if no_test_frameworks_added? && no_libraries_set?
             raise ConfigurationError, <<EOT
 shoulda-matchers is not configured correctly. You need to specify a test
 framework and/or library. For example:
@@ -44,7 +45,7 @@ EOT
 
           @test_frameworks.each do |test_framework|
             test_framework.include(Shoulda::Matchers::Independent)
-            @library.integrate_with(test_framework)
+            @libraries.each { |library| library.integrate_with(test_framework) }
           end
         end
 
@@ -58,8 +59,8 @@ EOT
           @test_frameworks.empty? || !@test_frameworks.any?(&:present?)
         end
 
-        def library_not_set?
-          @library.nil?
+        def no_libraries_set?
+          @libraries.empty?
         end
       end
     end

--- a/spec/acceptance/multiple_libraries_integration_spec.rb
+++ b/spec/acceptance/multiple_libraries_integration_spec.rb
@@ -1,0 +1,53 @@
+require 'acceptance_spec_helper'
+
+describe 'shoulda-matchers integrates with multiple libraries' do
+  before do
+    create_rails_application
+
+    write_file 'db/migrate/1_create_users.rb', <<-FILE
+      class CreateUsers < ActiveRecord::Migration
+        def self.up
+          create_table :users do |t|
+            t.string :name
+          end
+        end
+      end
+    FILE
+
+    run_rake_tasks! *%w(db:drop db:create db:migrate)
+
+    write_file 'app/models/user.rb', <<-FILE
+      class User < ActiveRecord::Base
+        validates_presence_of :name
+        validates_uniqueness_of :name
+      end
+    FILE
+
+    add_rspec_file 'spec/models/user_spec.rb', <<-FILE
+      describe User do
+        it { should validate_presence_of(:name) }
+        it { should validate_uniqueness_of(:name) }
+      end
+    FILE
+
+    updating_bundle do
+      add_rspec_rails_to_project!
+      add_shoulda_matchers_to_project(
+        test_frameworks: [:rspec],
+        library: [:active_record, :active_model]
+      )
+    end
+  end
+
+  subject { run_rspec_suite }
+
+  context 'when using both active_record and active_model libraries' do
+    it 'allows the use of matchers from both libraries' do
+      expect(subject).to have_output('2 examples, 0 failures')
+      expect(subject).to have_output('should require name to be set')
+      expect(subject).to have_output(
+        'should require case sensitive unique value for name'
+      )
+    end
+  end
+end

--- a/spec/support/acceptance/adds_shoulda_matchers_to_project.rb
+++ b/spec/support/acceptance/adds_shoulda_matchers_to_project.rb
@@ -82,7 +82,9 @@ module AcceptanceTests
     end
 
     def library_config_for(library)
-      if library
+      if library.respond_to? :map
+        library.map { |lib| "with.library :#{lib}\n" }.join
+      elsif library
         "with.library :#{library}\n"
       else
         ''


### PR DESCRIPTION
* It changes shoulda-matchers to allow the integration with multiple
  libraries like active_model and active_record.

  For example, in a non Rails project isn't possible to use both
  validate_presence_of and validate_uniqueness_of matchers, because they
  are from different libraries (one from active_model and the another from
  active_record respectively).

  This change allow the integration with multiple libraries.

  fixes #710