### PR TITLE
Add assignment method support to delegate_method matcher

### DIFF
--- a/lib/shoulda/matchers/independent/delegate_method_matcher.rb
+++ b/lib/shoulda/matchers/independent/delegate_method_matcher.rb
@@ -226,7 +226,7 @@ module Shoulda
         end
 
         def assignment_method?
-          @delegating_method.to_s.match(/=$/).present?
+          !@delegating_method.to_s.match(/=$/).nil?
         end
 
         def build_delegating_method_prefix(prefix)

--- a/lib/shoulda/matchers/independent/delegate_method_matcher.rb
+++ b/lib/shoulda/matchers/independent/delegate_method_matcher.rb
@@ -159,7 +159,7 @@ module Shoulda
           @delegate_method = @delegating_method
           @delegate_object = Doublespeak::ObjectDouble.new
 
-          @delegated_arguments = []
+          @delegated_arguments = init_delegated_arguments
           @delegate_object_reader_method = nil
           @subject = nil
           @subject_double_collection = nil
@@ -215,6 +215,18 @@ module Shoulda
             :"#{build_delegating_method_prefix(prefix)}_#{delegate_method}"
             delegate_method
           self
+        end
+
+        def init_delegated_arguments
+          if assignment_method?
+            ["test"]
+          else
+            []
+          end
+        end
+
+        def assignment_method?
+          @delegating_method.to_s.match(/=$/).present?
         end
 
         def build_delegating_method_prefix(prefix)

--- a/lib/shoulda/matchers/independent/delegate_method_matcher.rb
+++ b/lib/shoulda/matchers/independent/delegate_method_matcher.rb
@@ -219,7 +219,7 @@ module Shoulda
 
         def init_delegated_arguments
           if assignment_method?
-            ["test"]
+            [nil]
           else
             []
           end

--- a/spec/unit/shoulda/matchers/independent/delegate_method_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/independent/delegate_method_matcher_spec.rb
@@ -202,7 +202,7 @@ describe Shoulda::Matchers::Independent::DelegateMethodMatcher do
     end
   end
 
-  context 'when the subject delegates correctly' do
+  context 'when the subject delegates correctly in normal method' do
     before do
       define_class('Mailman')
 
@@ -229,6 +229,38 @@ describe Shoulda::Matchers::Independent::DelegateMethodMatcher do
 
         expect {
           expect(post_office).not_to delegate_method(:deliver_mail).to(:mailman)
+        }.to fail_with_message(message)
+      end
+    end
+  end
+
+  context 'when the subject delegates correctly in assignment method' do
+    before do
+      define_class('Mailman')
+
+      define_class('PostOffice') do
+        def deliver_mail=(arg)
+          mailman.deliver_mail = arg
+        end
+
+        def mailman
+          Mailman.new
+        end
+      end
+    end
+
+    it 'accepts' do
+      post_office = PostOffice.new
+      expect(post_office).to delegate_method(:deliver_mail=).to(:mailman)
+    end
+
+    context 'negating the matcher' do
+      it 'rejects with the correct failure message' do
+        post_office = PostOffice.new
+        message = 'Expected PostOffice not to delegate #deliver_mail to #mailman object, but it did'
+
+        expect {
+          expect(post_office).not_to delegate_method(:deliver_mail=).to(:mailman)
         }.to fail_with_message(message)
       end
     end

--- a/spec/unit/shoulda/matchers/independent/delegate_method_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/independent/delegate_method_matcher_spec.rb
@@ -257,7 +257,7 @@ describe Shoulda::Matchers::Independent::DelegateMethodMatcher do
     context 'negating the matcher' do
       it 'rejects with the correct failure message' do
         post_office = PostOffice.new
-        message = 'Expected PostOffice not to delegate #deliver_mail to #mailman object, but it did'
+        message = 'Expected PostOffice not to delegate #deliver_mail= to #mailman object, but it did'
 
         expect {
           expect(post_office).not_to delegate_method(:deliver_mail=).to(:mailman)


### PR DESCRIPTION
Fix #606 's wrong argument error when delegate assignment method.
