### PR TITLE
Make ValidateUniquenessOfMatcher method signature consistent

### DIFF
--- a/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
+++ b/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
@@ -235,13 +235,13 @@ module Shoulda
           self
         end
 
-        def allow_nil
-          @options[:allow_nil] = true
+        def allow_nil(allow_nil = true)
+          @options[:allow_nil] = allow_nil
           self
         end
 
-        def allow_blank
-          @options[:allow_blank] = true
+        def allow_blank(allow_blank = true)
+          @options[:allow_blank] = allow_blank
           self
         end
 


### PR DESCRIPTION
* Make ValidateUniquenessOfMatcher#allow_nil & #allow_blank accepts an optional boolean argument

This makes it consistent with ValidateInclusionOfMatcher

For #721 