### PR TITLE
Update RDoc of permit matchers according the new behavior.

### DIFF
--- a/lib/shoulda/matchers/action_controller/permit_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/permit_matcher.rb
@@ -38,7 +38,14 @@ module Shoulda
       #     describe UsersController do
       #       it do
       #         should permit(:first_name, :last_name, :email, :password).
-      #           for(:create).
+      #           for(:create, params: {
+      #             user: {
+      #               first_name: 'Jon',
+      #               last_name: 'Doe',
+      #               email: 'jondoe@example.com',
+      #               password: 'password'
+      #             }
+      #           }).
       #           on(:user)
       #       end
       #     end
@@ -46,8 +53,15 @@ module Shoulda
       #     # Test::Unit
       #     class UsersControllerTest < ActionController::TestCase
       #       should permit(:first_name, :last_name, :email, :password).
-      #         for(:create).
-      #         on(:user)
+      #         for(:create, params: {
+      #            user: {
+      #              first_name: 'Jon',
+      #              last_name: 'Doe',
+      #              email: 'jondoe@example.com',
+      #              password: 'password'
+      #            }
+      #          }).
+      #        on(:user)
       #     end
       #
       # If your action requires query parameters in order to work, then you'll
@@ -84,7 +98,15 @@ module Shoulda
       #
       #       it do
       #         should permit(:first_name, :last_name, :email, :password).
-      #           for(:update, params: { id: 1 }).
+      #           for(:update, params: {
+      #              id: 1,
+      #              user: {
+      #                first_name: 'Jon',
+      #                last_name: 'Doe',
+      #                email: 'jondoe@example.com',
+      #                password: 'password'
+      #              }
+      #            }).
       #           on(:user)
       #       end
       #     end
@@ -96,7 +118,15 @@ module Shoulda
       #       end
       #
       #       should permit(:first_name, :last_name, :email, :password).
-      #         for(:update, params: { id: 1 }).
+      #         for(:update, params: {
+      #          id: 1,
+      #          user: {
+      #            first_name: 'Jon',
+      #            last_name: 'Doe',
+      #            email: 'jondoe@example.com',
+      #            password: 'password'
+      #          }
+      #         }).
       #         on(:user)
       #     end
       #
@@ -137,7 +167,7 @@ module Shoulda
       #
       #       it do
       #         should permit(:activated).
-      #           for(:toggle, params: { id: 1 }, verb: :put).
+      #           for(:toggle, params: { id: 1, user: { activated: true } }, verb: :put).
       #           on(:user)
       #       end
       #     end
@@ -149,7 +179,7 @@ module Shoulda
       #       end
       #
       #       should permit(:activated).
-      #         for(:toggle, params: { id: 1 }, verb: :put).
+      #         for(:toggle, params: { id: 1, user: { activated: true } }, verb: :put).
       #         on(:user)
       #     end
       #

--- a/lib/shoulda/matchers/action_controller/permit_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/permit_matcher.rb
@@ -38,14 +38,16 @@ module Shoulda
       #     describe UsersController do
       #       it do
       #         should permit(:first_name, :last_name, :email, :password).
-      #           for(:create, params: {
-      #             user: {
-      #               first_name: 'Jon',
-      #               last_name: 'Doe',
-      #               email: 'jondoe@example.com',
-      #               password: 'password'
+      #           for(:create,
+      #             params: {
+      #               user: {
+      #                 first_name: 'Jon',
+      #                 last_name: 'Doe',
+      #                 email: 'jondoe@example.com',
+      #                 password: 'password'
+      #               }
       #             }
-      #           }).
+      #           ).
       #           on(:user)
       #       end
       #     end
@@ -53,15 +55,17 @@ module Shoulda
       #     # Test::Unit
       #     class UsersControllerTest < ActionController::TestCase
       #       should permit(:first_name, :last_name, :email, :password).
-      #         for(:create, params: {
-      #            user: {
-      #              first_name: 'Jon',
-      #              last_name: 'Doe',
-      #              email: 'jondoe@example.com',
-      #              password: 'password'
-      #            }
-      #          }).
-      #        on(:user)
+      #         for(:create,
+      #           params: {
+      #             user: {
+      #               first_name: 'Jon',
+      #               last_name: 'Doe',
+      #               email: 'jondoe@example.com',
+      #               password: 'password'
+      #             }
+      #           }
+      #         ).
+      #         on(:user)
       #     end
       #
       # If your action requires query parameters in order to work, then you'll
@@ -98,15 +102,17 @@ module Shoulda
       #
       #       it do
       #         should permit(:first_name, :last_name, :email, :password).
-      #           for(:update, params: {
-      #              id: 1,
-      #              user: {
-      #                first_name: 'Jon',
-      #                last_name: 'Doe',
-      #                email: 'jondoe@example.com',
-      #                password: 'password'
-      #              }
-      #            }).
+      #           for(:update,
+      #             params: {
+      #               id: 1,
+      #               user: {
+      #                 first_name: 'Jon',
+      #                 last_name: 'Doe',
+      #                 email: 'jondoe@example.com',
+      #                 password: 'password'
+      #               }
+      #             }
+      #           ).
       #           on(:user)
       #       end
       #     end
@@ -118,15 +124,17 @@ module Shoulda
       #       end
       #
       #       should permit(:first_name, :last_name, :email, :password).
-      #         for(:update, params: {
-      #          id: 1,
-      #          user: {
-      #            first_name: 'Jon',
-      #            last_name: 'Doe',
-      #            email: 'jondoe@example.com',
-      #            password: 'password'
-      #          }
-      #         }).
+      #         for(:update,
+      #           params: {
+      #             id: 1,
+      #             user: {
+      #               first_name: 'Jon',
+      #               last_name: 'Doe',
+      #               email: 'jondoe@example.com',
+      #               password: 'password'
+      #             }
+      #           }
+      #         ).
       #         on(:user)
       #     end
       #
@@ -167,7 +175,10 @@ module Shoulda
       #
       #       it do
       #         should permit(:activated).
-      #           for(:toggle, params: { id: 1, user: { activated: true } }, verb: :put).
+      #           for(:toggle,
+      #             params: { id: 1, user: { activated: true } },
+      #             verb: :put
+      #           ).
       #           on(:user)
       #       end
       #     end
@@ -179,7 +190,10 @@ module Shoulda
       #       end
       #
       #       should permit(:activated).
-      #         for(:toggle, params: { id: 1, user: { activated: true } }, verb: :put).
+      #         for(:toggle,
+      #           params: { id: 1, user: { activated: true } },
+      #           verb: :put
+      #         ).
       #         on(:user)
       #     end
       #


### PR DESCRIPTION
In 3.0 the permit matcher require the definition of the params.

Closes #729