### PR TITLE
Fix the set_flash matcher to accept a symbol as a param

### DIFF
--- a/lib/shoulda/matchers/action_controller/flash_store.rb
+++ b/lib/shoulda/matchers/action_controller/flash_store.rb
@@ -26,7 +26,7 @@ module Shoulda
         end
 
         def has_key?(key)
-          values_to_check.include?(key)
+          values_to_check.include?(key.to_s)
         end
 
         def has_value?(expected_value)

--- a/spec/support/unit/shared_examples/set_session_or_flash.rb
+++ b/spec/support/unit/shared_examples/set_session_or_flash.rb
@@ -56,9 +56,28 @@ shared_examples_for 'set session or flash matcher' do
 
     context 'in the positive' do
       context 'if the given key is present in the store' do
-        it 'accepts' do
-          controller = controller_with_store('the key' => 'any value')
-          expect(controller).to set_store['the key']
+        context 'and controller set the key as a string' do
+          it 'accepts the param as a string' do
+            controller = controller_with_store('the_key' => 'any value')
+            expect(controller).to set_store['the_key']
+          end
+
+          it 'accepts the param as a symbol' do
+            controller = controller_with_store('the_key' => 'any value')
+            expect(controller).to set_store[:the_key]
+          end
+        end
+
+        context 'and controller set the key as a symbol' do
+          it 'accepts the param as a string' do
+            controller = controller_with_store(the_key: 'any value')
+            expect(controller).to set_store['the_key']
+          end
+
+          it 'accepts the param as a symbol' do
+            controller = controller_with_store(the_key: 'any value')
+            expect(controller).to set_store[:the_key]
+          end
         end
       end
 

--- a/spec/support/unit/shared_examples/set_session_or_flash.rb
+++ b/spec/support/unit/shared_examples/set_session_or_flash.rb
@@ -56,28 +56,14 @@ shared_examples_for 'set session or flash matcher' do
 
     context 'in the positive' do
       context 'if the given key is present in the store' do
-        context 'and controller set the key as a string' do
-          it 'accepts the param as a string' do
-            controller = controller_with_store('the_key' => 'any value')
-            expect(controller).to set_store['the_key']
-          end
-
-          it 'accepts the param as a symbol' do
-            controller = controller_with_store('the_key' => 'any value')
-            expect(controller).to set_store[:the_key]
-          end
+        it 'accepts the param as a string' do
+          controller = controller_with_store('the_key' => 'any value')
+          expect(controller).to set_store['the_key']
         end
 
-        context 'and controller set the key as a symbol' do
-          it 'accepts the param as a string' do
-            controller = controller_with_store(the_key: 'any value')
-            expect(controller).to set_store['the_key']
-          end
-
-          it 'accepts the param as a symbol' do
-            controller = controller_with_store(the_key: 'any value')
-            expect(controller).to set_store[:the_key]
-          end
+        it 'accepts the param as a symbol' do
+          controller = controller_with_store('the_key' => 'any value')
+          expect(controller).to set_store[:the_key]
         end
       end
 


### PR DESCRIPTION
This is a regression bug fix, on the previous version the matcher
accepts a string or a symbol as a param.

This commit brings back this behavior.

closes #728 