### PR TITLE
Run formatter documentation when running a single file

### DIFF
--- a/spec/unit_spec_helper.rb
+++ b/spec/unit_spec_helper.rb
@@ -30,6 +30,10 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
+  if config.files_to_run.one?
+    config.default_formatter = 'doc'
+  end
+
   config.mock_with :rspec
 
   if config.respond_to?(:infer_spec_type_from_file_location!)


### PR DESCRIPTION
Today if we run a single file or spec like `callback_matcher_spec.rb` or `callback_matcher_spec.rb:12` the formatter is the default dot.

With this config when we run a single file or spec the formatter is the documentation and when we run the suite the formatter is the default dot.

I think this is good when we are working since we have the documentation output when we are doing the TDD and the regular formatter on running all suite.