### PR TITLE
Remove cucumber.yml

### DIFF
--- a/cucumber.yml
+++ b/cucumber.yml
@@ -1,1 +1,0 @@
-without_spring: --tags ~@spring


### PR DESCRIPTION
Since we are using the [RSpec for acceptance tests](https://github.com/thoughtbot/shoulda-matchers/commit/3fb4cdb3b7bf531c94ce6c725d18f5f108d373d3) we no longer need this
config.