### PR TITLE
Use the RSpec 3 syntax on RDocs

### DIFF
--- a/lib/shoulda/matchers/action_controller/callback_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/callback_matcher.rb
@@ -10,8 +10,8 @@ module Shoulda
       #
       #     # RSpec
       #     describe UsersController do
-      #       it { should use_before_filter(:authenticate_user!) }
-      #       it { should_not use_before_filter(:prevent_ssl) }
+      #       it { is_expected.to use_before_filter(:authenticate_user!) }
+      #       it { is_expected.not_to use_before_filter(:prevent_ssl) }
       #     end
       #
       #     # Test::Unit
@@ -35,8 +35,8 @@ module Shoulda
       #
       #     # RSpec
       #     describe IssuesController do
-      #       it { should use_after_filter(:log_activity) }
-      #       it { should_not use_after_filter(:destroy_user) }
+      #       it { is_expected.to use_after_filter(:log_activity) }
+      #       it { is_expected.not_to use_after_filter(:destroy_user) }
       #     end
       #
       #     # Test::Unit
@@ -60,8 +60,8 @@ module Shoulda
       #
       #     # RSpec
       #     describe UsersController do
-      #       it { should use_before_action(:authenticate_user!) }
-      #       it { should_not use_before_action(:prevent_ssl) }
+      #       it { is_expected.to use_before_action(:authenticate_user!) }
+      #       it { is_expected.not_to use_before_action(:prevent_ssl) }
       #     end
       #
       #     # Test::Unit
@@ -85,8 +85,8 @@ module Shoulda
       #
       #     # RSpec
       #     describe IssuesController do
-      #       it { should use_after_action(:log_activity) }
-      #       it { should_not use_after_action(:destroy_user) }
+      #       it { is_expected.to use_after_action(:log_activity) }
+      #       it { is_expected.not_to use_after_action(:destroy_user) }
       #     end
       #
       #     # Test::Unit
@@ -110,8 +110,8 @@ module Shoulda
       #
       #     # RSpec
       #     describe ChangesController do
-      #       it { should use_around_filter(:wrap_in_transaction) }
-      #       it { should_not use_around_filter(:save_view_context) }
+      #       it { is_expected.to use_around_filter(:wrap_in_transaction) }
+      #       it { is_expected.not_to use_around_filter(:save_view_context) }
       #     end
       #
       #     # Test::Unit
@@ -135,8 +135,8 @@ module Shoulda
       #
       #     # RSpec
       #     describe ChangesController do
-      #       it { should use_around_action(:wrap_in_transaction) }
-      #       it { should_not use_around_action(:save_view_context) }
+      #       it { is_expected.to use_around_action(:wrap_in_transaction) }
+      #       it { is_expected.not_to use_around_action(:save_view_context) }
       #     end
       #
       #     # Test::Unit

--- a/lib/shoulda/matchers/action_controller/filter_param_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/filter_param_matcher.rb
@@ -11,7 +11,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe ApplicationController do
-      #       it { should filter_param(:secret_key) }
+      #       it { is_expected.to filter_param(:secret_key) }
       #     end
       #
       #     # Test::Unit

--- a/lib/shoulda/matchers/action_controller/permit_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/permit_matcher.rb
@@ -37,7 +37,7 @@ module Shoulda
       #     # RSpec
       #     describe UsersController do
       #       it do
-      #         should permit(:first_name, :last_name, :email, :password).
+      #         is_expected.to permit(:first_name, :last_name, :email, :password).
       #           for(:create).
       #           on(:user)
       #       end
@@ -83,7 +83,7 @@ module Shoulda
       #       end
       #
       #       it do
-      #         should permit(:first_name, :last_name, :email, :password).
+      #         is_expected.to permit(:first_name, :last_name, :email, :password).
       #           for(:update, params: { id: 1 }).
       #           on(:user)
       #       end
@@ -136,7 +136,7 @@ module Shoulda
       #       end
       #
       #       it do
-      #         should permit(:activated).
+      #         is_expected.to permit(:activated).
       #           for(:toggle, params: { id: 1 }, verb: :put).
       #           on(:user)
       #       end

--- a/lib/shoulda/matchers/action_controller/redirect_to_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/redirect_to_matcher.rb
@@ -18,8 +18,8 @@ module Shoulda
       #       describe 'GET #show' do
       #         before { get :show }
       #
-      #         it { should redirect_to(posts_path) }
-      #         it { should redirect_to(action: :index) }
+      #         it { is_expected.to redirect_to(posts_path) }
+      #         it { is_expected.to redirect_to(action: :index) }
       #       end
       #     end
       #

--- a/lib/shoulda/matchers/action_controller/render_template_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/render_template_matcher.rb
@@ -19,8 +19,8 @@ module Shoulda
       #       describe 'GET #show' do
       #         before { get :show }
       #
-      #         it { should render_template('show') }
-      #         it { should render_template(partial: 'sidebar') }
+      #         it { is_expected.to render_template('show') }
+      #         it { is_expected.to render_template(partial: 'sidebar') }
       #       end
       #     end
       #

--- a/lib/shoulda/matchers/action_controller/render_with_layout_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/render_with_layout_matcher.rb
@@ -15,7 +15,7 @@ module Shoulda
       #       describe 'GET #show' do
       #         before { get :show }
       #
-      #         it { should render_with_layout('posts') }
+      #         it { is_expected.to render_with_layout('posts') }
       #       end
       #     end
       #
@@ -42,7 +42,7 @@ module Shoulda
       #       describe 'GET #sidebar' do
       #         before { get :sidebar }
       #
-      #         it { should_not render_with_layout }
+      #         it { is_expected.not_to render_with_layout }
       #       end
       #     end
       #

--- a/lib/shoulda/matchers/action_controller/rescue_from_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/rescue_from_matcher.rb
@@ -18,7 +18,7 @@ module Shoulda
       #     # RSpec
       #     describe ApplicationController do
       #       it do
-      #         should rescue_from(ActiveRecord::RecordNotFound).
+      #         is_expected.to rescue_from(ActiveRecord::RecordNotFound).
       #           with(:handle_not_found)
       #       end
       #     end

--- a/lib/shoulda/matchers/action_controller/respond_with_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/respond_with_matcher.rb
@@ -17,7 +17,7 @@ module Shoulda
       #       describe 'GET #index' do
       #         before { get :index }
       #
-      #         it { should respond_with(403) }
+      #         it { is_expected.to respond_with(403) }
       #       end
       #     end
       #
@@ -43,7 +43,7 @@ module Shoulda
       #       describe 'DELETE #destroy' do
       #         before { delete :destroy }
       #
-      #         it { should respond_with(500..600) }
+      #         it { is_expected.to respond_with(500..600) }
       #       end
       #     end
       #
@@ -69,7 +69,7 @@ module Shoulda
       #       describe 'GET #show' do
       #         before { get :show }
       #
-      #         it { should respond_with(:locked) }
+      #         it { is_expected.to respond_with(:locked) }
       #       end
       #     end
       #

--- a/lib/shoulda/matchers/action_controller/route_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/route_matcher.rb
@@ -24,8 +24,8 @@ module Shoulda
       #
       #     # RSpec
       #     describe PostsController do
-      #       it { should route(:get, '/posts').to(action: :index) }
-      #       it { should route(:get, '/posts/1').to(action: :show, id: 1) }
+      #       it { is_expected.to route(:get, '/posts').to(action: :index) }
+      #       it { is_expected.to route(:get, '/posts/1').to(action: :show, id: 1) }
       #     end
       #
       #     # Test::Unit
@@ -39,12 +39,12 @@ module Shoulda
       #     # RSpec
       #     describe 'Routing' do
       #       it do
-      #         should route(:get, '/posts').
+      #         is_expected.to route(:get, '/posts').
       #           to(controller: :posts, action: :index)
       #       end
       #
       #       it do
-      #         should route(:get, '/posts/1').
+      #         is_expected.to route(:get, '/posts/1').
       #           to('posts#show', id: 1)
       #       end
       #     end

--- a/lib/shoulda/matchers/action_controller/set_flash_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/set_flash_matcher.rb
@@ -20,13 +20,13 @@ module Shoulda
       #       describe 'GET #index' do
       #         before { get :index }
       #
-      #         it { should set_flash }
+      #         it { is_expected.to set_flash }
       #       end
       #
       #       describe 'DELETE #destroy' do
       #         before { delete :destroy }
       #
-      #         it { should_not set_flash }
+      #         it { is_expected.not_to set_flash }
       #       end
       #     end
       #
@@ -62,8 +62,8 @@ module Shoulda
       #       describe 'GET #index' do
       #         before { get :index }
       #
-      #         it { should set_flash[:foo] }
-      #         it { should_not set_flash[:bar] }
+      #         it { is_expected.to set_flash[:foo] }
+      #         it { is_expected.not_to set_flash[:bar] }
       #       end
       #     end
       #
@@ -93,10 +93,10 @@ module Shoulda
       #       describe 'GET #index' do
       #         before { get :index }
       #
-      #         it { should set_flash.to('A candy bar') }
-      #         it { should set_flash.to(/bar/) }
-      #         it { should set_flash[:foo].to('bar') }
-      #         it { should_not set_flash[:foo].to('something else') }
+      #         it { is_expected.to set_flash.to('A candy bar') }
+      #         it { is_expected.to set_flash.to(/bar/) }
+      #         it { is_expected.to set_flash[:foo].to('bar') }
+      #         it { is_expected.not_to set_flash[:foo].to('something else') }
       #       end
       #     end
       #
@@ -128,9 +128,9 @@ module Shoulda
       #       describe 'GET #show' do
       #         before { get :show }
       #
-      #         it { should set_flash.now }
-      #         it { should set_flash[:foo].now }
-      #         it { should set_flash[:foo].to('bar').now }
+      #         it { is_expected.to set_flash.now }
+      #         it { is_expected.to set_flash[:foo].now }
+      #         it { is_expected.to set_flash[:foo].to('bar').now }
       #       end
       #     end
       #

--- a/lib/shoulda/matchers/action_controller/set_session_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/set_session_matcher.rb
@@ -20,13 +20,13 @@ module Shoulda
       #       describe 'GET #index' do
       #         before { get :index }
       #
-      #         it { should set_session }
+      #         it { is_expected.to set_session }
       #       end
       #
       #       describe 'DELETE #destroy' do
       #         before { delete :destroy }
       #
-      #         it { should_not set_session }
+      #         it { is_expected.not_to set_session }
       #       end
       #     end
       #
@@ -62,8 +62,8 @@ module Shoulda
       #       describe 'GET #index' do
       #         before { get :index }
       #
-      #         it { should set_session[:foo] }
-      #         it { should_not set_session[:bar] }
+      #         it { is_expected.to set_session[:foo] }
+      #         it { is_expected.not_to set_session[:bar] }
       #       end
       #     end
       #
@@ -93,10 +93,10 @@ module Shoulda
       #       describe 'GET #index' do
       #         before { get :index }
       #
-      #         it { should set_session.to('A candy bar') }
-      #         it { should set_session.to(/bar/) }
-      #         it { should set_session[:foo].to('bar') }
-      #         it { should_not set_session[:foo].to('something else') }
+      #         it { is_expected.to set_session.to('A candy bar') }
+      #         it { is_expected.to set_session.to(/bar/) }
+      #         it { is_expected.to set_session[:foo].to('bar') }
+      #         it { is_expected.not_to set_session[:foo].to('something else') }
       #       end
       #     end
       #

--- a/lib/shoulda/matchers/active_model/allow_mass_assignment_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/allow_mass_assignment_of_matcher.rb
@@ -24,11 +24,11 @@ module Shoulda
       #
       #     # RSpec
       #     describe Post do
-      #       it { should allow_mass_assignment_of(:title) }
+      #       it { is_expected.to allow_mass_assignment_of(:title) }
       #     end
       #
       #     describe User do
-      #       it { should_not allow_mass_assignment_of(:encrypted_password) }
+      #       it { is_expected.not_to allow_mass_assignment_of(:encrypted_password) }
       #     end
       #
       #     # Test::Unit
@@ -57,7 +57,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Post do
-      #       it { should allow_mass_assignment_of(:title).as(:admin) }
+      #       it { is_expected.to allow_mass_assignment_of(:title).as(:admin) }
       #     end
       #
       #     # Test::Unit

--- a/lib/shoulda/matchers/active_model/allow_value_matcher.rb
+++ b/lib/shoulda/matchers/active_model/allow_value_matcher.rb
@@ -21,7 +21,7 @@ module Shoulda
       #     # RSpec
       #     describe UserProfile do
       #       it do
-      #         should allow_value('http://foo.com', 'http://bar.com/baz').
+      #         is_expected.to allow_value('http://foo.com', 'http://bar.com/baz').
       #           for(:website_url)
       #       end
       #     end
@@ -50,12 +50,12 @@ module Shoulda
       #
       #     describe UserProfile do
       #       # One assertion: 'buz' and 'bar' will not be tested
-      #       it { should_not allow_value('fiz', 'buz', 'bar').for(:website_url) }
+      #       it { is_expected.not_to allow_value('fiz', 'buz', 'bar').for(:website_url) }
       #
       #       # Three assertions, all tested separately
-      #       it { should_not allow_value('fiz').for(:website_url) }
-      #       it { should_not allow_value('buz').for(:website_url) }
-      #       it { should_not allow_value('bar').for(:website_url) }
+      #       it { is_expected.not_to allow_value('fiz').for(:website_url) }
+      #       it { is_expected.not_to allow_value('buz').for(:website_url) }
+      #       it { is_expected.not_to allow_value('bar').for(:website_url) }
       #     end
       #
       # #### Qualifiers
@@ -76,7 +76,7 @@ module Shoulda
       #     # RSpec
       #     describe UserProfile do
       #       it do
-      #         should allow_value('2013-01-01').
+      #         is_expected.to allow_value('2013-01-01').
       #           for(:birthday_as_string).
       #           on(:create)
       #       end
@@ -105,7 +105,7 @@ module Shoulda
       #     # RSpec
       #     describe UserProfile do
       #       it do
-      #         should allow_value('open', 'closed').
+      #         is_expected.to allow_value('open', 'closed').
       #           for(:state).
       #           with_message('State must be open or closed')
       #       end
@@ -132,7 +132,7 @@ module Shoulda
       #     # RSpec
       #     describe UserProfile do
       #       it do
-      #         should allow_value('open', 'closed').
+      #         is_expected.to allow_value('open', 'closed').
       #           for(:state).
       #           with_message(/open or closed/)
       #       end
@@ -168,7 +168,7 @@ module Shoulda
       #     # RSpec
       #     describe UserProfile do
       #       it do
-      #         should allow_value('Broncos', 'Titans').
+      #         is_expected.to allow_value('Broncos', 'Titans').
       #           for(:sports_team).
       #           with_message('Must be either a Broncos or Titans fan',
       #             against: :chosen_sports_team

--- a/lib/shoulda/matchers/active_model/have_secure_password_matcher.rb
+++ b/lib/shoulda/matchers/active_model/have_secure_password_matcher.rb
@@ -16,7 +16,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe User do
-      #       it { should have_secure_password }
+      #       it { is_expected.to have_secure_password }
       #     end
       #
       #     # Test::Unit

--- a/lib/shoulda/matchers/active_model/validate_absence_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_absence_of_matcher.rb
@@ -13,7 +13,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Artillery do
-      #       it { should validate_absence_of(:arms) }
+      #       it { is_expected.to validate_absence_of(:arms) }
       #     end
       #
       #     # Test::Unit
@@ -36,7 +36,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Artillery do
-      #       it { should validate_absence_of(:arms).on(:create) }
+      #       it { is_expected.to validate_absence_of(:arms).on(:create) }
       #     end
       #
       #     # Test::Unit
@@ -59,7 +59,7 @@ module Shoulda
       #     # RSpec
       #     describe Artillery do
       #       it do
-      #         should validate_absence_of(:arms).
+      #         is_expected.to validate_absence_of(:arms).
       #           with_message("We're fresh outta arms here, soldier!")
       #       end
       #     end

--- a/lib/shoulda/matchers/active_model/validate_acceptance_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_acceptance_of_matcher.rb
@@ -13,7 +13,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Registration do
-      #       it { should validate_acceptance_of(:eula) }
+      #       it { is_expected.to validate_acceptance_of(:eula) }
       #     end
       #
       #     # Test::Unit
@@ -37,7 +37,7 @@ module Shoulda
       #     # RSpec
       #     describe Registration do
       #       it do
-      #         should validate_acceptance_of(:terms_of_service).
+      #         is_expected.to validate_acceptance_of(:terms_of_service).
       #           on(:create)
       #       end
       #     end
@@ -62,7 +62,7 @@ module Shoulda
       #     # RSpec
       #     describe Registration do
       #       it do
-      #         should validate_acceptance_of(:terms_of_service).
+      #         is_expected.to validate_acceptance_of(:terms_of_service).
       #           with_message('You must accept the terms of service')
       #       end
       #     end

--- a/lib/shoulda/matchers/active_model/validate_confirmation_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_confirmation_of_matcher.rb
@@ -13,7 +13,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe User do
-      #       it { should validate_confirmation_of(:email) }
+      #       it { is_expected.to validate_confirmation_of(:email) }
       #     end
       #
       #     # Test::Unit
@@ -36,7 +36,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe User do
-      #       it { should validate_confirmation_of(:password).on(:create) }
+      #       it { is_expected.to validate_confirmation_of(:password).on(:create) }
       #     end
       #
       #     # Test::Unit
@@ -59,7 +59,7 @@ module Shoulda
       #     # RSpec
       #     describe User do
       #       it do
-      #         should validate_confirmation_of(:password).
+      #         is_expected.to validate_confirmation_of(:password).
       #           with_message('Please re-enter your password')
       #       end
       #     end

--- a/lib/shoulda/matchers/active_model/validate_exclusion_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_exclusion_of_matcher.rb
@@ -18,7 +18,7 @@ module Shoulda
       #     # RSpec
       #     describe Game do
       #       it do
-      #         should validate_exclusion_of(:supported_os).
+      #         is_expected.to validate_exclusion_of(:supported_os).
       #           in_array(['Mac', 'Linux'])
       #       end
       #     end
@@ -41,7 +41,7 @@ module Shoulda
       #     # RSpec
       #     describe Game do
       #       it do
-      #         should validate_exclusion_of(:floors_with_enemies).
+      #         is_expected.to validate_exclusion_of(:floors_with_enemies).
       #           in_range(5..8)
       #       end
       #     end
@@ -70,7 +70,7 @@ module Shoulda
       #     # RSpec
       #     describe Game do
       #       it do
-      #         should validate_exclusion_of(:weapon).
+      #         is_expected.to validate_exclusion_of(:weapon).
       #           in_array(['pistol', 'paintball gun', 'stick']).
       #           on(:create)
       #       end
@@ -99,7 +99,7 @@ module Shoulda
       #     # RSpec
       #     describe Game do
       #       it do
-      #         should validate_exclusion_of(:weapon).
+      #         is_expected.to validate_exclusion_of(:weapon).
       #           in_array(['pistol', 'paintball gun', 'stick']).
       #           with_message('You chose a puny weapon')
       #       end

--- a/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
@@ -19,7 +19,7 @@ module Shoulda
       #     # RSpec
       #     describe Issue do
       #       it do
-      #         should validate_inclusion_of(:state).
+      #         is_expected.to validate_inclusion_of(:state).
       #           in_array(%w(open resolved unresolved))
       #       end
       #     end
@@ -41,7 +41,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Issue do
-      #       it { should validate_inclusion_of(:state).in_range(1..5) }
+      #       it { is_expected.to validate_inclusion_of(:state).in_range(1..5) }
       #     end
       #
       #     # Test::Unit
@@ -57,13 +57,13 @@ module Shoulda
       # one of these three values. That means there isn't any way we can refute
       # this logic in a test. Hence, this will produce a warning:
       #
-      #     it { should validate_inclusion_of(:imported).in_array([true, false]) }
+      #     it { is_expected.to validate_inclusion_of(:imported).in_array([true, false]) }
       #
       # The only case where `validate_inclusion_of` *could* be appropriate is
       # for ensuring that a boolean column accepts nil, but we recommend
       # using `allow_value` instead, like this:
       #
-      #     it { should allow_value(nil).for(:imported) }
+      #     it { is_expected.to allow_value(nil).for(:imported) }
       #
       # #### Qualifiers
       #
@@ -81,7 +81,7 @@ module Shoulda
       #     # RSpec
       #     describe Issue do
       #       it do
-      #         should validate_inclusion_of(:severity).
+      #         is_expected.to validate_inclusion_of(:severity).
       #           in_array(%w(low medium high)).
       #           on(:create)
       #       end
@@ -110,7 +110,7 @@ module Shoulda
       #     # RSpec
       #     describe Issue do
       #       it do
-      #         should validate_inclusion_of(:severity).
+      #         is_expected.to validate_inclusion_of(:severity).
       #           in_array(%w(low medium high)).
       #           with_message('Severity must be low, medium, or high')
       #       end
@@ -146,7 +146,7 @@ module Shoulda
       #     # RSpec
       #     describe Person do
       #       it do
-      #         should validate_inclusion_of(:age).
+      #         is_expected.to validate_inclusion_of(:age).
       #           in_range(0..65).
       #           with_low_message('You do not receive any benefits')
       #       end
@@ -182,7 +182,7 @@ module Shoulda
       #     # RSpec
       #     describe Person do
       #       it do
-      #         should validate_inclusion_of(:age).
+      #         is_expected.to validate_inclusion_of(:age).
       #           in_range(0..21).
       #           with_high_message("You're too old for this stuff")
       #       end
@@ -212,7 +212,7 @@ module Shoulda
       #     # RSpec
       #     describe Issue do
       #       it do
-      #         should validate_inclusion_of(:state).
+      #         is_expected.to validate_inclusion_of(:state).
       #           in_array(%w(open resolved unresolved)).
       #           allow_nil
       #       end
@@ -242,7 +242,7 @@ module Shoulda
       #     # RSpec
       #     describe Issue do
       #       it do
-      #         should validate_inclusion_of(:state).
+      #         is_expected.to validate_inclusion_of(:state).
       #           in_array(%w(open resolved unresolved)).
       #           allow_blank
       #       end

--- a/lib/shoulda/matchers/active_model/validate_length_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_length_of_matcher.rb
@@ -19,7 +19,7 @@ module Shoulda
       #     # RSpec
       #     describe User do
       #       it do
-      #         should validate_length_of(:password).
+      #         is_expected.to validate_length_of(:password).
       #           is_at_least(10).
       #           on(:create)
       #       end
@@ -48,7 +48,7 @@ module Shoulda
       #     # RSpec
       #
       #     describe User do
-      #       it { should validate_length_of(:bio).is_at_least(15) }
+      #       it { is_expected.to validate_length_of(:bio).is_at_least(15) }
       #     end
       #
       #     # Test::Unit
@@ -72,7 +72,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe User do
-      #       it { should validate_length_of(:status_update).is_at_most(140) }
+      #       it { is_expected.to validate_length_of(:status_update).is_at_most(140) }
       #     end
       #
       #     # Test::Unit
@@ -95,7 +95,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe User do
-      #       it { should validate_length_of(:favorite_superhero).is_equal_to(6) }
+      #       it { is_expected.to validate_length_of(:favorite_superhero).is_equal_to(6) }
       #     end
       #
       #     # Test::Unit
@@ -118,7 +118,7 @@ module Shoulda
       #     # RSpec
       #     describe User do
       #       it do
-      #         should validate_length_of(:password).
+      #         is_expected.to validate_length_of(:password).
       #           is_at_least(5).is_at_most(30)
       #       end
       #     end
@@ -145,7 +145,7 @@ module Shoulda
       #     # RSpec
       #     describe User do
       #       it do
-      #         should validate_length_of(:password).
+      #         is_expected.to validate_length_of(:password).
       #           is_at_least(10).
       #           with_message("Password isn't long enough")
       #       end
@@ -174,7 +174,7 @@ module Shoulda
       #     # RSpec
       #     describe User do
       #       it do
-      #         should validate_length_of(:secret_key).
+      #         is_expected.to validate_length_of(:secret_key).
       #           is_at_least(15).
       #           with_short_message('Secret key must be more than 15 characters')
       #       end
@@ -203,7 +203,7 @@ module Shoulda
       #     # RSpec
       #     describe User do
       #       it do
-      #         should validate_length_of(:secret_key).
+      #         is_expected.to validate_length_of(:secret_key).
       #           is_at_most(100).
       #           with_long_message('Secret key must be less than 100 characters')
       #       end

--- a/lib/shoulda/matchers/active_model/validate_numericality_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_numericality_of_matcher.rb
@@ -13,7 +13,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Person do
-      #       it { should validate_numericality_of(:gpa) }
+      #       it { is_expected.to validate_numericality_of(:gpa) }
       #     end
       #
       #     # Test::Unit
@@ -37,7 +37,7 @@ module Shoulda
       #     # RSpec
       #     describe Person do
       #       it do
-      #         should validate_numericality_of(:number_of_dependents).
+      #         is_expected.to validate_numericality_of(:number_of_dependents).
       #           on(:create)
       #       end
       #     end
@@ -62,7 +62,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Person do
-      #       it { should validate_numericality_of(:age).only_integer }
+      #       it { is_expected.to validate_numericality_of(:age).only_integer }
       #     end
       #
       #     # Test::Unit
@@ -87,7 +87,7 @@ module Shoulda
       #     # RSpec
       #     describe Person do
       #       it do
-      #         should validate_numericality_of(:number_of_cars).
+      #         is_expected.to validate_numericality_of(:number_of_cars).
       #           is_less_than(2)
       #       end
       #     end
@@ -115,7 +115,7 @@ module Shoulda
       #     # RSpec
       #     describe Person do
       #       it do
-      #         should validate_numericality_of(:birth_year).
+      #         is_expected.to validate_numericality_of(:birth_year).
       #           is_less_than_or_equal_to(1987)
       #       end
       #     end
@@ -141,7 +141,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Person do
-      #       it { should validate_numericality_of(:weight).is_equal_to(150) }
+      #       it { is_expected.to validate_numericality_of(:weight).is_equal_to(150) }
       #     end
       #
       #     # Test::Unit
@@ -166,7 +166,7 @@ module Shoulda
       #     # RSpec
       #     describe Person do
       #       it do
-      #         should validate_numericality_of(:height).
+      #         is_expected.to validate_numericality_of(:height).
       #           is_greater_than_or_equal_to(55)
       #       end
       #     end
@@ -193,7 +193,7 @@ module Shoulda
       #     # RSpec
       #     describe Person do
       #       it do
-      #         should validate_numericality_of(:legal_age).
+      #         is_expected.to validate_numericality_of(:legal_age).
       #           is_greater_than(21)
       #       end
       #     end
@@ -218,7 +218,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Person do
-      #       it { should validate_numericality_of(:birth_month).even }
+      #       it { is_expected.to validate_numericality_of(:birth_month).even }
       #     end
       #
       #     # Test::Unit
@@ -241,7 +241,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Person do
-      #       it { should validate_numericality_of(:birth_day).odd }
+      #       it { is_expected.to validate_numericality_of(:birth_day).odd }
       #     end
       #
       #     # Test::Unit
@@ -264,7 +264,7 @@ module Shoulda
       #     # RSpec
       #     describe Person do
       #       it do
-      #         should validate_numericality_of(:number_of_dependents).
+      #         is_expected.to validate_numericality_of(:number_of_dependents).
       #           with_message('Number of dependents must be a number')
       #       end
       #     end
@@ -288,7 +288,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Post do
-      #       it { should validate_numericality_of(:age).allow_nil }
+      #       it { is_expected.to validate_numericality_of(:age).allow_nil }
       #     end
       #
       #     # Test::Unit

--- a/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
@@ -13,7 +13,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Robot do
-      #       it { should validate_presence_of(:arms) }
+      #       it { is_expected.to validate_presence_of(:arms) }
       #     end
       #
       #     # Test::Unit
@@ -39,7 +39,7 @@ module Shoulda
       #     describe User do
       #       subject { User.new(password: '123456') }
       #
-      #       it { should validate_presence_of(:password) }
+      #       it { is_expected.to validate_presence_of(:password) }
       #     end
       #
       # the above test will raise an error like this:
@@ -70,7 +70,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Robot do
-      #       it { should validate_presence_of(:arms).on(:create) }
+      #       it { is_expected.to validate_presence_of(:arms).on(:create) }
       #     end
       #
       #     # Test::Unit
@@ -92,7 +92,7 @@ module Shoulda
       #     # RSpec
       #     describe Robot do
       #       it do
-      #         should validate_presence_of(:legs).
+      #         is_expected.to validate_presence_of(:legs).
       #           with_message('Robot has no legs')
       #       end
       #     end

--- a/lib/shoulda/matchers/active_record/accept_nested_attributes_for_matcher.rb
+++ b/lib/shoulda/matchers/active_record/accept_nested_attributes_for_matcher.rb
@@ -10,7 +10,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Car do
-      #       it { should accept_nested_attributes_for(:doors) }
+      #       it { is_expected.to accept_nested_attributes_for(:doors) }
       #     end
       #
       #     # Test::Unit (using Shoulda)
@@ -32,7 +32,7 @@ module Shoulda
       #     # RSpec
       #     describe Car do
       #       it do
-      #         should accept_nested_attributes_for(:mirrors).
+      #         is_expected.to accept_nested_attributes_for(:mirrors).
       #           allow_destroy(true)
       #       end
       #     end
@@ -54,7 +54,7 @@ module Shoulda
       #     # RSpec
       #     describe Car do
       #       it do
-      #         should accept_nested_attributes_for(:windows).
+      #         is_expected.to accept_nested_attributes_for(:windows).
       #           limit(3)
       #       end
       #     end
@@ -77,7 +77,7 @@ module Shoulda
       #     # RSpec
       #     describe Car do
       #       it do
-      #         should accept_nested_attributes_for(:engine).
+      #         is_expected.to accept_nested_attributes_for(:engine).
       #           update_only(true)
       #       end
       #     end

--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -12,7 +12,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Person do
-      #       it { should belong_to(:organization) }
+      #       it { is_expected.to belong_to(:organization) }
       #     end
       #
       #     # Test::Unit
@@ -29,7 +29,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Comment do
-      #       it { should belong_to(:commentable) }
+      #       it { is_expected.to belong_to(:commentable) }
       #     end
       #
       #     # Test::Unit
@@ -51,7 +51,7 @@ module Shoulda
       #     # RSpec
       #     describe Person do
       #       it do
-      #         should belong_to(:family).
+      #         is_expected.to belong_to(:family).
       #           conditions(everyone_is_perfect: false)
       #       end
       #     end
@@ -73,7 +73,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Person do
-      #       it { should belong_to(:previous_company).order('hired_on desc') }
+      #       it { is_expected.to belong_to(:previous_company).order('hired_on desc') }
       #     end
       #
       #     # Test::Unit
@@ -92,7 +92,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Person do
-      #       it { should belong_to(:ancient_city).class_name('City') }
+      #       it { is_expected.to belong_to(:ancient_city).class_name('City') }
       #     end
       #
       #     # Test::Unit
@@ -111,7 +111,7 @@ module Shoulda
       #     # RSpec
       #     describe Person do
       #       it do
-      #         should belong_to(:great_country).
+      #         is_expected.to belong_to(:great_country).
       #           with_primary_key('country_id')
       #       end
       #     end
@@ -133,7 +133,7 @@ module Shoulda
       #     # RSpec
       #     describe Person do
       #       it do
-      #         should belong_to(:great_country).
+      #         is_expected.to belong_to(:great_country).
       #           with_foreign_key('country_id')
       #       end
       #     end
@@ -154,7 +154,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Person do
-      #       it { should belong_to(:world).dependent(:destroy) }
+      #       it { is_expected.to belong_to(:world).dependent(:destroy) }
       #     end
       #
       #     # Test::Unit
@@ -166,7 +166,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Person do
-      #       it { should belong_to(:world).dependent(true) }
+      #       it { is_expected.to belong_to(:world).dependent(true) }
       #     end
       #
       # To assert that *no* `:dependent` option was specified, use `false`:
@@ -177,7 +177,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Person do
-      #       it { should belong_to(:company).dependent(false) }
+      #       it { is_expected.to belong_to(:company).dependent(false) }
       #     end
       #
       # ##### counter_cache
@@ -191,7 +191,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Person do
-      #       it { should belong_to(:organization).counter_cache(true) }
+      #       it { is_expected.to belong_to(:organization).counter_cache(true) }
       #     end
       #
       #     # Test::Unit
@@ -209,7 +209,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Person do
-      #       it { should belong_to(:organization).touch(true) }
+      #       it { is_expected.to belong_to(:organization).touch(true) }
       #     end
       #
       #     # Test::Unit
@@ -227,7 +227,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Account do
-      #       it { should belong_to(:bank).autosave(true) }
+      #       it { is_expected.to belong_to(:bank).autosave(true) }
       #     end
       #
       #     # Test::Unit
@@ -245,7 +245,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Person
-      #       it { should belong_to(:organization).inverse_of(:employees) }
+      #       it { is_expected.to belong_to(:organization).inverse_of(:employees) }
       #     end
       #
       #     # Test::Unit
@@ -268,7 +268,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Person do
-      #       it { should have_many(:friends) }
+      #       it { is_expected.to have_many(:friends) }
       #     end
       #
       #     # Test::Unit
@@ -289,7 +289,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Person do
-      #       it { should have_many(:coins).conditions(quality: 'mint') }
+      #       it { is_expected.to have_many(:coins).conditions(quality: 'mint') }
       #     end
       #
       #     # Test::Unit
@@ -308,7 +308,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Person do
-      #       it { should have_many(:shirts).order('color') }
+      #       it { is_expected.to have_many(:shirts).order('color') }
       #     end
       #
       #     # Test::Unit
@@ -327,7 +327,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Person do
-      #       it { should have_many(:hopes).class_name('Dream') }
+      #       it { is_expected.to have_many(:hopes).class_name('Dream') }
       #     end
       #
       #     # Test::Unit
@@ -345,7 +345,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Person do
-      #       it { should have_many(:worries).with_primary_key('worrier_id') }
+      #       it { is_expected.to have_many(:worries).with_primary_key('worrier_id') }
       #     end
       #
       #     # Test::Unit
@@ -363,7 +363,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Person do
-      #       it { should have_many(:worries).with_foreign_key('worrier_id') }
+      #       it { is_expected.to have_many(:worries).with_foreign_key('worrier_id') }
       #     end
       #
       #     # Test::Unit
@@ -381,7 +381,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Person do
-      #       it { should have_many(:secret_documents).dependent(:destroy) }
+      #       it { is_expected.to have_many(:secret_documents).dependent(:destroy) }
       #     end
       #
       #     # Test::Unit
@@ -400,7 +400,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Person do
-      #       it { should have_many(:acquaintances).through(:friends) }
+      #       it { is_expected.to have_many(:acquaintances).through(:friends) }
       #     end
       #
       #     # Test::Unit
@@ -420,7 +420,7 @@ module Shoulda
       #     # RSpec
       #     describe Person do
       #       it do
-      #         should have_many(:job_offers).
+      #         is_expected.to have_many(:job_offers).
       #           through(:friends).
       #           source(:opportunities)
       #       end
@@ -443,7 +443,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Person do
-      #       it { should have_many(:ideas).validate(false) }
+      #       it { is_expected.to have_many(:ideas).validate(false) }
       #     end
       #
       #     # Test::Unit
@@ -461,7 +461,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Player do
-      #       it { should have_many(:games).autosave(true) }
+      #       it { is_expected.to have_many(:games).autosave(true) }
       #     end
       #
       #     # Test::Unit
@@ -484,7 +484,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Person do
-      #       it { should have_one(:partner) }
+      #       it { is_expected.to have_one(:partner) }
       #     end
       #
       #     # Test::Unit
@@ -505,7 +505,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Person do
-      #       it { should have_one(:pet).conditions('weight < 80') }
+      #       it { is_expected.to have_one(:pet).conditions('weight < 80') }
       #     end
       #
       #     # Test::Unit
@@ -524,7 +524,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Person do
-      #       it { should have_one(:focus).order('priority desc') }
+      #       it { is_expected.to have_one(:focus).order('priority desc') }
       #     end
       #
       #     # Test::Unit
@@ -543,7 +543,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Person do
-      #       it { should have_one(:chance).class_name('Opportunity') }
+      #       it { is_expected.to have_one(:chance).class_name('Opportunity') }
       #     end
       #
       #     # Test::Unit
@@ -561,7 +561,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Person do
-      #       it { should have_one(:contract).dependent(:nullify) }
+      #       it { is_expected.to have_one(:contract).dependent(:nullify) }
       #     end
       #
       #     # Test::Unit
@@ -579,7 +579,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Person do
-      #       it { should have_one(:job).with_primary_key('worker_id') }
+      #       it { is_expected.to have_one(:job).with_primary_key('worker_id') }
       #     end
       #
       #     # Test::Unit
@@ -597,7 +597,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Person do
-      #       it { should have_one(:job).with_foreign_key('worker_id') }
+      #       it { is_expected.to have_one(:job).with_foreign_key('worker_id') }
       #     end
       #
       #     # Test::Unit
@@ -616,7 +616,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Person do
-      #       it { should have_one(:life).through(:partner) }
+      #       it { is_expected.to have_one(:life).through(:partner) }
       #     end
       #
       #     # Test::Unit
@@ -635,7 +635,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Person do
-      #       it { should have_one(:car).through(:partner).source(:vehicle) }
+      #       it { is_expected.to have_one(:car).through(:partner).source(:vehicle) }
       #     end
       #
       #     # Test::Unit
@@ -653,7 +653,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Person do
-      #       it { should have_one(:parking_card).validate(false) }
+      #       it { is_expected.to have_one(:parking_card).validate(false) }
       #     end
       #
       #     # Test::Unit
@@ -671,7 +671,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Account do
-      #       it { should have_one(:bank).autosave(true) }
+      #       it { is_expected.to have_one(:bank).autosave(true) }
       #     end
       #
       #     # Test::Unit
@@ -695,7 +695,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Person do
-      #       it { should have_and_belong_to_many(:awards) }
+      #       it { is_expected.to have_and_belong_to_many(:awards) }
       #     end
       #
       #     # Test::Unit
@@ -717,7 +717,7 @@ module Shoulda
       #     # RSpec
       #     describe Person do
       #       it do
-      #         should have_and_belong_to_many(:issues).
+      #         is_expected.to have_and_belong_to_many(:issues).
       #           conditions(difficulty: 'hard')
       #       end
       #     end
@@ -740,7 +740,7 @@ module Shoulda
       #     # RSpec
       #     describe Person do
       #       it do
-      #         should have_and_belong_to_many(:projects).
+      #         is_expected.to have_and_belong_to_many(:projects).
       #           order('time_spent')
       #       end
       #     end
@@ -763,7 +763,7 @@ module Shoulda
       #     # RSpec
       #     describe Person do
       #       it do
-      #         should have_and_belong_to_many(:places_visited).
+      #         is_expected.to have_and_belong_to_many(:places_visited).
       #           class_name('City')
       #       end
       #     end
@@ -786,7 +786,7 @@ module Shoulda
       #     # RSpec
       #     describe Person do
       #       it do
-      #         should have_and_belong_to_many(:issues).
+      #         is_expected.to have_and_belong_to_many(:issues).
       #           join_table('people_tickets')
       #       end
       #     end
@@ -808,7 +808,7 @@ module Shoulda
       #     # RSpec
       #     describe Person do
       #       it do
-      #         should have_and_belong_to_many(:interviews).
+      #         is_expected.to have_and_belong_to_many(:interviews).
       #           validate(false)
       #       end
       #     end
@@ -829,7 +829,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Publisher do
-      #       it { should have_and_belong_to_many(:advertisers).autosave(true) }
+      #       it { is_expected.to have_and_belong_to_many(:advertisers).autosave(true) }
       #     end
       #
       #     # Test::Unit

--- a/lib/shoulda/matchers/active_record/define_enum_for_matcher.rb
+++ b/lib/shoulda/matchers/active_record/define_enum_for_matcher.rb
@@ -10,7 +10,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Process do
-      #       it { should define_enum_for(:status) }
+      #       it { is_expected.to define_enum_for(:status) }
       #       end
       #     end
       #
@@ -33,7 +33,7 @@ module Shoulda
       #     # RSpec
       #     describe Process do
       #       it do
-      #         should define_enum_for(:status).
+      #         is_expected.to define_enum_for(:status).
       #           with([:running, :stopped, :suspended])
       #       end
       #     end

--- a/lib/shoulda/matchers/active_record/have_db_column_matcher.rb
+++ b/lib/shoulda/matchers/active_record/have_db_column_matcher.rb
@@ -14,7 +14,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Phone do
-      #       it { should have_db_column(:supported_ios_version) }
+      #       it { is_expected.to have_db_column(:supported_ios_version) }
       #     end
       #
       #     # Test::Unit
@@ -39,7 +39,7 @@ module Shoulda
       #     # RSpec
       #     describe Phone do
       #       it do
-      #         should have_db_column(:camera_aperture).of_type(:decimal)
+      #         is_expected.to have_db_column(:camera_aperture).of_type(:decimal)
       #       end
       #     end
       #
@@ -65,7 +65,7 @@ module Shoulda
       #     # RSpec
       #     describe Phone do
       #       it do
-      #         should have_db_column(:camera_aperture).
+      #         is_expected.to have_db_column(:camera_aperture).
       #           with_options(precision: 1, null: false)
       #       end
       #     end

--- a/lib/shoulda/matchers/active_record/have_db_index_matcher.rb
+++ b/lib/shoulda/matchers/active_record/have_db_index_matcher.rb
@@ -16,7 +16,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Blog do
-      #       it { should have_db_index(:user_id) }
+      #       it { is_expected.to have_db_index(:user_id) }
       #     end
       #
       #     # Test::Unit
@@ -42,7 +42,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Blog do
-      #       it { should have_db_index(:name).unique(true) }
+      #       it { is_expected.to have_db_index(:name).unique(true) }
       #     end
       #
       #     # Test::Unit
@@ -55,7 +55,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Blog do
-      #       it { should have_db_index(:name).unique }
+      #       it { is_expected.to have_db_index(:name).unique }
       #     end
       #
       #     # Test::Unit

--- a/lib/shoulda/matchers/active_record/have_readonly_attribute_matcher.rb
+++ b/lib/shoulda/matchers/active_record/have_readonly_attribute_matcher.rb
@@ -10,7 +10,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe User do
-      #       it { should have_readonly_attribute(:password) }
+      #       it { is_expected.to have_readonly_attribute(:password) }
       #     end
       #
       #     # Test::Unit

--- a/lib/shoulda/matchers/active_record/serialize_matcher.rb
+++ b/lib/shoulda/matchers/active_record/serialize_matcher.rb
@@ -9,7 +9,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Product do
-      #       it { should serialize(:customizations) }
+      #       it { is_expected.to serialize(:customizations) }
       #     end
       #
       #     # Test::Unit
@@ -40,7 +40,7 @@ module Shoulda
       #     # RSpec
       #     describe Product do
       #       it do
-      #         should serialize(:specifications).
+      #         is_expected.to serialize(:specifications).
       #           as(ProductSpecsSerializer)
       #       end
       #     end
@@ -72,7 +72,7 @@ module Shoulda
       #     # RSpec
       #     describe Product do
       #       it do
-      #         should serialize(:options).
+      #         is_expected.to serialize(:options).
       #           as_instance_of(ProductOptionsSerializer)
       #       end
       #     end

--- a/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
+++ b/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
@@ -15,7 +15,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Post do
-      #       it { should validate_uniqueness_of(:permalink) }
+      #       it { is_expected.to validate_uniqueness_of(:permalink) }
       #     end
       #
       #     # Test::Unit
@@ -50,7 +50,7 @@ module Shoulda
       # You may be tempted to test the model like this:
       #
       #     describe Post do
-      #       it { should validate_uniqueness_of(:title) }
+      #       it { is_expected.to validate_uniqueness_of(:title) }
       #     end
       #
       # However, running this test will fail with something like:
@@ -70,7 +70,7 @@ module Shoulda
       #     describe Post do
       #       describe "validations" do
       #         subject { Post.new(content: 'Here is the content') }
-      #         it { should validate_uniqueness_of(:title) }
+      #         it { is_expected.to validate_uniqueness_of(:title) }
       #       end
       #     end
       #
@@ -82,7 +82,7 @@ module Shoulda
       #     describe Post do
       #       describe "validations" do
       #         subject { FactoryGirl.build(:post) }
-      #         it { should validate_uniqueness_of(:title) }
+      #         it { is_expected.to validate_uniqueness_of(:title) }
       #       end
       #     end
       #
@@ -96,7 +96,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Post do
-      #       it { should validate_uniqueness_of(:title).on(:create) }
+      #       it { is_expected.to validate_uniqueness_of(:title).on(:create) }
       #     end
       #
       #     # Test::Unit
@@ -115,7 +115,7 @@ module Shoulda
       #     # RSpec
       #     describe Post do
       #       it do
-      #         should validate_uniqueness_of(:title).
+      #         is_expected.to validate_uniqueness_of(:title).
       #           with_message('Please choose another title')
       #       end
       #     end
@@ -138,7 +138,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Post do
-      #       it { should validate_uniqueness_of(:slug).scoped_to(:journal_id) }
+      #       it { is_expected.to validate_uniqueness_of(:slug).scoped_to(:journal_id) }
       #     end
       #
       #     # Test::Unit
@@ -159,7 +159,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Post do
-      #       it { should validate_uniqueness_of(:key).case_insensitive }
+      #       it { is_expected.to validate_uniqueness_of(:key).case_insensitive }
       #     end
       #
       #     # Test::Unit
@@ -177,7 +177,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Post do
-      #       it { should validate_uniqueness_of(:author_id).allow_nil }
+      #       it { is_expected.to validate_uniqueness_of(:author_id).allow_nil }
       #     end
       #
       #     # Test::Unit
@@ -197,7 +197,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Post do
-      #       it { should validate_uniqueness_of(:author_id).allow_blank }
+      #       it { is_expected.to validate_uniqueness_of(:author_id).allow_blank }
       #     end
       #
       #     # Test::Unit

--- a/lib/shoulda/matchers/independent/delegate_method_matcher.rb
+++ b/lib/shoulda/matchers/independent/delegate_method_matcher.rb
@@ -23,7 +23,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Courier do
-      #       it { should delegate_method(:deliver).to(:post_office) }
+      #       it { is_expected.to delegate_method(:deliver).to(:post_office) }
       #     end
       #
       #     # Test::Unit
@@ -43,7 +43,7 @@ module Shoulda
       #     end
       #
       #     describe Courier do
-      #       it { should delegate_method(:deliver).to(:post_office) }
+      #       it { is_expected.to delegate_method(:deliver).to(:post_office) }
       #     end
       #
       # To employ some terminology, we would say that Courier's #deliver method
@@ -74,7 +74,7 @@ module Shoulda
       #
       #     # RSpec
       #     describe Courier do
-      #       it { should delegate_method(:deliver).to(:post_office).as(:ship) }
+      #       it { is_expected.to delegate_method(:deliver).to(:post_office).as(:ship) }
       #     end
       #
       #     # Test::Unit
@@ -95,9 +95,9 @@ module Shoulda
       #
       #     # RSpec
       #     describe Page do
-      #       it { should delegate_method(:name).to(:site).with_prefix }
-      #       it { should delegate_method(:name).to(:site).with_prefix(true) }
-      #       it { should delegate_method(:title).to(:site).with_prefix(:root) }
+      #       it { is_expected.to delegate_method(:name).to(:site).with_prefix }
+      #       it { is_expected.to delegate_method(:name).to(:site).with_prefix(true) }
+      #       it { is_expected.to delegate_method(:title).to(:site).with_prefix(:root) }
       #     end
       #
       #     # Test::Unit
@@ -132,7 +132,7 @@ module Shoulda
       #     # RSpec
       #     describe Courier do
       #       it do
-      #         should delegate_method(:deliver_package).
+      #         is_expected.to delegate_method(:deliver_package).
       #           to(:post_office).
       #           with_arguments(expedited: true)
       #       end


### PR DESCRIPTION
RSpec 3 docs uses the `is_expected.to` over the `should` syntax. So I think we are good to go and update the docs to reflect the last RSpec version.