### PR TITLE
Drop support to RSpec 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Shoulda Matchers [![Gem Version][version-badge]][rubygems] [![Build Status][travis-badge]][travis] ![Downloads][downloads-badge]
 
-Shoulda Matchers provides RSpec- and Minitest-compatible one-liners that test
+Shoulda Matchers provides RSpec 3- and Minitest-compatible one-liners that test
 common Rails functionality. These tests would otherwise be much longer, more
 complex, and error-prone.
 
@@ -97,7 +97,7 @@ interested in the README for 2.8.0 instead.][2.8.0-README]**
 
 ## Installation
 
-### RSpec
+### RSpec 3
 
 Include `shoulda-matchers` in your Gemfile:
 

--- a/lib/shoulda/matchers/action_controller/callback_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/callback_matcher.rb
@@ -169,12 +169,10 @@ module Shoulda
         def failure_message
           "Expected that #{controller_class.name} would have :#{method_name} as a #{kind}_#{callback_type}"
         end
-        alias failure_message_for_should failure_message
 
         def failure_message_when_negated
           "Expected that #{controller_class.name} would not have :#{method_name} as a #{kind}_#{callback_type}"
         end
-        alias failure_message_for_should_not failure_message_when_negated
 
         def description
           "have :#{method_name} as a #{kind}_#{callback_type}"

--- a/lib/shoulda/matchers/action_controller/filter_param_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/filter_param_matcher.rb
@@ -38,12 +38,10 @@ module Shoulda
         def failure_message
           "Expected #{@key} to be filtered; filtered keys: #{filtered_keys.join(', ')}"
         end
-        alias failure_message_for_should failure_message
 
         def failure_message_when_negated
           "Did not expect #{@key} to be filtered"
         end
-        alias failure_message_for_should_not failure_message_when_negated
 
         def description
           "filter #{@key}"

--- a/lib/shoulda/matchers/action_controller/permit_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/permit_matcher.rb
@@ -215,12 +215,10 @@ module Shoulda
         def failure_message
           "Expected #{verb.upcase} ##{action} to #{expectation},\nbut #{reality}."
         end
-        alias failure_message_for_should failure_message
 
         def failure_message_when_negated
           "Expected #{verb.upcase} ##{action} not to #{expectation},\nbut it did."
         end
-        alias failure_message_for_should_not failure_message_when_negated
 
         protected
 

--- a/lib/shoulda/matchers/action_controller/redirect_to_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/redirect_to_matcher.rb
@@ -43,9 +43,6 @@ module Shoulda
       class RedirectToMatcher
         attr_reader :failure_message, :failure_message_when_negated
 
-        alias failure_message_for_should failure_message
-        alias failure_message_for_should_not failure_message_when_negated
-
         def initialize(url_or_description, context, &block)
           @url_block = nil
           @url = nil

--- a/lib/shoulda/matchers/action_controller/render_template_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/render_template_matcher.rb
@@ -34,7 +34,7 @@ module Shoulda
       #       end
       #     end
       #
-      # 
+      #
       #
       # @return [RenderTemplateMatcher]
       #
@@ -45,9 +45,6 @@ module Shoulda
       # @private
       class RenderTemplateMatcher
         attr_reader :failure_message, :failure_message_when_negated
-
-        alias failure_message_for_should failure_message
-        alias failure_message_for_should_not failure_message_when_negated
 
         def initialize(options, message, context)
           @options = options

--- a/lib/shoulda/matchers/action_controller/render_with_layout_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/render_with_layout_matcher.rb
@@ -88,12 +88,10 @@ module Shoulda
         def failure_message
           "Expected #{expectation}, but #{result}"
         end
-        alias failure_message_for_should failure_message
 
         def failure_message_when_negated
           "Did not expect #{expectation}, but #{result}"
         end
-        alias failure_message_for_should_not failure_message_when_negated
 
         def description
           description = 'render with '

--- a/lib/shoulda/matchers/action_controller/rescue_from_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/rescue_from_matcher.rb
@@ -62,12 +62,10 @@ module Shoulda
         def failure_message
           "Expected #{expectation}"
         end
-        alias failure_message_for_should failure_message
 
         def failure_message_when_negated
           "Did not expect #{expectation}"
         end
-        alias failure_message_for_should_not failure_message_when_negated
 
         protected
 

--- a/lib/shoulda/matchers/action_controller/respond_with_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/respond_with_matcher.rb
@@ -102,12 +102,10 @@ module Shoulda
         def failure_message
           "Expected #{expectation}"
         end
-        alias failure_message_for_should failure_message
 
         def failure_message_when_negated
           "Did not expect #{expectation}"
         end
-        alias failure_message_for_should_not failure_message_when_negated
 
         def description
           "respond with #{@status}"

--- a/lib/shoulda/matchers/action_controller/route_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/route_matcher.rb
@@ -99,9 +99,6 @@ module Shoulda
 
         attr_reader :failure_message, :failure_message_when_negated
 
-        alias failure_message_for_should failure_message
-        alias failure_message_for_should_not failure_message_when_negated
-
         def to(*args)
           @params = RouteParams.new(args).normalize
           self

--- a/lib/shoulda/matchers/active_model/allow_mass_assignment_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/allow_mass_assignment_of_matcher.rb
@@ -75,9 +75,6 @@ module Shoulda
       class AllowMassAssignmentOfMatcher
         attr_reader :failure_message, :failure_message_when_negated
 
-        alias failure_message_for_should failure_message
-        alias failure_message_for_should_not failure_message_when_negated
-
         def initialize(attribute)
           @attribute = attribute.to_s
           @options = {}

--- a/lib/shoulda/matchers/active_model/allow_value_matcher.rb
+++ b/lib/shoulda/matchers/active_model/allow_value_matcher.rb
@@ -272,12 +272,10 @@ module Shoulda
         def failure_message
           "Did not expect #{expectation},\ngot#{error_description}"
         end
-        alias failure_message_for_should failure_message
 
         def failure_message_when_negated
           "Expected #{expectation},\ngot#{error_description}"
         end
-        alias failure_message_for_should_not failure_message_when_negated
 
         def description
           validator.allow_description(allowed_values)

--- a/lib/shoulda/matchers/active_model/disallow_value_matcher.rb
+++ b/lib/shoulda/matchers/active_model/disallow_value_matcher.rb
@@ -34,12 +34,10 @@ module Shoulda
         def failure_message
           @allow_matcher.failure_message_when_negated
         end
-        alias failure_message_for_should failure_message
 
         def failure_message_when_negated
           @allow_matcher.failure_message
         end
-        alias failure_message_for_should_not failure_message_when_negated
 
         def strict
           @allow_matcher.strict

--- a/lib/shoulda/matchers/active_model/have_secure_password_matcher.rb
+++ b/lib/shoulda/matchers/active_model/have_secure_password_matcher.rb
@@ -34,8 +34,6 @@ module Shoulda
       class HaveSecurePasswordMatcher
         attr_reader :failure_message
 
-        alias failure_message_for_should failure_message
-
         CORRECT_PASSWORD = "aBcDe12345"
         INCORRECT_PASSWORD = "password"
 

--- a/lib/shoulda/matchers/active_model/numericality_matchers/comparison_matcher.rb
+++ b/lib/shoulda/matchers/active_model/numericality_matchers/comparison_matcher.rb
@@ -45,12 +45,10 @@ module Shoulda
           def failure_message
             last_failing_submatcher.failure_message
           end
-          alias failure_message_for_should failure_message
 
           def failure_message_when_negated
             last_failing_submatcher.failure_message_when_negated
           end
-          alias failure_message_for_should_not failure_message_when_negated
 
           private
 

--- a/lib/shoulda/matchers/active_model/numericality_matchers/numeric_type_matcher.rb
+++ b/lib/shoulda/matchers/active_model/numericality_matchers/numeric_type_matcher.rb
@@ -38,12 +38,10 @@ module Shoulda
           def failure_message
             @disallow_value_matcher.failure_message
           end
-          alias failure_message_for_should failure_message
 
           def failure_message_when_negated
             @disallow_value_matcher.failure_message_when_negated
           end
-          alias failure_message_for_should_not failure_message_when_negated
         end
       end
     end

--- a/lib/shoulda/matchers/active_model/validate_numericality_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_numericality_of_matcher.rb
@@ -412,12 +412,10 @@ module Shoulda
         def failure_message
           first_failing_submatcher.failure_message
         end
-        alias failure_message_for_should failure_message
 
         def failure_message_when_negated
           first_failing_submatcher.failure_message_when_negated
         end
-        alias failure_message_for_should_not failure_message_when_negated
 
         private
 

--- a/lib/shoulda/matchers/active_model/validation_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validation_matcher.rb
@@ -5,8 +5,6 @@ module Shoulda
       class ValidationMatcher
         attr_reader :failure_message
 
-        alias failure_message_for_should failure_message
-
         def initialize(attribute)
           @attribute = attribute
           @strict = false
@@ -27,7 +25,6 @@ module Shoulda
         def failure_message_when_negated
           @failure_message_when_negated || @failure_message
         end
-        alias failure_message_for_should_not failure_message_when_negated
 
         def matches?(subject)
           @subject = subject

--- a/lib/shoulda/matchers/active_record/accept_nested_attributes_for_matcher.rb
+++ b/lib/shoulda/matchers/active_record/accept_nested_attributes_for_matcher.rb
@@ -127,12 +127,10 @@ module Shoulda
         def failure_message
           "Expected #{expectation} (#{@problem})"
         end
-        alias failure_message_for_should failure_message
 
         def failure_message_when_negated
           "Did not expect #{expectation}"
         end
-        alias failure_message_for_should_not failure_message_when_negated
 
         def description
           description = "accepts_nested_attributes_for :#{@name}"

--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -944,12 +944,10 @@ module Shoulda
         def failure_message
           "Expected #{expectation} (#{missing_options})"
         end
-        alias failure_message_for_should failure_message
 
         def failure_message_when_negated
           "Did not expect #{expectation}"
         end
-        alias failure_message_for_should_not failure_message_when_negated
 
         def matches?(subject)
           @subject = subject

--- a/lib/shoulda/matchers/active_record/have_db_column_matcher.rb
+++ b/lib/shoulda/matchers/active_record/have_db_column_matcher.rb
@@ -118,12 +118,10 @@ module Shoulda
         def failure_message
           "Expected #{expectation} (#{@missing})"
         end
-        alias failure_message_for_should failure_message
 
         def failure_message_when_negated
           "Did not expect #{expectation}"
         end
-        alias failure_message_for_should_not failure_message_when_negated
 
         def description
           desc = "have db column named #{@column}"

--- a/lib/shoulda/matchers/active_record/have_db_index_matcher.rb
+++ b/lib/shoulda/matchers/active_record/have_db_index_matcher.rb
@@ -89,12 +89,10 @@ module Shoulda
         def failure_message
           "Expected #{expectation} (#{@missing})"
         end
-        alias failure_message_for_should failure_message
 
         def failure_message_when_negated
           "Did not expect #{expectation}"
         end
-        alias failure_message_for_should_not failure_message_when_negated
 
         def description
           if @options.key?(:unique)

--- a/lib/shoulda/matchers/active_record/have_readonly_attribute_matcher.rb
+++ b/lib/shoulda/matchers/active_record/have_readonly_attribute_matcher.rb
@@ -32,9 +32,6 @@ module Shoulda
 
         attr_reader :failure_message, :failure_message_when_negated
 
-        alias failure_message_for_should failure_message
-        alias failure_message_for_should_not failure_message_when_negated
-
         def matches?(subject)
           @subject = subject
           if readonly_attributes.include?(@attribute)

--- a/lib/shoulda/matchers/active_record/serialize_matcher.rb
+++ b/lib/shoulda/matchers/active_record/serialize_matcher.rb
@@ -114,12 +114,10 @@ module Shoulda
         def failure_message
           "Expected #{expectation} (#{@missing})"
         end
-        alias failure_message_for_should failure_message
 
         def failure_message_when_negated
           "Did not expect #{expectation}"
         end
-        alias failure_message_for_should_not failure_message_when_negated
 
         def description
           description = "serialize :#{@name}"

--- a/lib/shoulda/matchers/independent/delegate_method_matcher.rb
+++ b/lib/shoulda/matchers/independent/delegate_method_matcher.rb
@@ -230,12 +230,10 @@ module Shoulda
             "#{formatted_delegate_object_reader_method_name(include_module: true)}:" +
             formatted_calls_on_delegate_object
         end
-        alias failure_message_for_should failure_message
 
         def failure_message_when_negated
           "Expected #{class_under_test} not to #{description}, but it did"
         end
-        alias failure_message_for_should_not failure_message_when_negated
 
         protected
 


### PR DESCRIPTION
Since on 3.0 we [no more](https://github.com/thoughtbot/shoulda-matchers/issues/519#issuecomment-115524811) [support RSpec 2](https://github.com/thoughtbot/shoulda-matchers/blob/master/NEWS.md#backward-incompatible-changes) I think we can remove the alias that is defined to keep RSpec 2 legacy protocol.