### PR TITLE
Require DoubleSpeak from DelegateMethodMatcher

### DIFF
--- a/lib/shoulda/matchers/independent/delegate_method_matcher.rb
+++ b/lib/shoulda/matchers/independent/delegate_method_matcher.rb
@@ -1,3 +1,5 @@
+require 'shoulda/matchers/doublespeak'
+
 module Shoulda
   module Matchers
     module Independent


### PR DESCRIPTION
This makes it possible to require 'shoulda/matchers/independent' from
within a spec_helper file without 1) requiring all of Shoulda and 2)
also requiring DoubleSpeak, which is a dependency that should already
be handled.
