### PR TITLE
Keep consistency on allow_blank and allow_nil qualifiers

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
@@ -302,13 +302,13 @@ EOT
           self
         end
 
-        def allow_blank(allow_blank = true)
-          @options[:allow_blank] = allow_blank
+        def allow_blank
+          @options[:allow_blank] = true
           self
         end
 
-        def allow_nil(allow_nil = true)
-          @options[:allow_nil] = allow_nil
+        def allow_nil
+          @options[:allow_nil] = true
           self
         end
 


### PR DESCRIPTION
After some [discussion](https://github.com/thoughtbot/shoulda-matchers/pull/722) was decided that these qualifiers do not accept any parameter.

Closes #721 
