### PR TITLE
Fix `now` qualifier on `set_flash` when is called after the key and expected message is set

### DIFF
--- a/lib/shoulda/matchers/action_controller/set_flash_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/set_flash_matcher.rb
@@ -175,6 +175,9 @@ module Shoulda
         def now
           store = FlashStore.now
           @underlying_matcher = SetSessionOrFlashMatcher.new(store)
+          if key
+            @underlying_matcher[key]
+          end
           self
         end
 
@@ -184,6 +187,7 @@ module Shoulda
         end
 
         def [](key)
+          @key = key
           underlying_matcher[key]
           self
         end
@@ -195,7 +199,7 @@ module Shoulda
 
         protected
 
-        attr_reader :underlying_matcher
+        attr_reader :underlying_matcher, :key
       end
     end
   end

--- a/lib/shoulda/matchers/action_controller/set_flash_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/set_flash_matcher.rb
@@ -175,9 +175,8 @@ module Shoulda
         def now
           store = FlashStore.now
           @underlying_matcher = SetSessionOrFlashMatcher.new(store)
-          if key
-            @underlying_matcher[key]
-          end
+          @underlying_matcher[key]
+          @underlying_matcher.to(expected_value)
           self
         end
 
@@ -193,13 +192,14 @@ module Shoulda
         end
 
         def to(expected_value = nil, &block)
+          @expected_value = expected_value
           underlying_matcher.to(expected_value, &block)
           self
         end
 
         protected
 
-        attr_reader :underlying_matcher, :key
+        attr_reader :underlying_matcher, :key, :expected_value
       end
     end
   end

--- a/lib/shoulda/matchers/action_controller/set_session_or_flash_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/set_session_or_flash_matcher.rb
@@ -13,7 +13,9 @@ module Shoulda
         end
 
         def [](key)
-          @key = key
+          if key
+            @key = key
+          end
           self
         end
 
@@ -26,7 +28,9 @@ module Shoulda
 
             @expected_value = context.instance_eval(&block)
           else
-            @expected_value = expected_value
+            if expected_value
+              @expected_value = expected_value
+            end
           end
 
           self

--- a/spec/unit/shoulda/matchers/action_controller/set_flash_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/action_controller/set_flash_matcher_spec.rb
@@ -40,4 +40,22 @@ describe Shoulda::Matchers::ActionController::SetFlashMatcher, type: :controller
       expect(controller).not_to set_flash.now['key for flash']
     end
   end
+
+  context 'when the now qualifier is called after the key is set' do
+    it 'does not match when controller set flash' do
+      controller = build_fake_response do
+        flash['key for flash'] = 'value for flash'
+      end
+
+      expect(controller).not_to set_flash['key for flash'].now
+    end
+
+    it 'match when controller set flash.now' do
+      controller = build_fake_response do
+        flash.now['key for flash.now'] = 'value for flash.now'
+      end
+
+      expect(controller).to set_flash['key for flash.now'].now
+    end
+  end
 end

--- a/spec/unit/shoulda/matchers/action_controller/set_flash_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/action_controller/set_flash_matcher_spec.rb
@@ -58,4 +58,30 @@ describe Shoulda::Matchers::ActionController::SetFlashMatcher, type: :controller
       expect(controller).to set_flash['key for flash.now'].now
     end
   end
+
+  context 'when the now qualifier is called after the to is called' do
+    it 'does not match when controller set flash' do
+      controller = build_fake_response do
+        flash['to for flash'] = 'value for flash'
+      end
+
+      expect(controller).not_to set_flash['to for flash'].to('value for flash').now
+    end
+
+    it 'match when controller set flash.now' do
+      controller = build_fake_response do
+        flash.now['to for flash.now'] = 'value for flash.now'
+      end
+
+      expect(controller).to set_flash['to for flash.now'].to('value for flash.now').now
+    end
+
+    it 'does not match when controller set flash.now with a different message' do
+      controller = build_fake_response do
+        flash.now['to for flash.now'] = 'value for flash.now'
+      end
+
+      expect(controller).not_to set_flash['to for flash.now'].to('other message').now
+    end
+  end
 end


### PR DESCRIPTION
Closes  #750

When the `now` qualifier is called after the `[]` and `to`, example:

```
set_flash['to for flash.now'].to('value for flash.now').now
```

Is istantiated a new matcher(SetSessionOrFlashMatcher different from the one that is instantiated on the initialize) that does not know about the `[]` and `to` value that was set before the `now` is called.

This fixes this behavior passing the params explicitly to the matcher SetSessionOrFlashMatcher instantiated on `now`.