### PR TITLE
set_flash.now works only if called before any other qualifier

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -88,6 +88,8 @@
     `set_session['foo']` instead. ([535fe05])
   * `set_session['key'].to(nil)` will no longer pass when the key in question
     has not been set yet. ([535fe05])
+  * `set_flash[:foo].now` is no longer valid syntax, please use
+    `set_flash.now[:foo]` instead.
 
 * Change behavior of `validate_uniqueness_of` when the matcher is not
   qualified with any scopes, but your validation is. Previously the following

--- a/spec/unit/shoulda/matchers/action_controller/set_flash_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/action_controller/set_flash_matcher_spec.rb
@@ -40,4 +40,24 @@ describe Shoulda::Matchers::ActionController::SetFlashMatcher, type: :controller
       expect(controller).not_to set_flash.now['key for flash']
     end
   end
+
+  context 'when the now qualifier is called after the key is set' do
+    it 'raises a error' do
+      controller = build_fake_response
+
+      expect do
+        expect(controller).to set_flash['key for flash.now'].now
+      end.to raise_error(described_class::QualiferOrderError, /`now` qualifier/)
+    end
+  end
+
+  context 'when the now qualifier is called after the to qualifier' do
+    it 'raises a error' do
+      controller = build_fake_response
+
+      expect do
+        expect(controller).to set_flash.to('value for flash').now
+      end.to raise_error(described_class::QualiferOrderError, /`now` qualifier/)
+    end
+  end
 end


### PR DESCRIPTION
In the 3.0.0 `set_flash[:foo].now` is no longer a valid syntax, only the
`set_flash.now[:foo]` is valid [1].

Since this can create a false positive when people updating, we will raise a
exception to make the things more explicit.

[1]: https://github.com/thoughtbot/shoulda-matchers/pull/752