### PR TITLE
Prefix partial name with underscore

### DIFF
--- a/lib/shoulda/matchers/action_controller/render_template_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/render_template_matcher.rb
@@ -20,7 +20,7 @@ module Shoulda
       #         before { get :show }
       #
       #         it { should render_template('show') }
-      #         it { should render_template(partial: 'sidebar') }
+      #         it { should render_template(partial: '_sidebar') }
       #       end
       #     end
       #
@@ -30,7 +30,7 @@ module Shoulda
       #         setup { get :show }
       #
       #         should render_template('show')
-      #         should render_template(partial: 'sidebar')
+      #         should render_template(partial: '_sidebar')
       #       end
       #     end
       #


### PR DESCRIPTION
If a partial's is not prefixed with an underscore a test would fail with a similar error message, as:

> Failure/Error: it { should render_template(partial: 'form') }
       expecting partial \<form> but action rendered <["expenses/_form", "_form"]>.
       Expected {"expenses/_form"=>1, "_form"=>1} to include "form".