### PR TITLE
Always use Rack::Utils::SYMBOL_TO_STATUS_CODE

### DIFF
--- a/lib/shoulda/matchers/action_controller/respond_with_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/respond_with_matcher.rb
@@ -133,11 +133,7 @@ module Shoulda
           when :missing  then 404
           when :error    then 500..599
           when Symbol
-            if defined?(::Rack::Utils::SYMBOL_TO_STATUS_CODE)
-              ::Rack::Utils::SYMBOL_TO_STATUS_CODE[potential_symbol]
-            else
-              ::ActionController::Base::SYMBOL_TO_STATUS_CODE[potential_symbol]
-            end
+            ::Rack::Utils::SYMBOL_TO_STATUS_CODE[potential_symbol]
           else
             potential_symbol
           end


### PR DESCRIPTION
Always use `Rack::Utils::SYMBOL_TO_STATUS_CODE`.

Rails doesn't have this functionaly from 3.0.0. https://github.com/rails/rails/commit/a1bf2f96ce6f086de8519e344ee7e396ae3da9bb
