### PR TITLE
Fix permit docs for shoulda-context

### DIFF
--- a/lib/shoulda/matchers/action_controller/permit_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/permit_matcher.rb
@@ -62,9 +62,10 @@ module Shoulda
       #             password: 'password'
       #           }
       #         }
-      #         should permit(:first_name, :last_name, :email, :password).
+      #         assert_accepts permit(:first_name, :last_name, :email, :password).
       #           for(:create, params: params).
-      #           on(:user)
+      #           on(:user),
+      #           subject
       #       end
       #     end
       #
@@ -132,9 +133,10 @@ module Shoulda
       #             password: 'password'
       #           }
       #         }
-      #         should permit(:first_name, :last_name, :email, :password).
+      #         assert_accepts permit(:first_name, :last_name, :email, :password).
       #           for(:update, params: params).
-      #           on(:user)
+      #           on(:user),
+      #           subject
       #       end
       #     end
       #
@@ -189,9 +191,10 @@ module Shoulda
       #
       #       should "(for PUT #toggle) restrict parameters on :user to :activated" do
       #         params = { id: 1, user: { activated: true } }
-      #         should permit(:activated).
+      #         assert_accepts permit(:activated).
       #           for(:toggle, params: params, verb: :put).
-      #           on(:user)
+      #           on(:user),
+      #           subject
       #       end
       #     end
       #

--- a/lib/shoulda/matchers/action_controller/permit_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/permit_matcher.rb
@@ -308,16 +308,8 @@ module Shoulda
           end
         end
 
-        def permit_called?
-          actual_permitted_parameter_names.any?
-        end
-
         def unpermitted_parameter_names
           expected_permitted_parameter_names - actual_permitted_parameter_names
-        end
-
-        def verified_permitted_parameter_names
-          expected_permitted_parameter_names & actual_permitted_parameter_names
         end
 
         def ensure_action_and_verb_present!

--- a/lib/shoulda/matchers/action_controller/permit_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/permit_matcher.rb
@@ -62,10 +62,10 @@ module Shoulda
       #             password: 'password'
       #           }
       #         }
-      #         assert_accepts permit(:first_name, :last_name, :email, :password).
+      #         matcher = permit(:first_name, :last_name, :email, :password).
       #           for(:create, params: params).
       #           on(:user),
-      #           subject
+      #         assert_accepts matcher, subject
       #       end
       #     end
       #
@@ -133,10 +133,10 @@ module Shoulda
       #             password: 'password'
       #           }
       #         }
-      #         assert_accepts permit(:first_name, :last_name, :email, :password).
+      #         matcher = permit(:first_name, :last_name, :email, :password).
       #           for(:update, params: params).
       #           on(:user),
-      #           subject
+      #         assert_accepts matcher, subject
       #       end
       #     end
       #
@@ -191,10 +191,10 @@ module Shoulda
       #
       #       should "(for PUT #toggle) restrict parameters on :user to :activated" do
       #         params = { id: 1, user: { activated: true } }
-      #         assert_accepts permit(:activated).
+      #         matcher = permit(:activated).
       #           for(:toggle, params: params, verb: :put).
-      #           on(:user),
-      #           subject
+      #           on(:user)
+      #         assert_accepts matcher, subject
       #       end
       #     end
       #


### PR DESCRIPTION
`should` is not a valid method inside a `should` block, so we have to use `assert_accepts` instead. This lets us use any variables from the setup block, as opposed to a bare `should` which requires us to know all parameters up front.