### PR TITLE
Do not apply .railsrc when generating testing environment

### DIFF
--- a/spec/support/acceptance/helpers/step_helpers.rb
+++ b/spec/support/acceptance/helpers/step_helpers.rb
@@ -61,7 +61,7 @@ module AcceptanceTests
     end
 
     def create_rails_application
-      command = "bundle exec rails new #{fs.project_directory} --skip-bundle"
+      command = "bundle exec rails new #{fs.project_directory} --skip-bundle --no-rc"
 
       run_command!(command) do |runner|
         runner.directory = nil

--- a/spec/support/unit/rails_application.rb
+++ b/spec/support/unit/rails_application.rb
@@ -78,7 +78,7 @@ module UnitTests
     end
 
     def rails_new
-      run_command! %W(rails new #{fs.project_directory} --skip-bundle)
+      run_command! %W(rails new #{fs.project_directory} --skip-bundle --no-rc)
     end
 
     def fix_available_locales_warning


### PR DESCRIPTION
Getting ready to submit a patch/pull-request for this gem and I had trouble setting up and running the testing environment on this repository. I managed to trace the issues to the fact that it the command runner was shelling out with a *rails new* and applying my ~/.railsrc options.

Simple fix here is to just add the *--no-rc* flag to the *rails new* calls to maintain consistent generation of the unit and acceptance rails test applications.