### PR TITLE
support for ignoring_interference_by_writer on validate_length_of

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_length_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_length_of_matcher.rb
@@ -302,6 +302,12 @@ module Shoulda
           self
         end
 
+        protected
+
+        def ignoring_interference_by_writer?
+          @ignoring_interference_by_writer
+        end
+
         private
 
         def translate_messages!
@@ -364,11 +370,15 @@ module Shoulda
         end
 
         def allows_length_of?(length, message)
-          allows_value_of(string_of_length(length), message)
+          allows_value_of(string_of_length(length), message) do |allow|
+            allow.ignoring_interference_by_writer if ignoring_interference_by_writer?
+          end
         end
 
         def disallows_length_of?(length, message)
-          disallows_value_of(string_of_length(length), message)
+          disallows_value_of(string_of_length(length), message) do |disallow|
+            disallow.ignoring_interference_by_writer if ignoring_interference_by_writer?
+          end
         end
 
         def string_of_length(length)

--- a/lib/shoulda/matchers/active_model/validate_length_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_length_of_matcher.rb
@@ -231,6 +231,7 @@ module Shoulda
           @options = {}
           @short_message = nil
           @long_message = nil
+          @ignoring_interference_by_writer = false
         end
 
         def is_at_least(length)
@@ -294,6 +295,11 @@ module Shoulda
           super(subject)
           translate_messages!
           lower_bound_matches? && upper_bound_matches?
+        end
+
+        def ignoring_interference_by_writer
+          @ignoring_interference_by_writer = true
+          self
         end
 
         private

--- a/spec/unit/shoulda/matchers/active_model/validate_length_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_length_of_matcher_spec.rb
@@ -161,6 +161,28 @@ describe Shoulda::Matchers::ActiveModel::ValidateLengthOfMatcher, type: :model d
     end
   end
 
+  context 'an attribute with some type of normalization on it' do
+    subject do
+      define_model(:example, attr: :string) do
+        validates_length_of :attr, is: 4
+        validates_numericality_of :attr
+
+        def attr=(value)
+          value = value.respond_to?(:upcase) ? value.upcase : value
+          write_attribute(:attr, value)
+        end
+      end.new
+    end
+
+    context 'when ignoring_interference_by_writer is not specified' do
+      it 'should raise CouldNotSetAttributeError' do
+        expect do
+          validate_length_of(:attr).is_equal_to(4).matches?(subject)
+        end.to raise_error(Shoulda::Matchers::ActiveModel::AllowValueMatcher::CouldNotSetAttributeError)
+      end
+    end
+  end
+
   def validating_length(options = {})
     define_model(:example, attr: :string) do
       validates_length_of :attr, options

--- a/spec/unit/shoulda/matchers/active_model/validate_length_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_length_of_matcher_spec.rb
@@ -176,9 +176,21 @@ describe Shoulda::Matchers::ActiveModel::ValidateLengthOfMatcher, type: :model d
 
     context 'when ignoring_interference_by_writer is not specified' do
       it 'should raise CouldNotSetAttributeError' do
-        expect do
-          validate_length_of(:attr).is_equal_to(4).matches?(subject)
-        end.to raise_error(Shoulda::Matchers::ActiveModel::AllowValueMatcher::CouldNotSetAttributeError)
+        expect {
+          is_expected.to validate_length_of(:attr).is_equal_to(4)
+        }.to raise_error(
+          Shoulda::Matchers::ActiveModel::AllowValueMatcher::CouldNotSetAttributeError
+        )
+      end
+    end
+
+    context 'when ignoring_interference_by_writer is specified' do
+      it 'should not raise CouldNotSetAttributeError' do
+        expect {
+          is_expected.to validate_length_of(:attr).is_equal_to(4).ignoring_interference_by_writer
+        }.to_not raise_error(
+          # Shoulda::Matchers::ActiveModel::AllowValueMatcher::CouldNotSetAttributeError
+        )
       end
     end
   end

--- a/spec/unit/shoulda/matchers/active_model/validate_length_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_length_of_matcher_spec.rb
@@ -189,10 +189,7 @@ describe Shoulda::Matchers::ActiveModel::ValidateLengthOfMatcher, type: :model d
         expect {
           is_expected.to validate_length_of(:attr).is_equal_to(4).ignoring_interference_by_writer
         }.to_not raise_error(
-          # Will get the test passes with the below line commented out but it
-          # is then easy to unintentionally miss any other errors that may be
-          # happening.
-          # Shoulda::Matchers::ActiveModel::AllowValueMatcher::CouldNotSetAttributeError
+          Shoulda::Matchers::ActiveModel::AllowValueMatcher::CouldNotSetAttributeError
         )
       end
     end

--- a/spec/unit/shoulda/matchers/active_model/validate_length_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_length_of_matcher_spec.rb
@@ -189,6 +189,9 @@ describe Shoulda::Matchers::ActiveModel::ValidateLengthOfMatcher, type: :model d
         expect {
           is_expected.to validate_length_of(:attr).is_equal_to(4).ignoring_interference_by_writer
         }.to_not raise_error(
+          # Will get the test passes with the below line commented out but it
+          # is then easy to unintentionally miss any other errors that may be
+          # happening.
           # Shoulda::Matchers::ActiveModel::AllowValueMatcher::CouldNotSetAttributeError
         )
       end


### PR DESCRIPTION
I agree with @mcmire on pull request #800 that ignoring_interference_by_writer should not be blanketed into to all matchers by implementing in ValidationMatcher.

I want to see if this is more *likeable* implementation that could potentially be applied on a case-by-case basis to other matchers that may require it such as in the cases of #800, #799,  #786.

I think if it is the case that ignoring_interference_by_writer ends ups needing implementation in more then a few select matchers a pattern will emerge for DRYing it up if that does become an issue. I just want to run this approach past the maintainers before attempting this on other matchers within the gem.