### PR TITLE
WIP: Add `converting_values` to validation matchers

### DIFF
--- a/lib/shoulda/matchers/active_model/disallow_value_matcher.rb
+++ b/lib/shoulda/matchers/active_model/disallow_value_matcher.rb
@@ -8,6 +8,7 @@ module Shoulda
         extend Forwardable
 
         def_delegators :allow_matcher, :_after_setting_value
+
         def initialize(value)
           @allow_matcher = AllowValueMatcher.new(value)
         end
@@ -33,6 +34,11 @@ module Shoulda
 
         def ignoring_interference_by_writer
           @allow_matcher.ignoring_interference_by_writer
+          self
+        end
+
+        def converting_values(value_conversions)
+          @allow_matcher.converting_values(value_conversions)
           self
         end
 

--- a/lib/shoulda/matchers/active_model/validation_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validation_matcher.rb
@@ -10,6 +10,7 @@ module Shoulda
           @strict = false
           @failure_message = nil
           @failure_message_when_negated = nil
+          @allowed_value_conversions = {}
         end
 
         def on(context)
@@ -31,10 +32,16 @@ module Shoulda
           false
         end
 
+        def converting_values(value_conversions)
+          @allowed_value_conversions.merge!(value_conversions)
+          self
+        end
+
         private
 
         def allows_value_of(value, message = nil, &block)
           allow = allow_value_matcher(value, message)
+
           yield allow if block_given?
 
           if allow.matches?(@subject)
@@ -48,6 +55,7 @@ module Shoulda
 
         def disallows_value_of(value, message = nil, &block)
           disallow = disallow_value_matcher(value, message)
+
           yield disallow if block_given?
 
           if disallow.matches?(@subject)
@@ -71,6 +79,10 @@ module Shoulda
             matcher.strict
           end
 
+          unless @allowed_value_conversions.empty?
+            matcher.converting_values(@allowed_value_conversions)
+          end
+
           matcher
         end
 
@@ -84,6 +96,10 @@ module Shoulda
 
           if strict?
             matcher.strict
+          end
+
+          unless @allowed_value_conversions.empty?
+            matcher.converting_values(@allowed_value_conversions)
           end
 
           matcher

--- a/spec/support/unit/capture.rb
+++ b/spec/support/unit/capture.rb
@@ -2,6 +2,8 @@ module Kernel
   # #capture, #silence_stream, and #silence_stderr are deprecated after Rails
   # 4.2 and will be removed in 5.0, so just override them completely here
 
+  undef_method :capture
+
   def capture(stream)
     stream = stream.to_s
     captured_stream = Tempfile.new(stream)
@@ -18,6 +20,8 @@ module Kernel
     stream_io.reopen(origin_stream)
   end
 
+  undef_method :silence_stream
+
   def silence_stream(stream)
     old_stream = stream.dup
     stream.reopen(RbConfig::CONFIG['host_os'] =~ /mswin|mingw/ ? 'NUL:' : '/dev/null')
@@ -27,6 +31,8 @@ module Kernel
     stream.reopen(old_stream)
     old_stream.close
   end
+
+  undef_method :silence_stderr
 
   def silence_stderr
     silence_stream(STDERR) { yield }

--- a/spec/support/unit/record_validating_confirmation_builder.rb
+++ b/spec/support/unit/record_validating_confirmation_builder.rb
@@ -24,13 +24,12 @@ module UnitTests
       options[:message] = message
     end
 
-    def attribute_to_confirm
-      :attribute_to_confirm
+    def attribute
+      options.fetch(:attribute, :attribute)
     end
-    alias_method :attribute, :attribute_to_confirm
 
     def confirmation_attribute
-      :"#{attribute_to_confirm}_confirmation"
+      :"#{attribute}_confirmation"
     end
 
     def attribute_that_receives_error
@@ -44,7 +43,7 @@ module UnitTests
     private
 
     def create_model
-      _attribute = attribute_to_confirm
+      _attribute = attribute
       _options = options
 
       define_model(model_name, _attribute => :string) do

--- a/spec/unit/shoulda/matchers/active_model/allow_value_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/allow_value_matcher_spec.rb
@@ -384,5 +384,56 @@ describe Shoulda::Matchers::ActiveModel::AllowValueMatcher, type: :model do
         end
       end
     end
+
+    context 'when the matcher knows how incoming values get changed' do
+      context 'using #allow_value' do
+        it 'accepts (and does not raise an error)' do
+          model = define_active_model_class 'Example' do
+            attr_reader :name
+
+            def name=(name)
+              @name = name.upcase
+            end
+          end
+
+          record = model.new
+
+          assertion = lambda do
+            expect(record).
+              to allow_value('another name').
+              for(:name).
+              converting_value_to('ANOTHER NAME')
+          end
+
+          expect(&assertion).not_to raise_error
+        end
+      end
+
+      context 'using #allow_values' do
+        it 'accepts (and does not raise an error)' do
+          model = define_active_model_class 'Example' do
+            attr_reader :name
+
+            def name=(name)
+              @name = name.upcase
+            end
+          end
+
+          record = model.new
+
+          assertion = lambda do
+            expect(record).
+              to allow_values('first name', 'second name').
+              for(:name).
+              converting_values(
+                'first name' => 'FIRST NAME',
+                'second name' => 'SECOND NAME'
+              )
+          end
+
+          expect(&assertion).not_to raise_error
+        end
+      end
+    end
   end
 end

--- a/spec/unit/shoulda/matchers/active_model/validate_absence_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_absence_of_matcher_spec.rb
@@ -1,166 +1,164 @@
 require 'unit_spec_helper'
 
 describe Shoulda::Matchers::ActiveModel::ValidateAbsenceOfMatcher, type: :model do
-  if active_model_4_0?
-    def self.available_column_types
-      [
-        :string,
-        :text,
-        :integer,
-        :float,
-        :decimal,
-        :datetime,
-        :timestamp,
-        :time,
-        :date,
-        :binary
-      ]
+  def self.available_column_types
+    [
+      :string,
+      :text,
+      :integer,
+      :float,
+      :decimal,
+      :datetime,
+      :timestamp,
+      :time,
+      :date,
+      :binary
+    ]
+  end
+
+  context 'a model with an absence validation' do
+    it 'accepts' do
+      expect(validating_absence_of(:attr)).to validate_absence_of(:attr)
     end
 
-    context 'a model with an absence validation' do
-      it 'accepts' do
+    it 'does not override the default message with a present' do
+      expect(validating_absence_of(:attr)).to validate_absence_of(:attr).with_message(nil)
+    end
+
+    available_column_types.each do |type|
+      context "when column is of type #{type}" do
+        it "accepts" do
+          expect(validating_absence_of(:attr, {}, type: type)).
+            to validate_absence_of(:attr)
+        end
+      end
+    end
+  end
+
+  context 'a model without an absence validation' do
+    it 'rejects' do
+      model = define_model(:example, attr: :string).new
+      expect(model).not_to validate_absence_of(:attr)
+    end
+  end
+
+  context 'an ActiveModel class with an absence validation' do
+    it 'accepts' do
+      expect(active_model_validating_absence_of(:attr)).to validate_absence_of(:attr)
+    end
+
+    it 'does not override the default message with a blank' do
+      expect(active_model_validating_absence_of(:attr)).to validate_absence_of(:attr).with_message(nil)
+    end
+  end
+
+  context 'an ActiveModel class without an absence validation' do
+    it 'rejects' do
+      expect(active_model_with(:attr)).not_to validate_absence_of(:attr)
+    end
+
+    it 'provides the correct failure message' do
+      message = %{Expected errors to include "must be blank" when attr is set to "an arbitrary value",\ngot no errors}
+
+      expect { expect(active_model_with(:attr)).to validate_absence_of(:attr) }.to fail_with_message(message)
+    end
+  end
+
+  context 'a has_many association with an absence validation' do
+    it 'requires the attribute to not be set' do
+      expect(having_many(:children, absence: true)).to validate_absence_of(:children)
+    end
+  end
+
+  context 'a has_many association without an absence validation' do
+    it 'does not require the attribute to not be set' do
+      expect(having_many(:children, absence: false)).
+        not_to validate_absence_of(:children)
+    end
+  end
+
+  context 'an absent has_and_belongs_to_many association' do
+    it 'accepts' do
+      model = having_and_belonging_to_many(:children, absence: true)
+      expect(model).to validate_absence_of(:children)
+    end
+  end
+
+  context 'a non-absent has_and_belongs_to_many association' do
+    it 'rejects' do
+      model = having_and_belonging_to_many(:children, absence: false)
+      expect(model).not_to validate_absence_of(:children)
+    end
+  end
+
+  context "an i18n translation containing %{attribute} and %{model}" do
+    after { I18n.backend.reload! }
+
+    it "does not raise an exception" do
+      stub_translation("activerecord.errors.messages.present",
+                       "%{attribute} must be blank in a %{model}")
+
+      expect {
         expect(validating_absence_of(:attr)).to validate_absence_of(:attr)
-      end
+      }.to_not raise_exception
+    end
+  end
 
-      it 'does not override the default message with a present' do
-        expect(validating_absence_of(:attr)).to validate_absence_of(:attr).with_message(nil)
-      end
-
-      available_column_types.each do |type|
-        context "when column is of type #{type}" do
-          it "accepts" do
-            expect(validating_absence_of(:attr, {}, type: type)).
-              to validate_absence_of(:attr)
-          end
-        end
+  context "an attribute with a context-dependent validation" do
+    context "without the validation context" do
+      it "does not match" do
+        expect(validating_absence_of(:attr, on: :customisable)).not_to validate_absence_of(:attr)
       end
     end
 
-    context 'a model without an absence validation' do
-      it 'rejects' do
-        model = define_model(:example, attr: :string).new
-        expect(model).not_to validate_absence_of(:attr)
+    context "with the validation context" do
+      it "matches" do
+        expect(validating_absence_of(:attr, on: :customisable)).to validate_absence_of(:attr).on(:customisable)
       end
     end
+  end
 
-    context 'an ActiveModel class with an absence validation' do
-      it 'accepts' do
-        expect(active_model_validating_absence_of(:attr)).to validate_absence_of(:attr)
-      end
+  def validating_absence_of(attr, validation_options = {}, given_column_options = {})
+    default_column_options = { type: :string, options: {} }
+    column_options = default_column_options.merge(given_column_options)
 
-      it 'does not override the default message with a blank' do
-        expect(active_model_validating_absence_of(:attr)).to validate_absence_of(:attr).with_message(nil)
+    define_model :example, attr => column_options do
+      validates_absence_of attr, validation_options
+    end.new
+  end
+
+  def active_model_with(attr, &block)
+    define_active_model_class('Example', accessors: [attr], &block).new
+  end
+
+  def active_model_validating_absence_of(attr)
+    active_model_with(attr) do
+      validates_absence_of attr
+    end
+  end
+
+  def having_many(plural_name, options = {})
+    define_model plural_name.to_s.singularize
+    define_model :parent do
+      has_many plural_name
+      if options[:absence]
+        validates_absence_of plural_name
       end
+    end.new
+  end
+
+  def having_and_belonging_to_many(plural_name, options = {})
+    create_table 'children_parents', id: false do |t|
+      t.integer "#{plural_name.to_s.singularize}_id"
+      t.integer :parent_id
     end
 
-    context 'an ActiveModel class without an absence validation' do
-      it 'rejects' do
-        expect(active_model_with(:attr)).not_to validate_absence_of(:attr)
+    define_model plural_name.to_s.singularize
+    define_model :parent do
+      has_and_belongs_to_many plural_name
+      if options[:absence]
+        validates_absence_of plural_name
       end
-
-      it 'provides the correct failure message' do
-        message = %{Expected errors to include "must be blank" when attr is set to "an arbitrary value",\ngot no errors}
-
-        expect { expect(active_model_with(:attr)).to validate_absence_of(:attr) }.to fail_with_message(message)
-      end
-    end
-
-    context 'a has_many association with an absence validation' do
-      it 'requires the attribute to not be set' do
-        expect(having_many(:children, absence: true)).to validate_absence_of(:children)
-      end
-    end
-
-    context 'a has_many association without an absence validation' do
-      it 'does not require the attribute to not be set' do
-        expect(having_many(:children, absence: false)).
-          not_to validate_absence_of(:children)
-      end
-    end
-
-    context 'an absent has_and_belongs_to_many association' do
-      it 'accepts' do
-        model = having_and_belonging_to_many(:children, absence: true)
-        expect(model).to validate_absence_of(:children)
-      end
-    end
-
-    context 'a non-absent has_and_belongs_to_many association' do
-      it 'rejects' do
-        model = having_and_belonging_to_many(:children, absence: false)
-        expect(model).not_to validate_absence_of(:children)
-      end
-    end
-
-    context "an i18n translation containing %{attribute} and %{model}" do
-      after { I18n.backend.reload! }
-
-      it "does not raise an exception" do
-        stub_translation("activerecord.errors.messages.present",
-                         "%{attribute} must be blank in a %{model}")
-
-        expect {
-          expect(validating_absence_of(:attr)).to validate_absence_of(:attr)
-        }.to_not raise_exception
-      end
-    end
-
-    context "an attribute with a context-dependent validation" do
-      context "without the validation context" do
-        it "does not match" do
-          expect(validating_absence_of(:attr, on: :customisable)).not_to validate_absence_of(:attr)
-        end
-      end
-
-      context "with the validation context" do
-        it "matches" do
-          expect(validating_absence_of(:attr, on: :customisable)).to validate_absence_of(:attr).on(:customisable)
-        end
-      end
-    end
-
-    def validating_absence_of(attr, validation_options = {}, given_column_options = {})
-      default_column_options = { type: :string, options: {} }
-      column_options = default_column_options.merge(given_column_options)
-
-      define_model :example, attr => column_options do
-        validates_absence_of attr, validation_options
-      end.new
-    end
-
-    def active_model_with(attr, &block)
-      define_active_model_class('Example', accessors: [attr], &block).new
-    end
-
-    def active_model_validating_absence_of(attr)
-      active_model_with(attr) do
-        validates_absence_of attr
-      end
-    end
-
-    def having_many(plural_name, options = {})
-      define_model plural_name.to_s.singularize
-      define_model :parent do
-        has_many plural_name
-        if options[:absence]
-          validates_absence_of plural_name
-        end
-      end.new
-    end
-
-    def having_and_belonging_to_many(plural_name, options = {})
-      create_table 'children_parents', id: false do |t|
-        t.integer "#{plural_name.to_s.singularize}_id"
-        t.integer :parent_id
-      end
-
-      define_model plural_name.to_s.singularize
-      define_model :parent do
-        has_and_belongs_to_many plural_name
-        if options[:absence]
-          validates_absence_of plural_name
-        end
-      end.new
-    end
+    end.new
   end
 end

--- a/spec/unit/shoulda/matchers/active_model/validate_exclusion_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_exclusion_of_matcher_spec.rb
@@ -80,16 +80,26 @@ describe Shoulda::Matchers::ActiveModel::ValidateExclusionOfMatcher, type: :mode
         to eq 'ensure exclusion of attr in [true, "dog"]'
     end
 
-    def validating_exclusion(options)
-      define_model(:example, attr: :string) do
-        validates_exclusion_of :attr, options
-      end.new
+    def define_model_validating_exclusion(options)
+      options = options.dup
+      column_type = options.delete(:column_type) { :string }
+      super options.merge(column_type: column_type)
+    end
+  end
+
+  def define_model_validating_exclusion(options)
+    options = options.dup
+    attribute_name = options.delete(:attribute_name) { :attr }
+    column_type = options.delete(:column_type) { :integer }
+
+    define_model(:example, attribute_name => column_type) do |model|
+      model.validates_exclusion_of(attribute_name, options)
     end
   end
 
   def validating_exclusion(options)
-    define_model(:example, attr: :integer) do
-      validates_exclusion_of :attr, options
-    end.new
+    define_model_validating_exclusion(options).new
   end
+
+  alias_method :build_record_validating_exclusion, :validating_exclusion
 end

--- a/spec/unit/shoulda/matchers/active_model/validate_length_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_length_of_matcher_spec.rb
@@ -21,12 +21,84 @@ describe Shoulda::Matchers::ActiveModel::ValidateLengthOfMatcher, type: :model d
       expect(validating_length(minimum: 4)).
         to validate_length_of(:attr).is_at_least(4).with_short_message(nil)
     end
+
+    context 'when the writer method for the attribute changes incoming values' do
+      context 'and the matcher knows nothing of this' do
+        it 'raises a CouldNotSetAttributeError' do
+          record = build_record_validating_length(
+            attribute_name: :name,
+            convert_attribute_with: :upcase,
+            minimum: 4
+          )
+
+          assertion = lambda do
+            expect(record).to validate_length_of(:name).is_at_least(4)
+          end
+
+          expect(&assertion).to raise_error(
+            Shoulda::Matchers::ActiveModel::AllowValueMatcher::CouldNotSetAttributeError
+          )
+        end
+      end
+
+      context 'and the matcher knows how given values get changed' do
+        it 'accepts (and not raise an error)' do
+          record = build_record_validating_length(
+            attribute_name: :name,
+            convert_attribute_with: :upcase,
+            minimum: 4
+          )
+
+          expect(record).
+            to validate_length_of(:name).
+            is_at_least(4).
+            converting_values("xxx" => "XXX", "xxxx" => "XXXX")
+        end
+      end
+    end
   end
 
   context 'an attribute with a minimum length validation of 0' do
     it 'accepts ensuring the correct minimum length' do
       expect(validating_length(minimum: 0)).
         to validate_length_of(:attr).is_at_least(0)
+    end
+
+    context 'when the writer method for the attribute changes incoming values' do
+      context 'and the matcher knows nothing of this' do
+        it 'raises a CouldNotSetAttributeError' do
+          pending 'this should test that name accepts values > 0 length but does not'
+
+          record = build_record_validating_length(
+            attribute_name: :name,
+            convert_attribute_with: :upcase,
+            minimum: 0
+          )
+
+          assertion = lambda do
+            expect(record).to validate_length_of(:name).is_at_least(0)
+          end
+
+          expect(&assertion).to raise_error(
+            Shoulda::Matchers::ActiveModel::AllowValueMatcher::CouldNotSetAttributeError
+          )
+        end
+      end
+
+      context 'and the matcher knows how given values get changed' do
+        it 'accepts (and not raise an error)' do
+          record = build_record_validating_length(
+            attribute_name: :name,
+            convert_attribute_with: :upcase,
+            minimum: 0
+          )
+
+          expect(record).
+            to validate_length_of(:name).
+            is_at_least(0).
+            converting_values("x" => "X")
+        end
+      end
     end
   end
 
@@ -50,6 +122,41 @@ describe Shoulda::Matchers::ActiveModel::ValidateLengthOfMatcher, type: :model d
       expect(validating_length(maximum: 4)).
         to validate_length_of(:attr).is_at_most(4).with_long_message(nil)
     end
+
+    context 'when the writer method for the attribute changes incoming values' do
+      context 'and the matcher knows nothing of this' do
+        it 'raises a CouldNotSetAttributeError' do
+          record = build_record_validating_length(
+            attribute_name: :name,
+            convert_attribute_with: :upcase,
+            maximum: 4
+          )
+
+          assertion = lambda do
+            expect(record).to validate_length_of(:name).is_at_most(4)
+          end
+
+          expect(&assertion).to raise_error(
+            Shoulda::Matchers::ActiveModel::AllowValueMatcher::CouldNotSetAttributeError
+          )
+        end
+      end
+
+      context 'and the matcher knows how given values get changed' do
+        it 'accepts (and not raise an error)' do
+          record = build_record_validating_length(
+            attribute_name: :name,
+            convert_attribute_with: :upcase,
+            maximum: 4
+          )
+
+          expect(record).
+            to validate_length_of(:name).
+            is_at_most(4).
+            converting_values('xxxx' => 'XXXX', 'xxxxx' => 'XXXXX')
+        end
+      end
+    end
   end
 
   context 'an attribute with a required exact length' do
@@ -71,6 +178,45 @@ describe Shoulda::Matchers::ActiveModel::ValidateLengthOfMatcher, type: :model d
     it 'does not override the default message with a blank' do
       expect(validating_length(is: 4)).
         to validate_length_of(:attr).is_equal_to(4).with_message(nil)
+    end
+
+    context 'when the writer method for the attribute changes incoming values' do
+      context 'and the matcher knows nothing of this' do
+        it 'raises a CouldNotSetAttributeError' do
+          record = build_record_validating_length(
+            attribute_name: :name,
+            convert_attribute_with: :upcase,
+            is: 4
+          )
+
+          assertion = lambda do
+            expect(record).to validate_length_of(:name).is_equal_to(4)
+          end
+
+          expect(&assertion).to raise_error(
+            Shoulda::Matchers::ActiveModel::AllowValueMatcher::CouldNotSetAttributeError
+          )
+        end
+      end
+
+      context 'and the matcher knows how given values get changed' do
+        it 'accepts (and not raise an error)' do
+          record = build_record_validating_length(
+            attribute_name: :name,
+            convert_attribute_with: :upcase,
+            is: 4
+          )
+
+          expect(record).
+            to validate_length_of(:name).
+            is_equal_to(4).
+            converting_values(
+              'xxx' => 'XXX',
+              'xxxx' => 'XXXX',
+              'xxxxx' => 'XXXXX'
+            )
+        end
+      end
     end
   end
 
@@ -161,9 +307,24 @@ describe Shoulda::Matchers::ActiveModel::ValidateLengthOfMatcher, type: :model d
     end
   end
 
-  def validating_length(options = {})
-    define_model(:example, attr: :string) do
-      validates_length_of :attr, options
-    end.new
+  def define_model_validating_length(options = {})
+    options = options.dup
+    attribute_name = options.delete(:attribute_name) { :attr }
+
+    define_model(:example, attribute_name => :string) do |model|
+      model.validates_length_of(attribute_name, options)
+
+      if options.key?(:convert_attribute_with)
+        model.send(:define_method, "#{attribute_name}=") do |value|
+          super(value.send(options[:convert_attribute_with]))
+        end
+      end
+    end
   end
+
+  def validating_length(options = {})
+    define_model_validating_length(options).new
+  end
+
+  alias_method :build_record_validating_length, :validating_length
 end

--- a/spec/unit_spec_helper.rb
+++ b/spec/unit_spec_helper.rb
@@ -9,6 +9,7 @@ require File.expand_path('../support/unit/rails_application', __FILE__)
 $test_app = UnitTests::RailsApplication.new
 $test_app.create
 $test_app.load
+require 'active_record/base'
 
 ENV['BUNDLE_GEMFILE'] ||= app.gemfile_path
 ENV['RAILS_ENV'] = 'test'


### PR DESCRIPTION
This is WIP as I add tests for every matcher to which this applies.

I don't like the idea of blindly ignoring any CouldNotSetAttributeError that may arise from using a particular matcher. It may very well be that the exception could be raised for a good reason. So instead of doing this, I'm proposing a new matcher: `converting_values` (or its companion, `converting_value_to`, for `allow_value`). The idea here is that you give the matcher a whitelist of acceptable values and their converted forms. So if the matcher detects a CouldNotSetAttributeError, but the value it sent to the attribute and the value it got out are both in this whitelist, then it'll ignore the exception and move on.

I think this is preferable over supplying some kind of lambda (which I proposed in #799) because at that point you'd probably be copying or recreating the same logic you have in the model. I think that by explicitly listing the acceptable values it's far easier to control and it's more clear to someone reading the test what's going on.

- [x] numericality
- [x] absence
- [x] acceptance
- [x] confirmation
- [x] <del>exclusion</del> (producing a test case here is difficult) 
- [x] <del>inclusion</del> (producing a test case here is difficult)
- [x] length
- [x] <del>presence</del> (the only thing that's set on the record is nil, and we are handling value conversions here so as long as the final value is blank)
- [x] <del>uniqueness</del> (this actually creates a lot of problems so we should probably raise a specific error?)