### PR TITLE
Support symbol for `validates_numericality_of`

### DIFF
--- a/lib/shoulda/matchers/active_model/numericality_matchers/comparison_matcher.rb
+++ b/lib/shoulda/matchers/active_model/numericality_matchers/comparison_matcher.rb
@@ -45,6 +45,7 @@ module Shoulda
 
           def matches?(subject)
             @subject = subject
+            @expected_value = Symbol === @value ? @subject.__send__(@value) : @value
             all_bounds_correct?
           end
 
@@ -80,7 +81,7 @@ module Shoulda
             @_submatchers ||=
               comparison_combos.map do |diff, submatcher_method_name|
                 matcher = __send__(submatcher_method_name, diff, nil)
-                matcher.with_message(@message, values: { count: @value })
+                matcher.with_message(@message, values: { count: @expected_value })
                 matcher
               end
           end
@@ -123,7 +124,7 @@ module Shoulda
 
           def diffs_to_compare
             diff_to_compare = @numericality_matcher.diff_to_compare
-            values = [-1, 0, 1].map { |sign| @value + (diff_to_compare * sign) }
+            values = [-1, 0, 1].map { |sign| @expected_value + (diff_to_compare * sign) }
 
             if @numericality_matcher.given_numeric_column?
               values

--- a/lib/shoulda/matchers/active_model/numericality_matchers/comparison_matcher.rb
+++ b/lib/shoulda/matchers/active_model/numericality_matchers/comparison_matcher.rb
@@ -45,7 +45,13 @@ module Shoulda
 
           def matches?(subject)
             @subject = subject
-            @expected_value = Symbol === @value ? @subject.__send__(@value) : @value
+
+            if Symbol === @value
+              @expected_value = @subject.__send__(@value)
+            else
+              @expected_value = @value
+            end
+
             all_bounds_correct?
           end
 
@@ -81,7 +87,8 @@ module Shoulda
             @_submatchers ||=
               comparison_combos.map do |diff, submatcher_method_name|
                 matcher = __send__(submatcher_method_name, diff, nil)
-                matcher.with_message(@message, values: { count: @expected_value })
+                count = @expected_value
+                matcher.with_message(@message, values: { count: count })
                 matcher
               end
           end
@@ -124,7 +131,9 @@ module Shoulda
 
           def diffs_to_compare
             diff_to_compare = @numericality_matcher.diff_to_compare
-            values = [-1, 0, 1].map { |sign| @expected_value + (diff_to_compare * sign) }
+            values = [-1, 0, 1].map do |sign|
+              @expected_value + (diff_to_compare * sign)
+            end
 
             if @numericality_matcher.given_numeric_column?
               values

--- a/spec/unit/shoulda/matchers/active_model/numericality_matchers/comparison_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/numericality_matchers/comparison_matcher_spec.rb
@@ -38,6 +38,31 @@ describe Shoulda::Matchers::ActiveModel::NumericalityMatchers::ComparisonMatcher
     end
   end
 
+  shared_examples_for 'value symbol' do
+    let(:record_limit) { 2 }
+
+    it do
+      record = instance_with_validations(validation_qualifier => :limit)
+      record.limit = record_limit
+      matcher = build_matcher(operator: operator, value: :limit)
+      expect(record).to matcher
+    end
+
+    it do
+      record = instance_with_validations(validation_qualifier => :limit)
+      record.limit = record_limit
+      matcher = build_matcher(operator: operator, value: record_limit)
+      expect(record).to matcher
+    end
+
+    it do
+      record = instance_with_validations(validation_qualifier => record_limit)
+      record.limit = record_limit
+      matcher = build_matcher(operator: operator, value: :limit)
+      expect(record).to matcher
+    end
+  end
+
   context 'when initialized without correct numerical matcher' do
     it 'raises an ArgumentError' do
       numericality_matcher = double
@@ -48,6 +73,7 @@ describe Shoulda::Matchers::ActiveModel::NumericalityMatchers::ComparisonMatcher
 
   describe 'is_greater_than' do
     include_examples 'strict qualifier'
+    include_examples 'value symbol'
 
     it do
       record = instance_with_validations(greater_than: 1.5)
@@ -84,6 +110,7 @@ describe Shoulda::Matchers::ActiveModel::NumericalityMatchers::ComparisonMatcher
 
   describe 'is_greater_than_or_equal_to' do
     include_examples 'strict qualifier'
+    include_examples 'value symbol'
 
     it do
       record = instance_with_validations(greater_than_or_equal_to: 1.5)
@@ -120,6 +147,7 @@ describe Shoulda::Matchers::ActiveModel::NumericalityMatchers::ComparisonMatcher
 
   describe 'is_less_than' do
     include_examples 'strict qualifier'
+    include_examples 'value symbol'
 
     it do
       record = instance_with_validations(less_than: 1.5)
@@ -156,6 +184,7 @@ describe Shoulda::Matchers::ActiveModel::NumericalityMatchers::ComparisonMatcher
 
   describe 'is_less_than_or_equal_to' do
     include_examples 'strict qualifier'
+    include_examples 'value symbol'
 
     it do
       record = instance_with_validations(less_than_or_equal_to: 1.5)
@@ -192,6 +221,7 @@ describe Shoulda::Matchers::ActiveModel::NumericalityMatchers::ComparisonMatcher
 
   describe 'is_equal_to' do
     include_examples 'strict qualifier'
+    include_examples 'value symbol'
 
     it do
       record = instance_with_validations(equal_to: 1.5)
@@ -255,6 +285,10 @@ describe Shoulda::Matchers::ActiveModel::NumericalityMatchers::ComparisonMatcher
 
   def model_with_validations(options = {})
     define_model :example, attribute_name => :string do |model|
+      model.instance_eval do
+        attr_accessor :limit
+      end
+
       model.validates_numericality_of(attribute_name, options)
       model.attr_accessible(attribute_name)
     end


### PR DESCRIPTION
Have `vaidates_numericality_of` support symbols for feature request #688 
