### PR TITLE
838 add ignoring case sensitivity to uniqueness validation matcher

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,24 +1,49 @@
+# Contributing to shoulda-matchers
+
 We love contributions from the community! Here's a quick guide to making a pull
 request.
 
-## Overview
+1. If you haven't contributed before, please read and understand the [Code of
+   Conduct].
 
-0. If you haven't contributed before, please read and understand the [Code of
-Conduct].
+1. Ensure that you have a [working Ruby environment].
 
-1. Fork the repo.
+1. Fork the repo on GitHub, then clone it to your machine.
 
-2. Install [dependencies](#installing-dependencies).
+1. Now that you've cloned the repo, navigate to it and install dependencies by
+   running:
 
-3. Run the tests. We only take pull requests with passing tests, and it's great
-to know that you have a clean slate: `bundle && bundle exec rake`
+   ```
+   bundle install
+   ```
 
-4. If you're adding functionality or fixing a bug, add a failing test for the
-issue first.
+1. All tests should be passing, but it's a good idea to run them anyway
+   before starting any work:
+   
+   ```
+   bundle exec rake
+   ```
 
-5. Make the test pass.
+1. If you're adding functionality or fixing a bug, you'll want to add a
+   failing test for the issue first.
 
-6. Finally, push to your fork and submit a pull request.
+1. Now you can implement the feature or bugfix.
+
+1. Since we only accept pull requests with passing tests, it's a good idea to
+   run the tests again. Since you're probably working on a single file, you can
+   run the tests for that file with the following command:
+
+   ```
+   appraisal 4.2 rspec <path of test file to run>
+   ```
+
+   And to run the entire test suite again:
+   
+   ```
+   bundle exec rake
+   ```
+
+1. Finally, push to your fork and submit a pull request.
 
 At this point you're waiting on us. We try to respond to issues and pull
 requests within a few business days. We may suggest some changes to make to your
@@ -26,35 +51,27 @@ code to fit with our [code style] or the project style, or discuss alternate
 ways of addressing the issue in question. When we're happy with everything,
 we'll bring your changes into master. Now you're a contributor!
 
-## Installing Dependencies
+## Addendum: Setting up your environment
 
-### On Debian/Ubuntu-based systems
+### Installing dependencies (Linux only)
+
+#### Debian/Ubuntu
+
+Run this command to install necessary dependencies:
 
 ```
 sudo apt-get install -y ruby-dev libpq-dev libsqlite3-dev nodejs
 ```
 
-Ubuntu, as of 14.04, ships with Ruby 1.9.2. shoulda-matchers is only compatible
-with Ruby 2, so use your Ruby version manager of choice to install the latest
-version of Ruby (2.2.1 at the time of this writing).
+#### RedHat
 
-```
-# RVM
-rvm install 2.2
-rvm use 2.2
-
-# rbenv
-rbenv install 2.2.1
-rbenv shell 2.2.1
-```
-
-### On RedHat-based systems
+Run this command to install necessary dependencies:
 
 ```
 sudo yum install -y ruby-devel postgresql-devel sqlite-devel zlib-devel
 ```
 
-Also, install one of the JavaScript runtimes supported by [execjs]. For
+Then, install one of the JavaScript runtimes supported by [execjs]. For
 instance, to install node.js:
 
 ```
@@ -63,6 +80,14 @@ curl -sL https://rpm.nodesource.com/setup | bash -
 yum install -y nodejs
 ```
 
+### Installing Ruby (all platforms)
+
+shoulda-matchers is only compatible with Ruby 2.x. A `.ruby-version` is included
+in the repo, so if you're using one of the Ruby version manager tools, then you
+should be using (or have been prompted to install) the latest version of Ruby.
+If not, you'll want to do that.
+
+[working Ruby environment]: #addendum-setting-up-your-environment
 [Code of Conduct]: https://thoughtbot.com/open-source-code-of-conduct
 [code style]: https://github.com/thoughtbot/guides/tree/master/style
 [execjs]: https://github.com/sstephenson/execjs

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ group :test do
 end
 ```
 
-[Then, configure the gem to integrate with RSpec](#Configuration).
+[Then, configure the gem to integrate with RSpec](#configuration).
 
 Now you can use matchers in your tests. For instance a model test might look
 like this:
@@ -145,7 +145,7 @@ group :test do
 end
 ```
 
-[Then, configure the gem to integrate with Minitest](#Configuration).
+[Then, configure the gem to integrate with Minitest](#configuration).
 
 Now you can use matchers in your tests. For instance a model test might look
 like this:

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ complex, and error-prone.
   tests that an object forwards messages to other, internal objects by way of
   delegation.
 
-## Installation
+## Getting started
 
 ### RSpec
 
@@ -119,6 +119,42 @@ describe Person do
   it { should validate_presence_of(:name) }
 end
 ```
+
+#### Availability of matchers in various example groups
+
+Since shoulda-matchers provides four categories of matchers, there are four
+different levels where you can use these matchers:
+
+* ActiveRecord and ActiveModel matchers are available only in model example
+  groups, i.e., those tagged with `type: :model` or in files located under
+  `spec/models`.
+* ActionController matchers are available only in controller example groups,
+   i.e., those tagged with `type: :controller` or in files located under
+   `spec/controllers`.
+* The `route` matcher is available also in routing example groups, i.e., those
+  tagged with `type: :routing` or in files located under `spec/routing`.
+* Independent matchers are available in all example groups.
+
+**If you are using ActiveModel or ActiveRecord outside of Rails** and you want
+to use model matchers in certain example groups, you'll need to manually include
+them. Here's a good way of doing that:
+
+``` ruby
+RSpec.configure do |config|
+  config.include(Shoulda::Matchers::ActiveModel, type: :model)
+  config.include(Shoulda::Matchers::ActiveRecord, type: :model)
+end
+```
+
+Then you can say:
+
+``` ruby
+describe MyModel, type: :model do
+  # ...
+end
+```
+
+#### `should` vs `is_expected.to`
 
 Note that in this README and throughout the documentation we're using the
 `should` form of RSpec's one-liner syntax over `is_expected.to`. The `should`

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ group :test do
 end
 ```
 
-[Then, configure the gem to integrate with RSpec](#configuration).
+[Then, configure the gem to integrate with RSpec](#Configuration).
 
 Now you can use matchers in your tests. For instance a model test might look
 like this:
@@ -145,7 +145,7 @@ group :test do
 end
 ```
 
-[Then, configure the gem to integrate with Minitest](#configuration).
+[Then, configure the gem to integrate with Minitest](#Configuration).
 
 Now you can use matchers in your tests. For instance a model test might look
 like this:

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,7 @@ require 'rspec/core/rake_task'
 require 'appraisal'
 require_relative 'tasks/documentation'
 require_relative 'spec/support/tests/database'
+require_relative 'spec/support/tests/current_bundle'
 
 RSpec::Core::RakeTask.new('spec:unit') do |t|
   t.ruby_opts = '-w -r ./spec/report_warnings'
@@ -20,16 +21,17 @@ RSpec::Core::RakeTask.new('spec:acceptance') do |t|
 end
 
 task :default do
-  if ENV['BUNDLE_GEMFILE'] =~ /gemfiles/
+  if Tests::CurrentBundle.instance.appraisal_in_use?
     sh 'rake spec:unit'
     sh 'rake spec:acceptance'
   else
-    Rake::Task['appraise'].invoke
+    if ENV['CI']
+      exec "appraisal install && appraisal rake"
+    else
+      appraisal = Tests::CurrentBundle.instance.latest_appraisal
+      exec "appraisal install && appraisal #{appraisal} rake"
+    end
   end
-end
-
-task :appraise do
-  exec 'appraisal install && appraisal rake'
 end
 
 Shoulda::Matchers::DocumentationTasks.create

--- a/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
+++ b/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
@@ -167,6 +167,35 @@ module Shoulda
       #       should validate_uniqueness_of(:key).case_insensitive
       #     end
       #
+      # ##### ignoring_case_sensitivity
+      #
+      # By default, `validate_uniqueness_of` will check that the
+      # validation is case sensitive: it asserts that uniquable attributes pass
+      # validation when their values are in a different case than corresponding
+      # attributes in the pre-existing record.
+      #
+      # Use `ignoring_case_sensitivity` to skip this check. Use this if the model
+      # modifies the case of the attribute before setting it on the model
+      # e.g. with a custom setter  or as part of validation.
+      #
+      #     class Post < ActiveRecord::Base
+      #       validates_uniqueness_of :key
+      #
+      #       def key=(value)
+      #         super value.downcase
+      #       end
+      #     end
+      #
+      #     # RSpec
+      #     describe Post do
+      #       it { should validate_uniqueness_of(:key).ignoring_case_sensitivity }
+      #     end
+      #
+      #     # Minitest (Shoulda)
+      #     class PostTest < ActiveSupport::TestCase
+      #       should validate_uniqueness_of(:key).ignoring_case_sensitivity
+      #     end
+      #
       # ##### allow_nil
       #
       # Use `allow_nil` to assert that the attribute allows nil.
@@ -233,6 +262,11 @@ module Shoulda
 
         def case_insensitive
           @options[:case] = :insensitive
+          self
+        end
+
+        def ignoring_case_sensitivity
+          @options[:case] = :ignore
           self
         end
 
@@ -426,6 +460,8 @@ module Shoulda
               end
 
               allows_value_of(swapcased_value, @expected_message)
+            else
+              true
             end
           else
             true

--- a/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
+++ b/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
@@ -218,6 +218,7 @@ module Shoulda
         def initialize(attribute)
           super(attribute)
           @options = {}
+          @options[:case] = :sensitive
         end
 
         def scoped_to(*scopes)
@@ -231,7 +232,7 @@ module Shoulda
         end
 
         def case_insensitive
-          @options[:case_insensitive] = true
+          @options[:case] = :insensitive
           self
         end
 
@@ -247,7 +248,10 @@ module Shoulda
 
         def description
           result = "require "
-          result << "case sensitive " unless @options[:case_insensitive]
+          case @options[:case]
+          when :sensitive
+            result << "case sensitive "
+          end
           result << "unique value for #{@attribute}"
           result << " scoped to #{@options[:scopes].join(', ')}" if @options[:scopes].present?
           result
@@ -409,9 +413,10 @@ module Shoulda
           if value.respond_to?(:swapcase)
             swapcased_value = value.swapcase
 
-            if @options[:case_insensitive]
+            case @options[:case]
+            when :insensitive
               disallows_value_of(swapcased_value, @expected_message)
-            else
+            when :sensitive
               if value == swapcased_value
                 raise NonCaseSwappableValueError.create(
                   model: @subject.class,

--- a/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
+++ b/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
@@ -174,8 +174,8 @@ module Shoulda
       # validation when their values are in a different case than corresponding
       # attributes in the pre-existing record.
       #
-      # Use `ignoring_case_sensitivity` to skip this check. Use this if the model
-      # modifies the case of the attribute before setting it on the model
+      # Use `ignoring_case_sensitivity` to skip this check. Use this if the
+      # model modifies the case of the attribute before setting it on the model
       # e.g. with a custom setter  or as part of validation.
       #
       #     class Post < ActiveRecord::Base
@@ -310,9 +310,9 @@ module Shoulda
         def case_description
           case @options[:case]
           when :sensitive
-            "case sensitive "
+            'case sensitive '
           when :insensitive
-            "case insensitive "
+            'case insensitive '
           else
             ""
           end

--- a/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
+++ b/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
@@ -282,10 +282,7 @@ module Shoulda
 
         def description
           result = "require "
-          case @options[:case]
-          when :sensitive
-            result << "case sensitive "
-          end
+          result << case_description
           result << "unique value for #{@attribute}"
           result << " scoped to #{@options[:scopes].join(', ')}" if @options[:scopes].present?
           result
@@ -309,6 +306,17 @@ module Shoulda
         end
 
         private
+
+        def case_description
+          case @options[:case]
+          when :sensitive
+            "case sensitive "
+          when :insensitive
+            "case insensitive "
+          else
+            ""
+          end
+        end
 
         def validation
           @subject.class._validators[@attribute].detect do |validator|

--- a/spec/support/tests/current_bundle.rb
+++ b/spec/support/tests/current_bundle.rb
@@ -8,21 +8,29 @@ module Tests
     include Singleton
 
     def assert_appraisal!
-      unless appraisal?
+      unless appraisal_in_use?
         message = <<EOT
 
 
 Please run tests starting with `appraisal <appraisal_name>`.
-Possible appraisals are: #{possible_appraisals}
+Possible appraisals are: #{available_appraisals}
 
 EOT
         raise AppraisalNotSpecified, message
       end
     end
 
+    def appraisal_in_use?
+      path.dirname == root.join('gemfiles')
+    end
+
+    def latest_appraisal
+      available_appraisals.sort.last
+    end
+
     private
 
-    def possible_appraisals
+    def available_appraisals
       appraisals = []
 
       Appraisal::File.each do |appraisal|
@@ -32,12 +40,14 @@ EOT
       appraisals
     end
 
-    def path
-      Bundler.default_gemfile
+    def current_appraisal
+      if appraisal_in_use?
+        File.basename(path, ".gemfile")
+      end
     end
 
-    def appraisal?
-      path.dirname == root.join('gemfiles')
+    def path
+      Bundler.default_gemfile
     end
 
     def root


### PR DESCRIPTION
Fixes #836 
also possibly #838?

This branch is based off PR #820, but I think it could quite easily be rebased onto master with a couple of tweaks to the test suite.

The issue is that the existing functionality was either actively asserting case sensitivity or case insensitivity (depending on the `:case_sensitive` option). This commit adds an option to not assert either.

This allows handling of the scenario where the case of an attribute is
changed at some point before being assigned on the model.

Possibly some more work to be done, which may or may not belong on this PR? 
* A test cases around altering case as part of validation (as in #838)
* Perhaps it now makes sense to have an explicit `.case_sensitive` option?
* If the model has specified `case_sensitive: true` or `case_sensitive: false`, but the test suite specifies `ignoring_case_sensitivity` then it feels like there's an inconsistency - should we highlight this to the user, or treat the presence of this option as the user telling us not to?