### PR TITLE
Add ignoring case sensitivity to uniqueness validation matcher

### DIFF
--- a/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
+++ b/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
@@ -218,6 +218,7 @@ module Shoulda
         def initialize(attribute)
           super(attribute)
           @options = {}
+          @options[:case] = :sensitive
         end
 
         def scoped_to(*scopes)
@@ -231,7 +232,7 @@ module Shoulda
         end
 
         def case_insensitive
-          @options[:case_insensitive] = true
+          @options[:case] = :insensitive
           self
         end
 
@@ -247,7 +248,10 @@ module Shoulda
 
         def description
           result = "require "
-          result << "case sensitive " unless @options[:case_insensitive]
+          case @options[:case]
+          when :sensitive
+            result << "case sensitive "
+          end
           result << "unique value for #{@attribute}"
           result << " scoped to #{@options[:scopes].join(', ')}" if @options[:scopes].present?
           result
@@ -409,9 +413,10 @@ module Shoulda
           if value.respond_to?(:swapcase)
             swapcased_value = value.swapcase
 
-            if @options[:case_insensitive]
+            case @options[:case]
+            when :insensitive
               disallows_value_of(swapcased_value, @expected_message)
-            else
+            when :sensitive
               if value == swapcased_value
                 raise NonCaseSwappableValueError.create(
                   model: @subject.class,

--- a/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
+++ b/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
@@ -167,6 +167,35 @@ module Shoulda
       #       should validate_uniqueness_of(:key).case_insensitive
       #     end
       #
+      # ##### ignoring_case_sensitivity
+      #
+      # By default, `validate_uniqueness_of` will check that the
+      # validation is case sensitive: it asserts that uniquable attributes pass
+      # validation when their values are in a different case than corresponding
+      # attributes in the pre-existing record.
+      #
+      # Use `ignoring_case_sensitivity` to skip this check. Use this if the
+      # model modifies the case of the attribute before setting it on the model
+      # e.g. with a custom setter  or as part of validation.
+      #
+      #     class Post < ActiveRecord::Base
+      #       validates_uniqueness_of :key
+      #
+      #       def key=(value)
+      #         super value.downcase
+      #       end
+      #     end
+      #
+      #     # RSpec
+      #     describe Post do
+      #       it { should validate_uniqueness_of(:key).ignoring_case_sensitivity }
+      #     end
+      #
+      #     # Minitest (Shoulda)
+      #     class PostTest < ActiveSupport::TestCase
+      #       should validate_uniqueness_of(:key).ignoring_case_sensitivity
+      #     end
+      #
       # ##### allow_nil
       #
       # Use `allow_nil` to assert that the attribute allows nil.
@@ -233,6 +262,11 @@ module Shoulda
 
         def case_insensitive
           @options[:case] = :insensitive
+          self
+        end
+
+        def ignoring_case_sensitivity
+          @options[:case] = :ignore
           self
         end
 
@@ -426,6 +460,8 @@ module Shoulda
               end
 
               allows_value_of(swapcased_value, @expected_message)
+            else
+              true
             end
           else
             true

--- a/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
+++ b/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
@@ -282,10 +282,7 @@ module Shoulda
 
         def description
           result = "require "
-          case @options[:case]
-          when :sensitive
-            result << "case sensitive "
-          end
+          result << case_description
           result << "unique value for #{@attribute}"
           result << " scoped to #{@options[:scopes].join(', ')}" if @options[:scopes].present?
           result
@@ -309,6 +306,17 @@ module Shoulda
         end
 
         private
+
+        def case_description
+          case @options[:case]
+          when :sensitive
+            'case sensitive '
+          when :insensitive
+            'case insensitive '
+          else
+            ''
+          end
+        end
 
         def validation
           @subject.class._validators[@attribute].detect do |validator|


### PR DESCRIPTION
Fixes #836 
also possibly #838?

Duplicates some of the code on the WIP PR #820 - will cause some conflicts with that, but hopefully nothing too tricky. 

The issue is that the existing functionality was either actively
asserting case sensitivity or case insensitivity. This commit adds an
option to not assert either.

This allows handling of the scenario where the case of an attribute is
changed at some point before being assigned on the model.

Perhaps it now makes sense to have an explicit `.case_sensitive` option as well? 

