### PR TITLE
Fix join_table_matcher to work with pg views

### DIFF
--- a/lib/shoulda/matchers/active_record/association_matchers/join_table_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matchers/join_table_matcher.rb
@@ -38,7 +38,7 @@ module Shoulda
           end
 
           def join_table_exists?
-            if connection.tables.include?(join_table_name)
+            if connection.table_exists?(join_table_name)
               true
             else
               @failure_message = missing_table_message


### PR DESCRIPTION
Change the method of table existence confirmation in `#join_table_exists?`
from `#tables.include?` to `#table_exists?`.

Why:

* In fact, the behavior of `#tables` is different for each adapter.
  For some adapters (e.g. pg_adapter) it reflects only tables.
  And `#table_exists?` always checks both tables and views.