### PR TITLE
allow respond_with matcher to match on lambda

### DIFF
--- a/lib/shoulda/matchers/action_controller/respond_with_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/respond_with_matcher.rb
@@ -94,8 +94,13 @@ module Shoulda
           @status = symbol_to_status_code(status)
         end
 
-        def matches?(controller)
-          @controller = controller
+        def matches?(subject)
+          if subject.is_a? Proc
+            @response = subject.call
+          else
+            @response = subject.response
+          end
+
           correct_status_code? || correct_status_code_range?
         end
 
@@ -123,7 +128,7 @@ module Shoulda
         end
 
         def response_code
-          @controller.response.response_code
+          @response.response_code
         end
 
         def symbol_to_status_code(potential_symbol)


### PR DESCRIPTION
In an attempt to dry up my specs, I was really missing the ability to do something like:

``` ruby
subject { -> { post :create, foo: 'bar' } }

it { is_expected.to(respond_with :created) }
it { is_expected.to change(Foobar, :count).by(1) }
```

I think it's much simple, clean and readable than the following or any other equivalent:

``` ruby
it do
  post :create, foo: 'bar'
  is_expected.to(respond_with :created)
end

it { expect{ post :create, foo: 'bar' }.to change(FooBar, :count).by(1) }
```

This patch allows the matcher to work with lambda returning an ActionController::TestResponse

Note: I'm not really sure how to test this in the current specs, but it's late here so I'll look into it tomorrow
