### PR TITLE
Bugfix/validate presence of with serialize

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
@@ -135,14 +135,14 @@ module Shoulda
 
         def secure_password_being_validated?
           defined?(::ActiveModel::SecurePassword) &&
-            @subject.class.ancestors.include?(::ActiveModel::SecurePassword::InstanceMethodsOnActivation) &&
+            model.ancestors.include?(::ActiveModel::SecurePassword::InstanceMethodsOnActivation) &&
             @attribute == :password
         end
 
         def disallows_and_double_checks_value_of!(value, message)
           disallows_value_of(value, message)
         rescue ActiveModel::AllowValueMatcher::CouldNotSetAttributeError
-          raise ActiveModel::CouldNotSetPasswordError.create(@subject.class)
+          raise ActiveModel::CouldNotSetPasswordError.create(model)
         end
 
         def disallows_original_or_typecast_value?(value, message)
@@ -170,8 +170,8 @@ module Shoulda
         end
 
         def reflection
-          @subject.class.respond_to?(:reflect_on_association) &&
-            @subject.class.reflect_on_association(@attribute)
+          model.respond_to?(:reflect_on_association) &&
+            model.reflect_on_association(@attribute)
         end
 
         private

--- a/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
@@ -152,8 +152,10 @@ module Shoulda
         end
 
         def blank_value
-          if collection?
+          if collection? || serialization_class == Array
             []
+          elsif serialization_class == Hash
+            {}
           else
             nil
           end
@@ -170,6 +172,27 @@ module Shoulda
         def reflection
           @subject.class.respond_to?(:reflect_on_association) &&
             @subject.class.reflect_on_association(@attribute)
+        end
+
+        private
+
+        def serialization_class
+          klass = serialized_attributes[@attribute.to_s]
+          if klass.respond_to?(:object_class)
+            klass.object_class
+          end
+        end
+
+        def serialized_attributes
+          if model.respond_to?(:columns)
+            Shoulda::Matchers::RailsShim.serialized_attributes_for(model)
+          else
+            {}
+          end
+        end
+
+        def model
+          @subject.class
         end
       end
     end

--- a/spec/unit/shoulda/matchers/active_model/validate_presence_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_presence_of_matcher_spec.rb
@@ -39,6 +39,13 @@ describe Shoulda::Matchers::ActiveModel::ValidatePresenceOfMatcher, type: :model
     end
   end
 
+  context 'an ActiveRecord class with serialized attribute' do
+    it 'accepts' do
+      expect(with_serialized_attr(Hash)).to validate_presence_of(:attr)
+      expect(with_serialized_attr(Array)).to validate_presence_of(:attr)
+    end
+  end
+
   context 'a has_many association with a presence validation' do
     it 'requires the attribute to be set' do
       expect(has_many_children(presence: true)).to validate_presence_of(:children)
@@ -207,6 +214,18 @@ describe Shoulda::Matchers::ActiveModel::ValidatePresenceOfMatcher, type: :model
 
   def active_resource_model
     define_active_resource_class :foo, attr: :string do
+      validates_presence_of :attr
+    end.new
+  end
+
+  def with_serialized_attr(type = nil)
+    define_model(:example, attr: :string) do
+      if type
+        serialize :attr, type
+      else
+        serialize :attr
+      end
+
       validates_presence_of :attr
     end.new
   end


### PR DESCRIPTION
It think this should fix the issue described in #805.

I thought this would also fix a similar issue I have, but it does not... I will keep investigating. In my specific scenario I validate the presence of an attribute created by `hstore_translate` and I get the same error as described in #805. 
