### PR TITLE
Match more accurately when key AND value are set for SetFlashMatcher

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,12 +80,9 @@ curl -sL https://rpm.nodesource.com/setup | bash -
 yum install -y nodejs
 ```
 
-### Installing Ruby (all platforms)
+### Ruby Version Support
 
-shoulda-matchers is only compatible with Ruby 2.x. A `.ruby-version` is included
-in the repo, so if you're using one of the Ruby version manager tools, then you
-should be using (or have been prompted to install) the latest version of Ruby.
-If not, you'll want to do that.
+shoulda-matchers is only compatible with Ruby 2.x. 
 
 [working Ruby environment]: #addendum-setting-up-your-environment
 [Code of Conduct]: https://thoughtbot.com/open-source-code-of-conduct

--- a/lib/shoulda/matchers/action_controller.rb
+++ b/lib/shoulda/matchers/action_controller.rb
@@ -11,6 +11,7 @@ require 'shoulda/matchers/action_controller/rescue_from_matcher'
 require 'shoulda/matchers/action_controller/callback_matcher'
 require 'shoulda/matchers/action_controller/permit_matcher'
 require 'shoulda/matchers/action_controller/set_session_or_flash_matcher'
+require 'shoulda/matchers/action_controller/store'
 require 'shoulda/matchers/action_controller/flash_store'
 require 'shoulda/matchers/action_controller/session_store'
 

--- a/lib/shoulda/matchers/action_controller/flash_store.rb
+++ b/lib/shoulda/matchers/action_controller/flash_store.rb
@@ -2,7 +2,7 @@ module Shoulda
   module Matchers
     module ActionController
       # @private
-      class FlashStore
+      class FlashStore < Store
         def self.future
           new
         end
@@ -10,8 +10,6 @@ module Shoulda
         def self.now
           new.use_now!
         end
-
-        attr_accessor :controller
 
         def initialize
           @use_now = false
@@ -25,23 +23,17 @@ module Shoulda
           end
         end
 
-        def has_key?(key)
-          values_to_check.include?(key.to_s)
-        end
-
-        def has_value?(expected_value)
-          values_to_check.values.any? do |actual_value|
-            expected_value === actual_value
-          end
-        end
-
-        def empty?
-          flash.empty?
-        end
-
         def use_now!
           @use_now = true
           self
+        end
+
+        def store
+          if @use_now
+            set_values.slice(*keys_to_discard.to_a)
+          else
+            set_values.except(*keys_to_discard.to_a)
+          end
         end
 
         private
@@ -73,14 +65,6 @@ module Shoulda
 
         def keys_to_discard
           flash.instance_variable_get('@discard')
-        end
-
-        def values_to_check
-          if @use_now
-            set_values.slice(*keys_to_discard.to_a)
-          else
-            set_values.except(*keys_to_discard.to_a)
-          end
         end
       end
     end

--- a/lib/shoulda/matchers/action_controller/session_store.rb
+++ b/lib/shoulda/matchers/action_controller/session_store.rb
@@ -2,30 +2,12 @@ module Shoulda
   module Matchers
     module ActionController
       # @private
-      class SessionStore
-        attr_accessor :controller
-
+      class SessionStore < Store
         def name
           'session'
         end
 
-        def has_key?(key)
-          session.key?(key)
-        end
-
-        def has_value?(expected_value)
-          session.values.any? do |actual_value|
-            expected_value === actual_value
-          end
-        end
-
-        def empty?
-          session.empty?
-        end
-
-        private
-
-        def session
+        def store
           controller.session
         end
       end

--- a/lib/shoulda/matchers/action_controller/set_session_or_flash_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/set_session_or_flash_matcher.rb
@@ -78,7 +78,7 @@ module Shoulda
         end
 
         def expected_value_matches?
-          return store.has_value?(expected_value, key) if key_set?
+          return store.has_key_value?(key, expected_value) if key_set?
           store.has_value?(expected_value)
         end
 

--- a/lib/shoulda/matchers/action_controller/set_session_or_flash_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/set_session_or_flash_matcher.rb
@@ -38,7 +38,10 @@ module Shoulda
 
         def matches?(controller)
           @controller = store.controller = controller
-          !store.empty? && key_matches? && expected_value_matches?
+          return false if store.empty?
+          return expected_value_matches? if expected_value_set?
+          return key_matches? if key_set?
+          true
         end
 
         def failure_message
@@ -71,11 +74,12 @@ module Shoulda
         end
 
         def key_matches?
-          !key_set? || store.has_key?(key)
+          store.has_key?(key)
         end
 
         def expected_value_matches?
-          !expected_value_set? || store.has_value?(expected_value)
+          return store.has_value?(expected_value, key) if key_set?
+          store.has_value?(expected_value)
         end
 
         def expectation_description

--- a/lib/shoulda/matchers/action_controller/store.rb
+++ b/lib/shoulda/matchers/action_controller/store.rb
@@ -3,9 +3,6 @@ module Shoulda
     module ActionController
       # @private
       class Store
-        NO_KEY_SET = Object.new
-        private_constant :NO_KEY_SET
-
         attr_accessor :controller
 
         def name
@@ -20,11 +17,13 @@ module Shoulda
           store.has_key?(key.to_s)
         end
 
-        def has_value?(expected_value, key = NO_KEY_SET)
-          values = key.equal?(NO_KEY_SET) ? store.values : [store[key.to_s]]
-          values.any? do |actual_value|
-            expected_value === actual_value
-          end
+        def has_value?(expected_value)
+          store.values.any? { |actual_value| expected_value === actual_value }
+        end
+
+        def has_key_value?(expected_key, expected_value)
+          return false unless has_key?(expected_key)
+          expected_value === store[expected_key.to_s]
         end
 
         def empty?

--- a/lib/shoulda/matchers/action_controller/store.rb
+++ b/lib/shoulda/matchers/action_controller/store.rb
@@ -1,0 +1,36 @@
+module Shoulda
+  module Matchers
+    module ActionController
+      # @private
+      class Store
+        NO_KEY_SET = Object.new
+        private_constant :NO_KEY_SET
+
+        attr_accessor :controller
+
+        def name
+          raise NotImplementedError, 'must be implemented by subclass'
+        end
+
+        def store
+          raise NotImplementedError, 'must be implemented by subclass'
+        end
+
+        def has_key?(key)
+          store.has_key?(key.to_s)
+        end
+
+        def has_value?(expected_value, key = NO_KEY_SET)
+          values = key.equal?(NO_KEY_SET) ? store.values : [store[key.to_s]]
+          values.any? do |actual_value|
+            expected_value === actual_value
+          end
+        end
+
+        def empty?
+          store.empty?
+        end
+      end
+    end
+  end
+end

--- a/spec/support/unit/shared_examples/set_session_or_flash.rb
+++ b/spec/support/unit/shared_examples/set_session_or_flash.rb
@@ -248,6 +248,14 @@ shared_examples_for 'set session or flash matcher' do
             expect(controller).not_to set_store['the key'].to('the value')
           end
 
+          it 'rejects when the value is not present in the given key' do
+            controller = controller_with_store(
+              'the key' => 'not matching',
+              'other key' => 'the value',
+            )
+            expect(controller).not_to set_store['the key'].to('the value')
+          end
+
           it 'produces the correct failure message' do
             controller = controller_with_empty_store
             expected_message = %<Expected #{controller.class} to set #{store_name}["the key"] to "the value", but it did not>

--- a/spec/unit/shoulda/matchers/action_controller/set_session_or_flash_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/action_controller/set_session_or_flash_matcher_spec.rb
@@ -395,8 +395,8 @@ describe Shoulda::Matchers::ActionController::SetSessionOrFlashMatcher do
             allow(store).to receive(:has_key?).
               with('the key').
               and_return(true)
-            allow(store).to receive(:has_value?).
-              with('the value').
+            expect(store).to receive(:has_value?).
+              with('the value', 'the key').
               and_return(true)
             matcher = described_class.new(store)['the key'].to('the value')
 
@@ -446,7 +446,7 @@ describe Shoulda::Matchers::ActionController::SetSessionOrFlashMatcher do
               with('the key').
               and_return(true)
             allow(store).to receive(:has_value?).
-              with('the value').
+              with('the value', 'the key').
               and_return(true)
             matcher = described_class.new(store)['the key'].to('the value')
             expected_message = 'Expected MyController not to set flash["the key"] to "the value", but it did'
@@ -479,7 +479,7 @@ describe Shoulda::Matchers::ActionController::SetSessionOrFlashMatcher do
               with('the key').
               and_return(true)
             allow(store).to receive(:has_value?).
-              with('the value').
+              with('the value', 'the key').
               and_return(true)
             context = double('context', method_in_context: 'the value')
             matcher = described_class.new(store)['the key'].
@@ -532,7 +532,7 @@ describe Shoulda::Matchers::ActionController::SetSessionOrFlashMatcher do
               with('the key').
               and_return(true)
             allow(store).to receive(:has_value?).
-              with('the value').
+              with('the value', 'the key').
               and_return(true)
             context = double('context', method_in_context: 'the value')
             matcher = described_class.new(store)['the key'].

--- a/spec/unit/shoulda/matchers/action_controller/set_session_or_flash_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/action_controller/set_session_or_flash_matcher_spec.rb
@@ -392,11 +392,8 @@ describe Shoulda::Matchers::ActionController::SetSessionOrFlashMatcher do
           it 'accepts' do
             controller = define_class('MyController').new
             store = build_store
-            allow(store).to receive(:has_key?).
-              with('the key').
-              and_return(true)
-            expect(store).to receive(:has_value?).
-              with('the value', 'the key').
+            expect(store).to receive(:has_key_value?).
+              with('the key', 'the value').
               and_return(true)
             matcher = described_class.new(store)['the key'].to('the value')
 
@@ -408,11 +405,8 @@ describe Shoulda::Matchers::ActionController::SetSessionOrFlashMatcher do
           it 'rejects' do
             controller = define_class('MyController').new
             store = build_store
-            allow(store).to receive(:has_key?).
-              with('the key').
-              and_return(true)
-            allow(store).to receive(:has_value?).
-              with('the value').
+            allow(store).to receive(:has_key_value?).
+              with('the key', 'the value').
               and_return(false)
             matcher = described_class.new(store)['the key'].to('the value')
 
@@ -422,11 +416,8 @@ describe Shoulda::Matchers::ActionController::SetSessionOrFlashMatcher do
           it 'produces the correct failure message' do
             controller = define_class('MyController').new
             store = build_store(name: 'flash')
-            allow(store).to receive(:has_key?).
-              with('the key').
-              and_return(true)
-            allow(store).to receive(:has_value?).
-              with('the value').
+            allow(store).to receive(:has_key_value?).
+              with('the key', 'the value').
               and_return(false)
             matcher = described_class.new(store)['the key'].to('the value')
             expected_message = 'Expected MyController to set flash["the key"] to "the value", but it did not'
@@ -442,11 +433,8 @@ describe Shoulda::Matchers::ActionController::SetSessionOrFlashMatcher do
           it 'produces the correct failure message' do
             controller = define_class('MyController').new
             store = build_store(name: 'flash')
-            allow(store).to receive(:has_key?).
-              with('the key').
-              and_return(true)
-            allow(store).to receive(:has_value?).
-              with('the value', 'the key').
+            allow(store).to receive(:has_key_value?).
+              with('the key', 'the value').
               and_return(true)
             matcher = described_class.new(store)['the key'].to('the value')
             expected_message = 'Expected MyController not to set flash["the key"] to "the value", but it did'
@@ -475,11 +463,8 @@ describe Shoulda::Matchers::ActionController::SetSessionOrFlashMatcher do
           it 'accepts' do
             controller = define_class('MyController').new
             store = build_store
-            allow(store).to receive(:has_key?).
-              with('the key').
-              and_return(true)
-            allow(store).to receive(:has_value?).
-              with('the value', 'the key').
+            allow(store).to receive(:has_key_value?).
+              with('the key', 'the value').
               and_return(true)
             context = double('context', method_in_context: 'the value')
             matcher = described_class.new(store)['the key'].
@@ -494,8 +479,8 @@ describe Shoulda::Matchers::ActionController::SetSessionOrFlashMatcher do
           it 'rejects' do
             controller = define_class('MyController').new
             store = build_store
-            allow(store).to receive(:has_key?).
-              with('the key').
+            allow(store).to receive(:has_key_value?).
+              with('the key', 'the value').
               and_return(false)
             context = double('context', method_in_context: 'the value')
             matcher = described_class.new(store)['the key'].
@@ -508,8 +493,8 @@ describe Shoulda::Matchers::ActionController::SetSessionOrFlashMatcher do
           it 'produces the correct failure message' do
             controller = define_class('MyController').new
             store = build_store(name: 'flash')
-            allow(store).to receive(:has_key?).
-              with('the key').
+            allow(store).to receive(:has_key_value?).
+              with('the key', 'the value').
               and_return(false)
             context = double('context', method_in_context: 'the value')
             matcher = described_class.new(store)['the key'].
@@ -528,11 +513,8 @@ describe Shoulda::Matchers::ActionController::SetSessionOrFlashMatcher do
           it 'produces the correct failure message' do
             controller = define_class('MyController').new
             store = build_store(name: 'flash')
-            allow(store).to receive(:has_key?).
-              with('the key').
-              and_return(true)
-            allow(store).to receive(:has_value?).
-              with('the value', 'the key').
+            allow(store).to receive(:has_key_value?).
+              with('the key', 'the value').
               and_return(true)
             context = double('context', method_in_context: 'the value')
             matcher = described_class.new(store)['the key'].
@@ -554,6 +536,7 @@ describe Shoulda::Matchers::ActionController::SetSessionOrFlashMatcher do
       :controller= => nil,
       :has_key? => nil,
       :has_value? => nil,
+      :has_key_value? => nil,
       :empty? => nil,
     }
     methods = defaults.merge(overrides)


### PR DESCRIPTION
When specifying both a flash key AND value, this ensures that the
matching value is within the given flash key. Previously it would look
for the matching value within ALL the flash keys, which could result in
false positives.

For example:

``` ruby
expect(controller).not_to set_flash['the key'].to('the value')
```

This example used to make two independent assertions - that the flash key
'the key' is set, and that some flash value includes 'the value'. The
new behavior asserts that the flash value associated with 'the key' is
set to 'the value'.

This same applies to the session matcher as well.
