### PR TITLE
Fix NoMethodError when using `should_not allow_value` with Minitest+shoulda-context

### DIFF
--- a/lib/shoulda/matchers/active_model/allow_value_matcher.rb
+++ b/lib/shoulda/matchers/active_model/allow_value_matcher.rb
@@ -492,6 +492,8 @@ module Shoulda
 
           Shoulda::Matchers.word_wrap(message)
         end
+        alias_method :failure_message_for_should_not,
+          :failure_message_when_negated
 
         def attribute_changed_value_message
           <<-MESSAGE.strip

--- a/spec/unit/shoulda/matchers/active_model/allow_value_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/allow_value_matcher_spec.rb
@@ -9,6 +9,15 @@ describe Shoulda::Matchers::ActiveModel, type: :model do
 end
 
 describe Shoulda::Matchers::ActiveModel::AllowValueMatcher, type: :model do
+  describe 'backwards compatibility' do
+    it 'responds to :failure_message_for_should_not' do
+      matcher = allow_value('foo', 'bar').for(:baz)
+
+      expect(matcher).to\
+        respond_to(:failure_message_for_should_not).with(0).arguments
+    end
+  end
+
   context "#description" do
     it 'describes itself with multiple values' do
       matcher = allow_value('foo', 'bar').for(:baz)


### PR DESCRIPTION
When using Minitest (i.e. `ActiveSupport::TestCase`) in combination with shoulda-context, a failing `should_not allow_value...` assertion would result in this error:

```
NoMethodError: undefined method `negative_failure_message'
```

This commit fixes this error by defining `failure_message_for_should_not`, which shoulda-context will use instead.
