### PR TITLE
WIP: Add `ignoring_interference_by_writer` to everything

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,12 @@
   (formerly CouldNotSetAttributeError) when used against an attribute that is an
   enum in an ActiveRecord model.
 
+### Features
+
+* Add `ignoring_interference_by_writer` to all matchers, not just `allow_value`.
+  This makes it possible to get around CouldNotSetAttributeErrors that you are
+  probably used to seeing.
+
 ### Improvements
 
 * Improve failure messages and descriptions of all matchers across the board so

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # HEAD
 
+### Bug fixes
+
+* Update `validate_numericality_of` so that submatchers are applied lazily
+  instead of immediately. Previously, qualifiers were order-dependent, meaning
+  that if you used `strict` before you used, say, `odd`, then `strict` wouldn't
+  actually apply to `odd`. Now the order that you specify qualifiers doesn't
+  matter.
+
+* Fix `allow_value` so that it does not raise an AttributeChangedValueError
+  (formerly CouldNotSetAttributeError) when used against an attribute that is an
+  enum in an ActiveRecord model.
+
 ### Improvements
 
 * Improve failure messages and descriptions of all matchers across the board so
@@ -7,14 +19,11 @@
   (You'll see a huge difference in the output of the numericality and uniqueness
   matchers in particular.)
 
+* The CouldNotSetAttributeError that you have probably seen is now called
+  AttributeChangedValueError.
+
 * Matchers now raise an error if any attributes that the matcher is attempting
   to set do not exist on the model.
-
-* Update `validate_numericality_of` so that submatchers are applied lazily
-  instead of immediately. Previously, qualifiers were order-dependent, meaning
-  that if you used `strict` before you used, say, `odd`, then `strict` wouldn't
-  actually apply to `odd`. Now the order that you specify qualifiers doesn't
-  matter.
 
 * Update `validate_numericality_of` so that it doesn't always run all of the
   submatchers, but stops on the first one that fails. Since failure messages

--- a/lib/shoulda/matchers/active_model.rb
+++ b/lib/shoulda/matchers/active_model.rb
@@ -1,4 +1,5 @@
 require 'shoulda/matchers/active_model/helpers'
+require 'shoulda/matchers/active_model/qualifiers'
 require 'shoulda/matchers/active_model/validation_matcher'
 require 'shoulda/matchers/active_model/validation_matcher/build_description'
 require 'shoulda/matchers/active_model/validator'

--- a/lib/shoulda/matchers/active_model/allow_value_matcher/attribute_changed_value_error.rb
+++ b/lib/shoulda/matchers/active_model/allow_value_matcher/attribute_changed_value_error.rb
@@ -13,23 +13,26 @@ The #{matcher_name} matcher attempted to set :#{attribute_name} on
 #{model.name} to #{value_written.inspect}, but when the attribute was
 read back, it had stored #{value_read.inspect} instead.
 
-This creates a problem because it means that the model is behaving in a way that
-is interfering with the test -- there's a mismatch between the test that was
-written and test that was actually run.
+This creates a problem because it means that the model is behaving in a
+way that is interfering with the test -- there's a mismatch between the
+test that you wrote and test that we actually ran.
 
 There are a couple of reasons why this could be happening:
 
-* The writer method for :#{attribute_name} has been overridden and contains
-custom logic to prevent certain values from being set or change which values
-are stored.
+* The writer method for :#{attribute_name} has been overridden and
+  contains custom logic to prevent certain values from being set or
+  change which values are stored.
 * ActiveRecord is typecasting the incoming value.
 
-Regardless, the fact you're seeing this message usually indicates a larger
-problem. Please file an issue on the GitHub repo for shoulda-matchers,
-including details about your model and the test you've written, and we can point
-you in the right direction:
+If you understand this and you wish to bypass this exception, you can
+tack the `ignoring_interference_by_writer` qualifier onto the end of
+your matcher. If the test still does not pass after that, then you may
+need to do something different.
 
-https://github.com/thoughtbot/shoulda-matchers/issues
+If you need help, then post an issue to the shoulda-matchers issues list
+and we'll get you squared away:
+
+http://github.com/thoughtbot/shoulda-matchers/issues
             MESSAGE
           end
 

--- a/lib/shoulda/matchers/active_model/allow_value_matcher/attribute_setter.rb
+++ b/lib/shoulda/matchers/active_model/allow_value_matcher/attribute_setter.rb
@@ -8,16 +8,23 @@ module Shoulda
             new(args).set
           end
 
-          attr_reader :result_of_checking, :result_of_setting,
-            :value_written
+          attr_reader(
+            :attribute_name,
+            :result_of_checking,
+            :result_of_setting,
+            :value_written,
+          )
 
           def initialize(args)
+            @args = args
             @matcher_name = args.fetch(:matcher_name)
             @object = args.fetch(:object)
             @attribute_name = args.fetch(:attribute_name)
             @value_written = args.fetch(:value)
-            @ignoring_interference_by_writer =
-              args.fetch(:ignoring_interference_by_writer, false)
+            @ignore_interference_by_writer = args.fetch(
+              :ignore_interference_by_writer,
+              Qualifiers::IgnoreInterferenceByWriter.new
+            )
             @after_set_callback = args.fetch(:after_set_callback, -> { })
 
             @result_of_checking = nil
@@ -125,10 +132,17 @@ module Shoulda
             set? && result_of_setting.successful?
           end
 
+          def value_read
+            @_value_read ||= object.public_send(attribute_name)
+          end
+
+          def attribute_changed_value?
+            value_written != value_read
+          end
+
           protected
 
-          attr_reader :matcher_name, :object, :attribute_name,
-            :after_set_callback
+          attr_reader :args, :matcher_name, :object, :after_set_callback
 
           private
 
@@ -144,16 +158,13 @@ module Shoulda
             end
           end
 
-          def attribute_changed_value?
-            value_written != value_read
+          def raise_attribute_changed_value_error?
+            attribute_changed_value? &&
+              !ignore_interference_by_writer.considering?(value_read)
           end
 
-          def value_read
-            @_value_read ||= object.public_send(attribute_name)
-          end
-
-          def ignoring_interference_by_writer?
-            !!@ignoring_interference_by_writer
+          def ignore_interference_by_writer
+            @ignore_interference_by_writer
           end
 
           def raise_attribute_changed_value_error?

--- a/lib/shoulda/matchers/active_model/allow_value_matcher/attribute_setter_and_validator.rb
+++ b/lib/shoulda/matchers/active_model/allow_value_matcher/attribute_setter_and_validator.rb
@@ -15,7 +15,7 @@ module Shoulda
             :context,
             :expected_message,
             :expects_strict?,
-            :ignoring_interference_by_writer?,
+            :ignore_interference_by_writer,
             :instance,
           )
 
@@ -33,7 +33,7 @@ module Shoulda
               object: instance,
               attribute_name: attribute_name,
               value: value,
-              ignoring_interference_by_writer: ignoring_interference_by_writer?,
+              ignore_interference_by_writer: ignore_interference_by_writer,
               after_set_callback: after_setting_value_callback
             )
           end

--- a/lib/shoulda/matchers/active_model/disallow_value_matcher.rb
+++ b/lib/shoulda/matchers/active_model/disallow_value_matcher.rb
@@ -7,17 +7,21 @@ module Shoulda
       class DisallowValueMatcher
         extend Forwardable
 
-        def_delegators :allow_matcher,
+        def_delegators(
+          :allow_matcher,
           :_after_setting_value,
           :attribute_to_set,
           :description,
           :expects_strict?,
-          :model,
-          :last_value_set,
-          :simple_description,
           :failure_message_preface,
           :failure_message_preface=,
-          :values_to_preset=
+          :ignore_interference_by_writer,
+          :last_attribute_setter_used,
+          :last_value_set,
+          :model,
+          :simple_description,
+          :values_to_preset=,
+        )
 
         def initialize(value)
           @allow_matcher = AllowValueMatcher.new(value)
@@ -51,8 +55,8 @@ module Shoulda
           self
         end
 
-        def ignoring_interference_by_writer
-          allow_matcher.ignoring_interference_by_writer
+        def ignoring_interference_by_writer(value = :always)
+          allow_matcher.ignoring_interference_by_writer(value)
           self
         end
 

--- a/lib/shoulda/matchers/active_model/numericality_matchers/numeric_type_matcher.rb
+++ b/lib/shoulda/matchers/active_model/numericality_matchers/numeric_type_matcher.rb
@@ -14,6 +14,8 @@ module Shoulda
             :expects_strict?,
             :failure_message,
             :failure_message_when_negated,
+            :ignore_interference_by_writer,
+            :ignoring_interference_by_writer,
             :matches?,
             :on,
             :strict,

--- a/lib/shoulda/matchers/active_model/qualifiers.rb
+++ b/lib/shoulda/matchers/active_model/qualifiers.rb
@@ -1,0 +1,12 @@
+module Shoulda
+  module Matchers
+    module ActiveModel
+      # @private
+      module Qualifiers
+      end
+    end
+  end
+end
+
+require_relative 'qualifiers/ignore_interference_by_writer'
+require_relative 'qualifiers/ignoring_interference_by_writer'

--- a/lib/shoulda/matchers/active_model/qualifiers/ignore_interference_by_writer.rb
+++ b/lib/shoulda/matchers/active_model/qualifiers/ignore_interference_by_writer.rb
@@ -1,0 +1,97 @@
+module Shoulda
+  module Matchers
+    module ActiveModel
+      module Qualifiers
+        # @private
+        class IgnoreInterferenceByWriter
+          attr_reader :setting, :condition
+
+          def initialize(argument = :never)
+            set(argument)
+            @changed = false
+          end
+
+          def set(argument)
+            if argument.is_a?(self.class)
+              @setting = argument.setting
+              @condition = argument.condition
+            else
+              case argument
+              when true, :always
+                @setting = :always
+              when false, :never
+                @setting = :never
+              else
+                @setting = :sometimes
+
+                if argument.is_a?(Hash)
+                  @condition = argument.fetch(:when)
+                else
+                  raise invalid_argument_error(argument)
+                end
+              end
+            end
+
+            @changed = true
+
+            self
+          rescue KeyError
+            raise invalid_argument_error(argument)
+          end
+
+          def default_to(argument)
+            temporary_ignore_interference_by_writer =
+              IgnoreInterferenceByWriter.new(argument)
+
+            unless changed?
+              @setting = temporary_ignore_interference_by_writer.setting
+              @condition = temporary_ignore_interference_by_writer.condition
+            end
+
+            self
+          end
+
+          def considering?(value)
+            case setting
+            when :always then true
+            when :never then false
+            else condition_matches?(value)
+            end
+          end
+
+          def never?
+            setting == :never
+          end
+
+          def changed?
+            @changed
+          end
+
+          private
+
+          def invalid_argument_error(invalid_argument)
+            ArgumentError.new(<<-ERROR)
+Unknown argument: #{invalid_argument.inspect}.
+
+ignoring_interference_by_writer takes one of three arguments:
+
+* A symbol, either :never or :always.
+* A boolean, either true (which means always) or false (which means
+  never).
+* A hash with a single key, :when, and a single value, which is either
+  the name of a method or a Proc.
+            ERROR
+          end
+
+          def condition_matches?(value)
+            if condition.respond_to?(:call)
+              condition.call(value)
+            else
+              value.public_send(condition)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/shoulda/matchers/active_model/qualifiers/ignoring_interference_by_writer.rb
+++ b/lib/shoulda/matchers/active_model/qualifiers/ignoring_interference_by_writer.rb
@@ -1,0 +1,21 @@
+module Shoulda
+  module Matchers
+    module ActiveModel
+      module Qualifiers
+        # @private
+        module IgnoringInterferenceByWriter
+          attr_reader :ignore_interference_by_writer
+
+          def initialize(*args)
+            @ignore_interference_by_writer = IgnoreInterferenceByWriter.new
+          end
+
+          def ignoring_interference_by_writer(value = :always)
+            @ignore_interference_by_writer.set(value)
+            self
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/shoulda/matchers/active_model/validate_absence_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_absence_of_matcher.rb
@@ -4,21 +4,21 @@ module Shoulda
       # The `validate_absence_of` matcher tests the usage of the
       # `validates_absence_of` validation.
       #
-      #     class Artillery
+      #     class PowerHungryCountry
       #       include ActiveModel::Model
-      #       attr_accessor :arms
+      #       attr_accessor :nuclear_weapons
       #
-      #       validates_absence_of :arms
+      #       validates_absence_of :nuclear_weapons
       #     end
       #
       #     # RSpec
-      #     describe Artillery do
-      #       it { should validate_absence_of(:arms) }
+      #     describe PowerHungryCountry do
+      #       it { should validate_absence_of(:nuclear_weapons) }
       #     end
       #
       #     # Minitest (Shoulda)
-      #     class ArtilleryTest < ActiveSupport::TestCase
-      #       should validate_absence_of(:arms)
+      #     class PowerHungryCountryTest < ActiveSupport::TestCase
+      #       should validate_absence_of(:nuclear_weapons)
       #     end
       #
       # #### Qualifiers
@@ -27,47 +27,80 @@ module Shoulda
       #
       # Use `on` if your validation applies only under a certain context.
       #
-      #     class Artillery
+      #     class PowerHungryCountry
       #       include ActiveModel::Model
-      #       attr_accessor :arms
+      #       attr_accessor :nuclear_weapons
       #
-      #       validates_absence_of :arms, on: :create
+      #       validates_absence_of :nuclear_weapons, on: :create
       #     end
       #
       #     # RSpec
-      #     describe Artillery do
-      #       it { should validate_absence_of(:arms).on(:create) }
+      #     describe PowerHungryCountry do
+      #       it { should validate_absence_of(:nuclear_weapons).on(:create) }
       #     end
       #
       #     # Minitest (Shoulda)
-      #     class ArtilleryTest < ActiveSupport::TestCase
-      #       should validate_absence_of(:arms).on(:create)
+      #     class PowerHungryCountryTest < ActiveSupport::TestCase
+      #       should validate_absence_of(:nuclear_weapons).on(:create)
       #     end
       #
       # ##### with_message
       #
       # Use `with_message` if you are using a custom validation message.
       #
-      #     class Artillery
+      #     class PowerHungryCountry
       #       include ActiveModel::Model
-      #       attr_accessor :arms
+      #       attr_accessor :nuclear_weapons
       #
-      #       validates_absence_of :arms,
-      #         message: "We're fresh outta arms here, soldier!"
+      #       validates_absence_of :nuclear_weapons,
+      #         message: "there shall be peace on Earth"
       #     end
       #
       #     # RSpec
-      #     describe Artillery do
+      #     describe PowerHungryCountry do
       #       it do
-      #         should validate_absence_of(:arms).
-      #           with_message("We're fresh outta arms here, soldier!")
+      #         should validate_absence_of(:nuclear_weapons).
+      #           with_message("there shall be peace on Earth")
       #       end
       #     end
       #
       #     # Minitest (Shoulda)
-      #     class ArtilleryTest < ActiveSupport::TestCase
-      #       should validate_absence_of(:arms).
-      #         with_message("We're fresh outta arms here, soldier!")
+      #     class PowerHungryCountryTest < ActiveSupport::TestCase
+      #       should validate_absence_of(:nuclear_weapons).
+      #         with_message("there shall be peace on Earth")
+      #     end
+      #
+      # ##### ignoring_interference_by_writer
+      #
+      # Use `ignoring_interference_by_writer` when the attribute you're testing
+      # changes incoming values. This qualifier will instruct the matcher to
+      # suppress raising an AttributeValueChangedError, as long as changing the
+      # doesn't also change the outcome of the test and causes it to fail. See
+      # the documentation for `allow_value` for more information on this.
+      #
+      #     class PowerHungryCountry
+      #       include ActiveModel::Model
+      #       attr_accessor :nuclear_weapons
+      #
+      #       validates_absence_of :nuclear_weapons
+      #
+      #       def nuclear_weapons=(value)
+      #         @nuclear_weapons = value + [:hidden_weapon]
+      #       end
+      #     end
+      #
+      #     # RSpec
+      #     describe PowerHungryCountry do
+      #       it do
+      #         should validate_absence_of(:nuclear_weapons).
+      #           ignoring_interference_by_writer
+      #       end
+      #     end
+      #
+      #     # Minitest (Shoulda)
+      #     class PowerHungryCountryTest < ActiveSupport::TestCase
+      #       should validate_absence_of(:nuclear_weapons).
+      #         ignoring_interference_by_writer
       #     end
       #
       # @return [ValidateAbsenceOfMatcher}

--- a/lib/shoulda/matchers/active_model/validate_acceptance_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_acceptance_of_matcher.rb
@@ -73,6 +73,39 @@ module Shoulda
       #         with_message('You must accept the terms of service')
       #     end
       #
+      # ##### ignoring_interference_by_writer
+      #
+      # Use `ignoring_interference_by_writer` when the attribute you're testing
+      # changes incoming values. This qualifier will instruct the matcher to
+      # suppress raising an AttributeValueChangedError, as long as changing the
+      # doesn't also change the outcome of the test and cause it to fail. See
+      # the documentation for `allow_value` for more information on this.
+      #
+      #     class Registration
+      #       include ActiveModel::Model
+      #       attr_accessor :terms_of_service
+      #
+      #       validates_acceptance_of :terms_of_service
+      #
+      #       def terms_of_service=(value)
+      #         @terms_of_service = value || 'something else'
+      #       end
+      #     end
+      #
+      #     # RSpec
+      #     describe Registration do
+      #       it do
+      #         should validate_acceptance_of(:terms_of_service).
+      #           ignoring_interference_by_writer
+      #       end
+      #     end
+      #
+      #     # Minitest (Shoulda)
+      #     class RegistrationTest < ActiveSupport::TestCase
+      #       should validate_acceptance_of(:terms_of_service).
+      #         ignoring_interference_by_writer
+      #     end
+      #
       # @return [ValidateAcceptanceOfMatcher]
       #
       def validate_acceptance_of(attr)

--- a/lib/shoulda/matchers/active_model/validate_exclusion_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_exclusion_of_matcher.rb
@@ -112,6 +112,41 @@ module Shoulda
       #         with_message('You chose a puny weapon')
       #     end
       #
+      # ##### ignoring_interference_by_writer
+      #
+      # Use `ignoring_interference_by_writer` when the attribute you're testing
+      # changes incoming values. This qualifier will instruct the matcher to
+      # suppress raising an AttributeValueChangedError, as long as changing the
+      # doesn't also change the outcome of the test and cause it to fail. See
+      # the documentation for `allow_value` for more information on this.
+      #
+      #     class Game < ActiveRecord::Base
+      #       include ActiveModel::Model
+      #       attr_accessor :weapon
+      #
+      #       validates_exclusion_of :weapon
+      #
+      #       def weapon=(value)
+      #         @weapon = value.gsub(' ', '')
+      #       end
+      #     end
+      #
+      #     # RSpec
+      #     describe Game do
+      #       it do
+      #         should validate_exclusion_of(:weapon).
+      #           in_array(['pistol', 'paintball gun', 'stick']).
+      #           ignoring_interference_by_writer
+      #       end
+      #     end
+      #
+      #     # Minitest (Shoulda)
+      #     class GameTest < ActiveSupport::TestCase
+      #       should validate_exclusion_of(:weapon).
+      #         in_array(['pistol', 'paintball gun', 'stick']).
+      #         ignoring_interference_by_writer
+      #     end
+      #
       # @return [ValidateExclusionOfMatcher]
       #
       def validate_exclusion_of(attr)

--- a/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
@@ -13,21 +13,22 @@ module Shoulda
       #       include ActiveModel::Model
       #       attr_accessor :state
       #
-      #       validates_inclusion_of :state, in: %w(open resolved unresolved)
+      #       validates_inclusion_of :state,
+      #         in: ['open', 'resolved', 'unresolved']
       #     end
       #
       #     # RSpec
       #     describe Issue do
       #       it do
       #         should validate_inclusion_of(:state).
-      #           in_array(%w(open resolved unresolved))
+      #           in_array(['open', 'resolved', 'unresolved'])
       #       end
       #     end
       #
       #     # Minitest (Shoulda)
       #     class IssueTest < ActiveSupport::TestCase
       #       should validate_inclusion_of(:state).
-      #         in_array(%w(open resolved unresolved))
+      #         in_array(['open', 'resolved', 'unresolved'])
       #     end
       #
       # If your whitelist is a range of values, use `in_range`:
@@ -57,7 +58,10 @@ module Shoulda
       # one of these three values. That means there isn't any way we can refute
       # this logic in a test. Hence, this will produce a warning:
       #
-      #     it { should validate_inclusion_of(:imported).in_array([true, false]) }
+      #     it do
+      #       should validate_inclusion_of(:imported).
+      #         in_array([true, false])
+      #     end
       #
       # The only case where `validate_inclusion_of` *could* be appropriate is
       # for ensuring that a boolean column accepts nil, but we recommend
@@ -205,7 +209,7 @@ module Shoulda
       #
       #       validates_presence_of :state
       #       validates_inclusion_of :state,
-      #         in: %w(open resolved unresolved),
+      #         in: ['open', 'resolved', 'unresolved'],
       #         allow_nil: true
       #     end
       #
@@ -213,7 +217,7 @@ module Shoulda
       #     describe Issue do
       #       it do
       #         should validate_inclusion_of(:state).
-      #           in_array(%w(open resolved unresolved)).
+      #           in_array(['open', 'resolved', 'unresolved']).
       #           allow_nil
       #       end
       #     end
@@ -221,7 +225,7 @@ module Shoulda
       #     # Minitest (Shoulda)
       #     class IssueTest < ActiveSupport::TestCase
       #       should validate_inclusion_of(:state).
-      #         in_array(%w(open resolved unresolved)).
+      #         in_array(['open', 'resolved', 'unresolved']).
       #         allow_nil
       #     end
       #
@@ -235,7 +239,7 @@ module Shoulda
       #
       #       validates_presence_of :state
       #       validates_inclusion_of :state,
-      #         in: %w(open resolved unresolved),
+      #         in: ['open', 'resolved', 'unresolved'],
       #         allow_blank: true
       #     end
       #
@@ -243,7 +247,7 @@ module Shoulda
       #     describe Issue do
       #       it do
       #         should validate_inclusion_of(:state).
-      #           in_array(%w(open resolved unresolved)).
+      #           in_array(['open', 'resolved', 'unresolved']).
       #           allow_blank
       #       end
       #     end
@@ -251,8 +255,44 @@ module Shoulda
       #     # Minitest (Shoulda)
       #     class IssueTest < ActiveSupport::TestCase
       #       should validate_inclusion_of(:state).
-      #         in_array(%w(open resolved unresolved)).
+      #         in_array(['open', 'resolved', 'unresolved']).
       #         allow_blank
+      #     end
+      #
+      # ##### ignoring_interference_by_writer
+      #
+      # Use `ignoring_interference_by_writer` when the attribute you're testing
+      # changes incoming values. This qualifier will instruct the matcher to
+      # suppress raising an AttributeValueChangedError, as long as changing the
+      # doesn't also change the outcome of the test and cause it to fail. See
+      # the documentation for `allow_value` for more information on this.
+      #
+      #     class Issue
+      #       include ActiveModel::Model
+      #       attr_accessor :state
+      #
+      #       validates_inclusion_of :state,
+      #         in: ['open', 'resolved', 'unresolved']
+      #
+      #       def state=(value)
+      #         @state = 'open'
+      #       end
+      #     end
+      #
+      #     # RSpec
+      #     describe Issue do
+      #       it do
+      #         should validate_inclusion_of(:state).
+      #           in_array(['open', 'resolved', 'unresolved']).
+      #           ignoring_interference_by_writer
+      #       end
+      #     end
+      #
+      #     # Minitest (Shoulda)
+      #     class IssueTest < ActiveSupport::TestCase
+      #       should validate_inclusion_of(:state).
+      #         in_array(['open', 'resolved', 'unresolved']).
+      #         ignoring_interference_by_writer
       #     end
       #
       # @return [ValidateInclusionOfMatcher]

--- a/lib/shoulda/matchers/active_model/validate_length_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_length_of_matcher.rb
@@ -216,6 +216,41 @@ module Shoulda
       #         with_long_message('Secret key must be less than 100 characters')
       #     end
       #
+      # ##### ignoring_interference_by_writer
+      #
+      # Use `ignoring_interference_by_writer` when the attribute you're testing
+      # changes incoming values. This qualifier will instruct the matcher to
+      # suppress raising an AttributeValueChangedError, as long as changing the
+      # doesn't also change the outcome of the test and cause it to fail. See
+      # the documentation for `allow_value` for more information on this.
+      #
+      #     class User
+      #       include ActiveModel::Model
+      #       attr_accessor :password
+      #
+      #       validates_length_of :password, minimum: 10
+      #
+      #       def password=(value)
+      #         @password = value.upcase
+      #       end
+      #     end
+      #
+      #     # RSpec
+      #     describe User do
+      #       it do
+      #         should validate_length_of(:password).
+      #           is_at_least(10).
+      #           ignoring_interference_by_writer
+      #       end
+      #     end
+      #
+      #     # Minitest (Shoulda)
+      #     class UserTest < ActiveSupport::TestCase
+      #       should validate_length_of(:password).
+      #         is_at_least(10).
+      #         ignoring_interference_by_writer
+      #     end
+      #
       # @return [ValidateLengthOfMatcher]
       #
       def validate_length_of(attr)

--- a/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
@@ -103,6 +103,39 @@ module Shoulda
       #         with_message('Robot has no legs')
       #     end
       #
+      # ##### ignoring_interference_by_writer
+      #
+      # Use `ignoring_interference_by_writer` when the attribute you're testing
+      # changes incoming values. This qualifier will instruct the matcher to
+      # suppress raising an AttributeValueChangedError, as long as changing the
+      # doesn't also change the outcome of the test and cause it to fail. See
+      # the documentation for `allow_value` for more information on this.
+      #
+      #     class Robot
+      #       include ActiveModel::Model
+      #       attr_accessor :name
+      #
+      #       validates_presence_of :name
+      #
+      #       def name=(name)
+      #         @name = name.to_s
+      #       end
+      #     end
+      #
+      #     # RSpec
+      #     describe Robot do
+      #       it do
+      #         should validate_presence_of(:name).
+      #           ignoring_interference_by_writer
+      #       end
+      #     end
+      #
+      #     # Minitest (Shoulda)
+      #     class RobotTest < ActiveSupport::TestCase
+      #       should validate_presence_of(:name).
+      #         ignoring_interference_by_writer
+      #     end
+      #
       # @return [ValidatePresenceOfMatcher]
       #
       def validate_presence_of(attr)
@@ -114,6 +147,8 @@ module Shoulda
         def initialize(attribute)
           super
           @expected_message = :blank
+          @ignore_interference_by_writer =
+            Qualifiers::IgnoreInterferenceByWriter.new(when: :blank?)
         end
 
         def matches?(subject)
@@ -146,8 +181,6 @@ module Shoulda
 
         def disallows_original_or_typecast_value?(value, message)
           disallows_value_of(blank_value, @expected_message)
-        rescue ActiveModel::AllowValueMatcher::AttributeChangedValueError => error
-          error.value_read.blank?
         end
 
         def blank_value

--- a/lib/shoulda/matchers/active_model/validation_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validation_matcher.rb
@@ -3,13 +3,20 @@ module Shoulda
     module ActiveModel
       # @private
       class ValidationMatcher
+        include Qualifiers::IgnoringInterferenceByWriter
+
         def initialize(attribute)
+          super
           @attribute = attribute
           @expects_strict = false
           @subject = nil
           @last_submatcher_run = nil
           @expected_message = nil
           @expects_custom_validation_message = false
+        end
+
+        def description
+          ValidationMatcher::BuildDescription.call(self, simple_description)
         end
 
         def on(context)
@@ -26,11 +33,6 @@ module Shoulda
           @expects_strict
         end
 
-        def matches?(subject)
-          @subject = subject
-          false
-        end
-
         def with_message(expected_message)
           if expected_message
             @expects_custom_validation_message = true
@@ -44,8 +46,9 @@ module Shoulda
           @expects_custom_validation_message
         end
 
-        def description
-          ValidationMatcher::BuildDescription.call(self, simple_description)
+        def matches?(subject)
+          @subject = subject
+          false
         end
 
         def failure_message
@@ -139,7 +142,8 @@ module Shoulda
             for(attribute).
             with_message(message).
             on(context).
-            strict(expects_strict?)
+            strict(expects_strict?).
+            ignoring_interference_by_writer(ignore_interference_by_writer)
 
           yield matcher if block_given?
 

--- a/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
+++ b/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
@@ -591,20 +591,7 @@ module Shoulda
         end
 
         def dummy_scalar_value_for(column)
-          case column.type
-          when :integer
-            0
-          when :date
-            Date.today
-          when :datetime
-            DateTime.now
-          when :uuid
-            SecureRandom.uuid
-          when :boolean
-            true
-          else
-            'dummy value'
-          end
+          Shoulda::Matchers::Util.dummy_value_for(column.type)
         end
 
         def next_value_for(scope, previous_value)

--- a/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
+++ b/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
@@ -219,11 +219,13 @@ module Shoulda
           super(attribute)
           @expected_message = :taken
           @options = {}
-          @existing_record = nil
           @existing_record_created = false
-          @original_existing_value = nil
           @failure_reason = nil
           @failure_reason_when_negated = nil
+          @attribute_setters = {
+            existing_record: [],
+            new_record: []
+          }
         end
 
         def scoped_to(*scopes)
@@ -277,9 +279,10 @@ module Shoulda
           @all_records = model.all
 
           existing_record_valid? &&
+            validate_attribute_present? &&
             validate_scopes_present? &&
             scopes_match? &&
-            validate_everything_except_duplicate_nils_or_blanks? &&
+            validate_two_records_with_same_non_blank_value_cannot_coexist? &&
             validate_case_sensitivity? &&
             validate_after_scope_change? &&
             allows_nil? &&
@@ -307,7 +310,11 @@ module Shoulda
         private
 
         def new_record
-          @_new_record ||= build_new_record
+          unless defined?(@new_record)
+            build_new_record
+          end
+
+          @new_record
         end
         alias_method :subject, :new_record
 
@@ -362,7 +369,7 @@ module Shoulda
 
         def allows_nil?
           if expects_to_allow_nil?
-            update_existing_record(nil)
+            update_existing_record!(nil)
             allows_value_of(nil, @expected_message)
           else
             true
@@ -371,7 +378,7 @@ module Shoulda
 
         def allows_blank?
           if expects_to_allow_blank?
-            update_existing_record('')
+            update_existing_record!('')
             allows_value_of('', @expected_message)
           else
             true
@@ -383,64 +390,58 @@ module Shoulda
             true
           else
             @failure_reason =
-              "Given record could not be set to #{value.inspect}: " +
-              existing_record.errors.full_messages
+              "The record you provided could not be saved with " +
+              ":#{@attribute} set to #{value.inspect}, " +
+              "as it failed with the following validation errors:\n\n" +
+              format_validation_errors(existing_record.errors)
             false
           end
         end
 
         def existing_record
-          @existing_record ||= find_or_create_existing_record
+          unless defined?(@existing_record)
+            find_or_create_existing_record
+          end
+
+          @existing_record
         end
 
         def find_or_create_existing_record
-          if find_existing_record
-            find_existing_record
-          else
-            create_existing_record.tap do |existing_record|
-              @existing_record_created = true
-            end
+          @existing_record = find_existing_record
+
+          unless @existing_record
+            @existing_record = create_existing_record
+            @existing_record_created = true
           end
         end
 
         def find_existing_record
           record = model.first
 
-          if valid_existing_record?(record)
-            record.tap do |existing_record|
-              @original_existing_value = existing_record.public_send(@attribute)
-            end
+          if record.present?
+            record
           else
             nil
           end
         end
 
-        def valid_existing_record?(record)
-          record.present? &&
-            record_has_nil_when_required?(record) &&
-            record_has_blank_when_required?(record)
-        end
-
-        def record_has_nil_when_required?(record)
-          !expects_to_allow_nil? || record.public_send(@attribute).nil?
-        end
-
-        def record_has_blank_when_required?(record)
-          !expects_to_allow_blank? ||
-            record.public_send(@attribute).to_s.strip.empty?
-        end
-
         def create_existing_record
           @given_record.tap do |existing_record|
-            @original_existing_value = value = arbitrary_non_blank_value
-            existing_record.public_send("#{@attribute}=", value)
             ensure_secure_password_set(existing_record)
             existing_record.save
           end
         end
 
-        def update_existing_record(value)
-          existing_record.update_column(attribute, value)
+        def update_existing_record!(value)
+          if existing_value_read != value
+            set_attribute_on!(
+              :existing_record,
+              existing_record,
+              @attribute,
+              value
+            )
+            existing_record.save!
+          end
         end
 
         def ensure_secure_password_set(instance)
@@ -468,15 +469,25 @@ module Shoulda
         end
 
         def build_new_record
-          existing_record.dup.tap do |new_record|
-            new_record.public_send("#{@attribute}=", existing_value)
+          @new_record = existing_record.dup
 
-            expected_scopes.each do |scope|
-              new_record.public_send(
-                "#{scope}=",
-                existing_record.public_send(scope)
-              )
-            end
+          attribute_names_under_test.each do |attribute_name|
+            set_attribute_on_new_record!(
+              attribute_name,
+              existing_record.public_send(attribute_name)
+            )
+          end
+
+          @new_record
+        end
+
+        def validate_attribute_present?
+          if model.method_defined?("#{attribute}=")
+            true
+          else
+            @failure_reason =
+              ":#{attribute} does not seem to be an attribute on #{model.name}."
+            false
           end
         end
 
@@ -486,9 +497,9 @@ module Shoulda
           else
             reason = ''
 
-            reason << inspected_missing_scopes.to_sentence
+            reason << inspected_scopes_missing_on_model.to_sentence
 
-            if inspected_missing_scopes.many?
+            if inspected_scopes_missing_on_model.many?
               reason << " do not seem to be attributes"
             else
               reason << " does not seem to be an attribute"
@@ -503,29 +514,29 @@ module Shoulda
         end
 
         def all_scopes_present_on_model?
-          missing_scopes.none?
+          scopes_missing_on_model.none?
         end
 
-        def missing_scopes
+        def scopes_missing_on_model
           @_missing_scopes ||= expected_scopes.select do |scope|
-            !@given_record.respond_to?("#{scope}=")
+            !model.method_defined?("#{scope}=")
           end
         end
 
-        def inspected_missing_scopes
-          missing_scopes.map(&:inspect)
+        def inspected_scopes_missing_on_model
+          scopes_missing_on_model.map(&:inspect)
         end
 
-        def validate_everything_except_duplicate_nils_or_blanks?
-          if existing_value.nil? || (expects_to_allow_blank? && existing_value.blank?)
-            update_existing_record(arbitrary_non_blank_value)
+        def validate_two_records_with_same_non_blank_value_cannot_coexist?
+          if existing_value_read.blank?
+            update_existing_record!(arbitrary_non_blank_value)
           end
 
-          disallows_value_of(existing_value, @expected_message)
+          disallows_value_of(existing_value_read, @expected_message)
         end
 
         def validate_case_sensitivity?
-          value = existing_value
+          value = existing_value_read
 
           if value.respond_to?(:swapcase) && !value.empty?
             swapcased_value = value.swapcase
@@ -568,10 +579,10 @@ module Shoulda
                   next_value_for(scope, previous_value)
                 end
 
-              new_record.public_send("#{scope}=", next_value)
+              set_attribute_on_new_record!(scope, next_value)
 
-              if allows_value_of(existing_value, @expected_message)
-                new_record.public_send("#{scope}=", previous_value)
+              if allows_value_of(existing_value_read, @expected_message)
+                set_attribute_on_new_record!(scope, previous_value)
                 true
               else
                 false
@@ -648,12 +659,63 @@ module Shoulda
           end
         end
 
-        def existing_value
+        def set_attribute_on!(record_type, record, attribute_name, value)
+          attribute_setter = build_attribute_setter(
+            record,
+            attribute_name,
+            value
+          )
+          attribute_setter.set!
+
+          @attribute_setters[record_type] << attribute_setter
+        end
+
+        def set_attribute_on_existing_record!(attribute_name, value)
+          set_attribute_on!(
+            :existing_record,
+            existing_record,
+            attribute_name,
+            value
+          )
+        end
+
+        def set_attribute_on_new_record!(attribute_name, value)
+          set_attribute_on!(
+            :new_record,
+            new_record,
+            attribute_name,
+            value
+          )
+        end
+
+        def attribute_setter_for_existing_record
+          @attribute_setters[:existing_record].last
+        end
+
+        def attribute_names_under_test
+          [@attribute] + expected_scopes
+        end
+
+        def build_attribute_setter(record, attribute_name, value)
+          Shoulda::Matchers::ActiveModel::AllowValueMatcher::AttributeSetter.new(
+            matcher_name: :validate_uniqueness_of,
+            object: record,
+            attribute_name: attribute_name,
+            value: value,
+            ignore_interference_by_writer: ignore_interference_by_writer
+          )
+        end
+
+        def existing_value_read
           existing_record.public_send(@attribute)
         end
 
-        def model
-          @given_record.class
+        def existing_value_written
+          if attribute_setter_for_existing_record
+            attribute_setter_for_existing_record.value_written
+          else
+            existing_value_read
+          end
         end
 
         def column_for(scope)
@@ -664,45 +726,89 @@ module Shoulda
           column_for(attribute).try(:limit)
         end
 
+        def model
+          @given_record.class
+        end
+
         def failure_message_preface
           prefix = ''
 
           if @existing_record_created
-            prefix << "After taking the given #{model.name},"
-            prefix << " setting its :#{attribute} to "
-            prefix << Shoulda::Matchers::Util.inspect_value(existing_value)
-            prefix << ", and saving it as the existing record,"
-            prefix << " then"
-          elsif @original_existing_value != existing_value
-            prefix << "Given an existing #{model.name},"
-            prefix << " after setting its :#{attribute} to "
-            prefix << Shoulda::Matchers::Util.inspect_value(existing_value)
-            prefix << ", then"
+            prefix << "After taking the given #{model.name}"
+
+            if attribute_setter_for_existing_record
+              prefix << ', setting its '
+              prefix << description_for_attribute_setter(
+                attribute_setter_for_existing_record
+              )
+            else
+              prefix << ", whose :#{attribute} is "
+              prefix << "‹#{existing_value_read.inspect}›"
+            end
+
+            prefix << ", and saving it as the existing record, then"
           else
-            prefix << "Given an existing #{model.name} whose :#{attribute}"
-            prefix << " is "
-            prefix << Shoulda::Matchers::Util.inspect_value(existing_value)
-            prefix << ", after"
+            if attribute_setter_for_existing_record
+              prefix << "Given an existing #{model.name},"
+              prefix << ' after setting its '
+              prefix << description_for_attribute_setter(
+                attribute_setter_for_existing_record
+              )
+              prefix << ', then'
+            else
+              prefix << "Given an existing #{model.name} whose :#{attribute}"
+              prefix << ' is '
+              prefix << Shoulda::Matchers::Util.inspect_value(
+                existing_value_read
+              )
+              prefix << ', after'
+            end
           end
 
-          prefix << " making a new #{model.name} and setting its"
-          prefix << " :#{attribute} to "
+          prefix << " making a new #{model.name} and setting its "
 
-          if last_value_set_on_new_record == existing_value
-            prefix << Shoulda::Matchers::Util.inspect_value(
-              last_value_set_on_new_record
-            )
-            prefix << " as well"
-          else
-            prefix << " a different value, "
-            prefix << Shoulda::Matchers::Util.inspect_value(
-              last_value_set_on_new_record
-            )
-          end
+          prefix << description_for_attribute_setter(
+            last_attribute_setter_used_on_new_record,
+            same_as_existing: existing_and_new_values_are_same?
+          )
 
           prefix << ", the matcher expected the new #{model.name} to be"
 
           prefix
+        end
+
+        def description_for_attribute_setter(attribute_setter, same_as_existing: nil)
+          description = ":#{attribute_setter.attribute_name} to "
+
+          if same_as_existing == false
+            description << 'a different value, '
+          end
+
+          description << Shoulda::Matchers::Util.inspect_value(
+            attribute_setter.value_written
+          )
+
+          if attribute_setter.attribute_changed_value?
+            description << ' (read back as '
+            description << Shoulda::Matchers::Util.inspect_value(
+              attribute_setter.value_read
+            )
+            description << ')'
+          end
+
+          if same_as_existing == true
+            description << ' as well'
+          end
+
+          description
+        end
+
+        def existing_and_new_values_are_same?
+          last_value_set_on_new_record == existing_value_written
+        end
+
+        def last_attribute_setter_used_on_new_record
+          last_submatcher_run.last_attribute_setter_used
         end
 
         def last_value_set_on_new_record

--- a/lib/shoulda/matchers/util.rb
+++ b/lib/shoulda/matchers/util.rb
@@ -50,6 +50,29 @@ module Shoulda
       def self.inspect_range(range)
         "#{inspect_value(range.first)} to #{inspect_value(range.last)}"
       end
+
+      def self.dummy_value_for(column_type, array: false)
+        if array
+          [dummy_value_for(column_type, array: false)]
+        else
+          case column_type
+          when :integer
+            0
+          when :date
+            Date.new(2100, 1, 1)
+          when :datetime, :timestamp
+            DateTime.new(2100, 1, 1)
+          when :time
+            Time.new(2100, 1, 1)
+          when :uuid
+            SecureRandom.uuid
+          when :boolean
+            true
+          else
+            'dummy value'
+          end
+        end
+      end
     end
   end
 end

--- a/spec/support/unit/active_record/create_table.rb
+++ b/spec/support/unit/active_record/create_table.rb
@@ -1,0 +1,61 @@
+module UnitTests
+  module ActiveRecord
+    class CreateTable
+      def self.call(table_name, columns)
+        new(table_name, columns).call
+      end
+
+      def initialize(table_name, columns)
+        @table_name = table_name
+        @columns = columns
+      end
+
+      def call
+        if columns.key?(:id) && columns[:id] == false
+          columns.delete(:id)
+          UnitTests::ModelBuilder.create_table(
+            table_name,
+            id: false,
+            &method(:add_columns_to_table)
+          )
+        else
+          UnitTests::ModelBuilder.create_table(
+            table_name,
+            &method(:add_columns_to_table)
+          )
+        end
+      end
+
+      protected
+
+      attr_reader :table_name, :columns
+
+      private
+
+      def add_columns_to_table(table)
+        columns.each do |column_name, column_specification|
+          add_column_to_table(table, column_name, column_specification)
+        end
+      end
+
+      def add_column_to_table(table, column_name, column_specification)
+        if column_specification.is_a?(Hash)
+          column_type = column_specification.fetch(:type)
+          column_options = column_specification.fetch(:options, {})
+        else
+          column_type = column_specification
+          column_options = {}
+        end
+
+        begin
+          table.__send__(column_type, column_name, column_options)
+        rescue NoMethodError
+          raise ColumnNotSupportedError.new(
+            "#{Tests::Database.instance.adapter_class} does not support " +
+            ":#{column_type} columns."
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/support/unit/attribute.rb
+++ b/spec/support/unit/attribute.rb
@@ -1,0 +1,47 @@
+module UnitTests
+  class Attribute
+    attr_reader :name, :column_type, :column_options
+
+    DEFAULT_COLUMN_TYPE = :string
+    DEFAULT_COLUMN_OPTIONS = {
+      null: false,
+      array: false
+    }
+
+    def initialize(args)
+      @args = args
+    end
+
+    def name
+      args.fetch(:name)
+    end
+
+    def column_type
+      args.fetch(:column_type, DEFAULT_COLUMN_TYPE)
+    end
+
+    def column_options
+      DEFAULT_COLUMN_OPTIONS.
+        merge(args.fetch(:column_options, {})).
+        merge(type: column_type)
+    end
+
+    def array?
+      column_options[:array]
+    end
+
+    def default_value
+      args.fetch(:default_value) do
+        if column_options[:null]
+          nil
+        else
+          Shoulda::Matchers::Util.dummy_value_for(value_type, array: array?)
+        end
+      end
+    end
+
+    protected
+
+    attr_reader :args
+  end
+end

--- a/spec/support/unit/change_value.rb
+++ b/spec/support/unit/change_value.rb
@@ -1,0 +1,111 @@
+module UnitTests
+  class ChangeValue
+    def self.call(column_type, value, value_changer)
+      new(column_type, value, value_changer).call
+    end
+
+    def initialize(column_type, value, value_changer)
+      @column_type = column_type
+      @value = value
+      @value_changer = value_changer
+    end
+
+    def call
+      if value_changer.is_a?(Proc)
+        value_changer.call(value)
+      elsif respond_to?(value_changer, true)
+        send(value_changer)
+      else
+        value.public_send(value_changer)
+      end
+    end
+
+    protected
+
+    attr_reader :column_type, :value, :value_changer
+
+    private
+
+    def previous_value
+      if value.is_a?(String)
+        value[0..-2] + (value[-1].ord - 1).chr
+      else
+        value - 1
+      end
+    end
+
+    def next_value
+      if value.is_a?(Array)
+        value + [value.first.class.new]
+      elsif value.respond_to?(:next)
+        value.next
+      else
+        value + 1
+      end
+    end
+
+    def next_next_value
+      change_value(change_value(value, :next_value), :next_value)
+    end
+
+    def next_value_or_numeric_value
+      if value
+        change_value(value, :next_value)
+      else
+        change_value(value, :numeric_value)
+      end
+    end
+
+    def next_value_or_non_numeric_value
+      if value
+        change_value(value, :next_value)
+      else
+        change_value(value, :non_numeric_value)
+      end
+    end
+
+    def never_falsy
+      value || dummy_value_for_column
+    end
+
+    def truthy_or_numeric
+      value || 1
+    end
+
+    def never_blank
+      value.presence || dummy_value_for_column
+    end
+
+    def nil_to_blank
+      value || ''
+    end
+
+    def always_nil
+      nil
+    end
+
+    def add_character
+      value + 'a'
+    end
+
+    def remove_character
+      value.chop
+    end
+
+    def numeric_value
+      1
+    end
+
+    def non_numeric_value
+      'a'
+    end
+
+    def change_value(value, value_changer)
+      self.class.call(column_type, value, value_changer)
+    end
+
+    def dummy_value_for_column
+      Shoulda::Matchers::Util.dummy_value_for(column_type)
+    end
+  end
+end

--- a/spec/support/unit/create_model_arguments/basic.rb
+++ b/spec/support/unit/create_model_arguments/basic.rb
@@ -1,0 +1,135 @@
+require 'forwardable'
+
+module UnitTests
+  module CreateModelArguments
+    class Basic
+      DEFAULT_MODEL_NAME = 'Example'
+      DEFAULT_ATTRIBUTE_NAME = :attr
+      DEFAULT_COLUMN_TYPE = :string
+
+      def self.wrap(args)
+        if args.is_a?(self)
+          args
+        else
+          new(args)
+        end
+      end
+
+      extend Forwardable
+
+      def_delegators(
+        :attribute,
+        :column_type,
+        :column_options,
+        :default_value,
+        :value_type
+      )
+
+      def initialize(args)
+        @args = args
+      end
+
+      def fetch(*args, &block)
+        self.args.fetch(*args, &block)
+      end
+
+      def merge(given_args)
+        self.class.new(args.deep_merge(given_args))
+      end
+
+      def model_name
+        args.fetch(:model_name, DEFAULT_MODEL_NAME)
+      end
+
+      def attribute_name
+        args.fetch(:attribute_name, default_attribute_name)
+      end
+
+      def model_creation_strategy
+        args.fetch(:model_creation_strategy)
+      end
+
+      def columns
+        { attribute_name => column_options }
+      end
+
+      def attribute
+        @_attribute ||= attribute_class.new(attribute_args)
+      end
+
+      def all_attribute_overrides
+        @_all_attribute_overrides ||= begin
+          attribute_overrides = args.slice(
+            :changing_values_with,
+            :default_value
+          )
+
+          overrides =
+            if attribute_overrides.empty?
+              {}
+            else
+              { attribute_name => attribute_overrides }
+            end
+
+          overrides.deep_merge(args.fetch(:attribute_overrides, {}))
+        end
+      end
+
+      def attribute_overrides
+        all_attribute_overrides.fetch(attribute_name, {})
+      end
+
+      def validation_name
+        args.fetch(:validation_name) { map_matcher_name_to_validation_name }
+      end
+
+      def validation_options
+        args.fetch(:validation_options, {})
+      end
+
+      def custom_validation?
+        args.fetch(:custom_validation, false)
+      end
+
+      def matcher_name
+        args.fetch(:matcher_name)
+      end
+
+      def attribute_default_values_by_name
+        if attribute_overrides.key?(:default_value)
+          { attribute_name => attribute_overrides[:default_value] }
+        else
+          {}
+        end
+      end
+
+      def to_hash
+        args.deep_dup
+      end
+
+      protected
+
+      attr_reader :args
+
+      def attribute_class
+        UnitTests::Attribute
+      end
+
+      def default_attribute_name
+        DEFAULT_ATTRIBUTE_NAME
+      end
+
+      private
+
+      def map_matcher_name_to_validation_name
+        matcher_name.to_s.sub('validate', 'validates')
+      end
+
+      def attribute_args
+        args.slice(:column_type).deep_merge(
+          attribute_overrides.deep_merge(name: attribute_name)
+        )
+      end
+    end
+  end
+end

--- a/spec/support/unit/create_model_arguments/has_many.rb
+++ b/spec/support/unit/create_model_arguments/has_many.rb
@@ -1,0 +1,15 @@
+module UnitTests
+  module CreateModelArguments
+    class HasMany < Basic
+      def columns
+        super.except(attribute_name)
+      end
+
+      private
+
+      def default_attribute_name
+        :children
+      end
+    end
+  end
+end

--- a/spec/support/unit/create_model_arguments/uniqueness_matcher.rb
+++ b/spec/support/unit/create_model_arguments/uniqueness_matcher.rb
@@ -1,0 +1,74 @@
+module UnitTests
+  module CreateModelArguments
+    class UniquenessMatcher < Basic
+      def self.normalize_attribute(attribute)
+        if attribute.is_a?(Hash)
+          Attribute.new(attribute)
+        else
+          Attribute.new(name: attribute)
+        end
+      end
+
+      def self.normalize_attributes(attributes)
+        attributes.map do |attribute|
+          normalize_attribute(attribute)
+        end
+      end
+
+      def columns
+        attributes.reduce({}) do |options, attribute|
+          options.merge(
+            attribute.name => {
+              type: attribute.column_type,
+              options: attribute.column_options
+            }
+          )
+        end
+      end
+
+      def validation_options
+        super.merge(scope: scope_attribute_names)
+      end
+
+      def attribute_default_values_by_name
+        attributes.reduce({}) do |values, attribute|
+          values.merge(attribute.name => attribute.default_value)
+        end
+      end
+
+      protected
+
+      def attribute_class
+        Attribute
+      end
+
+      private
+
+      def attributes
+        [attribute] + scope_attributes + additional_attributes
+      end
+
+      def scope_attribute_names
+        scope_attributes.map(&:name)
+      end
+
+      def scope_attributes
+        @_scope_attributes ||= self.class.normalize_attributes(
+          args.fetch(:scopes, [])
+        )
+      end
+
+      def additional_attributes
+        @_additional_attributes ||= self.class.normalize_attributes(
+          args.fetch(:additional_attributes, [])
+        )
+      end
+
+      class Attribute < UnitTests::Attribute
+        def value_type
+          args.fetch(:value_type) { column_type }
+        end
+      end
+    end
+  end
+end

--- a/spec/support/unit/helpers/active_record_versions.rb
+++ b/spec/support/unit/helpers/active_record_versions.rb
@@ -6,7 +6,7 @@ module UnitTests
     end
 
     def active_record_version
-      Tests::Version.new(ActiveRecord::VERSION::STRING)
+      Tests::Version.new(::ActiveRecord::VERSION::STRING)
     end
 
     def active_record_supports_enum?

--- a/spec/support/unit/helpers/class_builder.rb
+++ b/spec/support/unit/helpers/class_builder.rb
@@ -1,76 +1,90 @@
 module UnitTests
   module ClassBuilder
-    def self.parse_constant_name(name)
-      namespace = Shoulda::Matchers::Util.deconstantize(name)
-      qualified_namespace = (namespace.presence || 'Object').constantize
-      name_without_namespace = name.to_s.demodulize
-      [qualified_namespace, name_without_namespace]
+    def define_module(*args, &block)
+      ClassBuilder.define_module(*args, &block)
     end
 
-    def self.configure_example_group(example_group)
-      example_group.include(self)
-
-      example_group.after do
-        teardown_defined_constants
-      end
+    def define_class(*args, &block)
+      ClassBuilder.define_class(*args, &block)
     end
 
-    def define_module(module_name, &block)
-      module_name = module_name.to_s.camelize
+    class << self
+      def configure_example_group(example_group)
+        example_group.include(self)
 
-      namespace, name_without_namespace =
-        ClassBuilder.parse_constant_name(module_name)
-
-      if namespace.const_defined?(name_without_namespace, false)
-        namespace.__send__(:remove_const, name_without_namespace)
-      end
-
-      eval <<-RUBY
-        module #{namespace}::#{name_without_namespace}
-        end
-      RUBY
-
-      namespace.const_get(name_without_namespace).tap do |constant|
-        constant.unloadable
-
-        if block
-          constant.module_eval(&block)
+        example_group.after do
+          ClassBuilder.reset
         end
       end
-    end
 
-    def define_class(class_name, parent_class = Object, &block)
-      class_name = class_name.to_s.camelize
-
-      namespace, name_without_namespace =
-        ClassBuilder.parse_constant_name(class_name)
-
-      if namespace.const_defined?(name_without_namespace, false)
-        namespace.__send__(:remove_const, name_without_namespace)
+      def reset
+        remove_defined_classes
       end
 
-      eval <<-RUBY
-        class #{namespace}::#{name_without_namespace} < #{parent_class}
+      def define_module(module_name, &block)
+        module_name = module_name.to_s.camelize
+
+        namespace, name_without_namespace =
+          ClassBuilder.parse_constant_name(module_name)
+
+        if namespace.const_defined?(name_without_namespace, false)
+          namespace.__send__(:remove_const, name_without_namespace)
         end
-      RUBY
 
-      namespace.const_get(name_without_namespace).tap do |constant|
-        constant.unloadable
+        eval <<-RUBY
+          module #{namespace}::#{name_without_namespace}
+          end
+        RUBY
 
-        if block
-          if block.arity == 0
-            constant.class_eval(&block)
-          else
-            block.call(constant)
+        namespace.const_get(name_without_namespace).tap do |constant|
+          constant.unloadable
+
+          if block
+            constant.module_eval(&block)
           end
         end
       end
-    end
 
-    private
+      def define_class(class_name, parent_class = Object, &block)
+        class_name = class_name.to_s.camelize
 
-    def teardown_defined_constants
-      ActiveSupport::Dependencies.clear
+        namespace, name_without_namespace =
+          ClassBuilder.parse_constant_name(class_name)
+
+        if namespace.const_defined?(name_without_namespace, false)
+          namespace.__send__(:remove_const, name_without_namespace)
+        end
+
+        eval <<-RUBY
+          class #{namespace}::#{name_without_namespace} < ::#{parent_class}
+          end
+        RUBY
+
+        namespace.const_get(name_without_namespace).tap do |constant|
+          constant.unloadable
+
+          if block
+            if block.arity == 0
+              constant.class_eval(&block)
+            else
+              block.call(constant)
+            end
+          end
+        end
+      end
+
+      def parse_constant_name(name)
+        namespace = Shoulda::Matchers::Util.deconstantize(name)
+        qualified_namespace = (namespace.presence || 'Object').constantize
+        name_without_namespace = name.to_s.demodulize
+        [qualified_namespace, name_without_namespace]
+      end
+
+      private
+
+      def remove_defined_classes
+        ::ActiveSupport::Dependencies.clear
+      end
     end
   end
 end

--- a/spec/support/unit/helpers/model_builder.rb
+++ b/spec/support/unit/helpers/model_builder.rb
@@ -2,136 +2,113 @@ require_relative 'class_builder'
 
 module UnitTests
   module ModelBuilder
-    include ClassBuilder
+    def create_table(*args, &block)
+      ModelBuilder.create_table(*args, &block)
+    end
 
-    def self.configure_example_group(example_group)
-      example_group.include(self)
+    def define_model(*args, &block)
+      ModelBuilder.define_model(*args, &block)
+    end
 
-      example_group.after do
+    def define_model_class(*args, &block)
+      ModelBuilder.define_model_class(*args, &block)
+    end
+
+    def define_active_model_class(*args, &block)
+      ModelBuilder.define_active_model_class(*args, &block)
+    end
+
+    class << self
+      def configure_example_group(example_group)
+        example_group.include(self)
+
+        example_group.after do
+          ModelBuilder.reset
+        end
+      end
+
+      def reset
         clear_column_caches
         drop_created_tables
+        created_tables.clear
+        defined_models.clear
       end
-    end
 
-    def create_table(table_name, options = {}, &block)
-      connection = ActiveRecord::Base.connection
+      def create_table(table_name, options = {}, &block)
+        connection = ::ActiveRecord::Base.connection
 
-      begin
-        connection.execute("DROP TABLE IF EXISTS #{table_name}")
-        connection.create_table(table_name, options, &block)
-        created_tables << table_name
-        connection
-      rescue Exception => e
-        connection.execute("DROP TABLE IF EXISTS #{table_name}")
-        raise e
-      end
-    end
-
-    def define_model_class(class_name, &block)
-      define_class(class_name, ActiveRecord::Base, &block)
-    end
-
-    def define_active_model_class(class_name, options = {}, &block)
-      accessors = options.fetch(:accessors, [])
-
-      attributes_module = Module.new do
-        accessors.each do |column|
-          attr_accessor column.to_sym
+        begin
+          connection.execute("DROP TABLE IF EXISTS #{table_name}")
+          connection.create_table(table_name, options, &block)
+          created_tables << table_name
+          connection
+        rescue Exception => e
+          connection.execute("DROP TABLE IF EXISTS #{table_name}")
+          raise e
         end
       end
 
-      define_class(class_name) do
-        include ActiveModel::Validations
-        include attributes_module
+      def define_model_class(class_name, &block)
+        ClassBuilder.define_class(class_name, ::ActiveRecord::Base, &block)
+      end
 
-        def initialize(attributes = {})
-          attributes.each do |name, value|
-            __send__("#{name}=", value)
-          end
+      def define_active_model_class(class_name, options = {}, &block)
+        attribute_names = options.delete(:accessors) { [] }
+
+        columns = attribute_names.reduce({}) do |hash, attribute_name|
+          hash.merge(attribute_name => nil)
         end
 
-        if block_given?
-          class_eval(&block)
-        end
-      end
-    end
-
-    def define_model(name, columns = {}, &block)
-      class_name = name.to_s.pluralize.classify
-      table_name = class_name.tableize.gsub('/', '_')
-
-      table_block = lambda do |table|
-        columns.each do |column_name, specification|
-          if specification.is_a?(Hash)
-            column_type = specification[:type]
-            column_options = specification.fetch(:options, {})
-          else
-            column_type = specification
-            column_options = {}
-          end
-
-          begin
-            table.__send__(column_type, column_name, column_options)
-          rescue NoMethodError
-            raise NoMethodError, "#{Tests::Database.instance.adapter_class} does not support :#{column_type} columns"
-          end
-        end
+        UnitTests::ModelCreationStrategies::ActiveModel.call(
+          'Example',
+          columns,
+          options,
+          &block
+        )
       end
 
-      if columns.key?(:id) && columns[:id] == false
-        columns.delete(:id)
-        create_table(table_name, id: false, &table_block)
-      else
-        create_table(table_name, &table_block)
+      def define_model(name, columns = {}, options = {}, &block)
+        model = UnitTests::ModelCreationStrategies::ActiveRecord.call(
+          name,
+          columns,
+          options,
+          &block
+        )
+        defined_models << model
+        model
       end
 
-      model = define_model_class(class_name).tap do |m|
-        if block
-          if block.arity == 0
-            m.class_eval(&block)
-          else
-            block.call(m)
-          end
+      private
+
+      def clear_column_caches
+        # Rails 4.x
+        if ::ActiveRecord::Base.connection.respond_to?(:schema_cache)
+          ::ActiveRecord::Base.connection.schema_cache.clear!
+        # Rails 3.1 - 4.0
+        elsif ::ActiveRecord::Base.connection_pool.respond_to?(:clear_cache!)
+          ::ActiveRecord::Base.connection_pool.clear_cache!
         end
 
-        m.table_name = table_name
+        defined_models.each do |model|
+          model.reset_column_information
+        end
       end
 
-      defined_models << model
+      def drop_created_tables
+        connection = ::ActiveRecord::Base.connection
 
-      model
-    end
-
-    private
-
-    def clear_column_caches
-      # Rails 4.x
-      if ActiveRecord::Base.connection.respond_to?(:schema_cache)
-        ActiveRecord::Base.connection.schema_cache.clear!
-      # Rails 3.1 - 4.0
-      elsif ActiveRecord::Base.connection_pool.respond_to?(:clear_cache!)
-        ActiveRecord::Base.connection_pool.clear_cache!
+        created_tables.each do |table_name|
+          connection.execute("DROP TABLE IF EXISTS #{table_name}")
+        end
       end
 
-      defined_models.each do |model|
-        model.reset_column_information
+      def created_tables
+        @_created_tables ||= []
       end
-    end
 
-    def drop_created_tables
-      connection = ActiveRecord::Base.connection
-
-      created_tables.each do |table_name|
-        connection.execute("DROP TABLE IF EXISTS #{table_name}")
+      def defined_models
+        @_defined_models ||= []
       end
-    end
-
-    def created_tables
-      @_created_tables ||= []
-    end
-
-    def defined_models
-      @_defined_models ||= []
     end
   end
 end

--- a/spec/support/unit/helpers/validation_matcher_scenario_helpers.rb
+++ b/spec/support/unit/helpers/validation_matcher_scenario_helpers.rb
@@ -1,0 +1,44 @@
+module UnitTests
+  module ValidationMatcherScenarioHelpers
+    def self.configure_example_group(example_group)
+      example_group.include(self)
+    end
+
+    def build_scenario_for_validation_matcher(args)
+      UnitTests::ValidationMatcherScenario.new(
+        build_validation_matcher_scenario_args(args)
+      )
+    end
+
+    protected
+
+    def validation_matcher_scenario_args
+      {}
+    end
+
+    def configure_validation_matcher(matcher)
+      matcher
+    end
+
+    private
+
+    def build_validation_matcher_scenario_args(args)
+      args.
+        deep_merge(validation_matcher_scenario_args).
+        deep_merge(
+          matcher_name: matcher_name,
+          matcher_proc: method(matcher_name)
+        )
+    end
+
+    def matcher_name
+      validation_matcher_scenario_args.fetch(:matcher_name) do
+        raise KeyNotFoundError.new(<<-MESSAGE)
+Please implement #validation_matcher_scenario_args in your example
+group, in such a way that it returns a hash that contains a
+:matcher_name key.
+        MESSAGE
+      end
+    end
+  end
+end

--- a/spec/support/unit/model_creation_strategies/active_model.rb
+++ b/spec/support/unit/model_creation_strategies/active_model.rb
@@ -1,0 +1,110 @@
+module UnitTests
+  module ModelCreationStrategies
+    class ActiveModel
+      def self.call(name, columns = {}, options = {}, &block)
+        new(name, columns, options, &block).call
+      end
+
+      def initialize(name, columns = {}, options = {}, &block)
+        @name = name
+        @columns = columns
+        @options = options
+        @model_customizers = []
+
+        if block
+          customize_model(&block)
+        end
+      end
+
+      def customize_model(&block)
+        model_customizers << block
+      end
+
+      def call
+        ClassBuilder.define_class(name, Model).tap do |model|
+          model.columns = columns.keys
+
+          model_customizers.each do |block|
+            run_block(model, block)
+          end
+        end
+      end
+
+      protected
+
+      attr_reader :name, :columns, :model_customizers, :options
+
+      private
+
+      def run_block(model, block)
+        if block
+          if block.arity == 0
+            model.class_eval(&block)
+          else
+            block.call(model)
+          end
+        end
+      end
+
+      class Model
+        class << self
+          def columns
+            @_columns ||= []
+          end
+
+          def columns=(columns)
+            existing_columns = self.columns
+            new_columns = columns - existing_columns
+
+            @_columns += new_columns
+
+            include attributes_module
+
+            attributes_module.module_eval do
+              new_columns.each do |column|
+                define_method(column) do
+                  attributes[column]
+                end
+
+                define_method("#{column}=") do |value|
+                  attributes[column] = value
+                end
+              end
+            end
+          end
+
+          private
+
+          def attributes_module
+            @_attributes_module ||= Module.new
+          end
+        end
+
+        include ::ActiveModel::Model
+
+        attr_reader :attributes
+
+        def initialize(attributes = {})
+          @attributes = attributes.symbolize_keys
+        end
+
+        def inspect
+          middle = '%s:0x%014x%s' % [
+            self.class,
+            object_id * 2,
+            ' ' + inspected_attributes.join(' ')
+          ]
+
+          "#<#{middle.strip}>"
+        end
+
+        private
+
+        def inspected_attributes
+          self.class.columns.
+            map { |key, value| "#{key}: #{attributes[key].inspect}" }
+        end
+      end
+    end
+  end
+end

--- a/spec/support/unit/model_creation_strategies/active_record.rb
+++ b/spec/support/unit/model_creation_strategies/active_record.rb
@@ -1,0 +1,79 @@
+module UnitTests
+  module ModelCreationStrategies
+    class ActiveRecord
+      def self.call(name, columns = {}, options = {}, &block)
+        new(name, columns, options, &block).call
+      end
+
+      def initialize(name, columns = {}, options = {}, &block)
+        @name = name
+        @columns = columns
+        @options = options
+        @model_customizers = []
+
+        if block
+          customize_model(&block)
+        end
+      end
+
+      def customize_model(&block)
+        model_customizers << block
+      end
+
+      def call
+        create_table_for_model
+        define_class_for_model
+      end
+
+      protected
+
+      attr_reader :columns, :model_customizers, :name, :options
+
+      private
+
+      def create_table_for_model
+        UnitTests::ActiveRecord::CreateTable.call(table_name, columns)
+      end
+
+      def define_class_for_model
+        model = UnitTests::ModelBuilder.define_model_class(class_name)
+
+        model_customizers.each do |block|
+          run_block(model, block)
+        end
+
+        if whitelist_attributes?
+          model.attr_accessible(*columns.keys)
+        end
+
+        model.table_name = table_name
+
+        model
+      end
+
+      def run_block(model, block)
+        if block
+          if block.arity == 0
+            model.class_eval(&block)
+          else
+            block.call(model)
+          end
+        end
+      end
+
+      def class_name
+        name.to_s.pluralize.classify
+      end
+
+      def table_name
+        class_name.tableize.gsub('/', '_')
+      end
+
+      def whitelist_attributes?
+        options.fetch(:whitelist_attributes, true)
+      end
+
+      ColumnNotSupportedError = Class.new(StandardError)
+    end
+  end
+end

--- a/spec/support/unit/model_creators.rb
+++ b/spec/support/unit/model_creators.rb
@@ -1,0 +1,19 @@
+module UnitTests
+  module ModelCreators
+    class << self
+      def register(name, klass)
+        registrations[name] = klass
+      end
+
+      def retrieve(name)
+        registrations[name]
+      end
+
+      private
+
+      def registrations
+        @_registrations ||= {}
+      end
+    end
+  end
+end

--- a/spec/support/unit/model_creators/active_model.rb
+++ b/spec/support/unit/model_creators/active_model.rb
@@ -1,0 +1,39 @@
+require_relative '../model_creators'
+require 'forwardable'
+
+module UnitTests
+  module ModelCreators
+    class ActiveModel
+      def self.call(args)
+        new(args).call
+      end
+
+      extend Forwardable
+
+      def_delegators(
+        :arguments,
+        :attribute_name,
+        :attribute_default_values_by_name,
+      )
+
+      def initialize(args)
+        @arguments = CreateModelArguments::Basic.wrap(
+          args.merge(
+            model_creation_strategy: UnitTests::ModelCreationStrategies::ActiveModel
+          )
+        )
+        @model_creator = Basic.new(arguments)
+      end
+
+      def call
+        model_creator.call
+      end
+
+      protected
+
+      attr_reader :arguments, :model_creator
+    end
+
+    register(:active_model, ActiveModel)
+  end
+end

--- a/spec/support/unit/model_creators/active_record.rb
+++ b/spec/support/unit/model_creators/active_record.rb
@@ -1,0 +1,43 @@
+require_relative '../model_creators'
+require 'forwardable'
+
+module UnitTests
+  module ModelCreators
+    class ActiveRecord
+      def self.call(args)
+        new(args).call
+      end
+
+      extend Forwardable
+
+      def_delegators(
+        :arguments,
+        :attribute_default_values_by_name,
+        :attribute_name,
+        :customize_model,
+        :model_name,
+      )
+
+      def_delegators :model_creator, :customize_model
+
+      def initialize(args)
+        @arguments = CreateModelArguments::Basic.wrap(
+          args.merge(
+            model_creation_strategy: UnitTests::ModelCreationStrategies::ActiveRecord
+          )
+        )
+        @model_creator = Basic.new(arguments)
+      end
+
+      def call
+        model_creator.call
+      end
+
+      protected
+
+      attr_reader :arguments, :model_creator
+    end
+
+    register(:active_record, ActiveRecord)
+  end
+end

--- a/spec/support/unit/model_creators/active_record/has_and_belongs_to_many.rb
+++ b/spec/support/unit/model_creators/active_record/has_and_belongs_to_many.rb
@@ -1,0 +1,95 @@
+require_relative '../../model_creators'
+require 'forwardable'
+
+module UnitTests
+  module ModelCreators
+    class ActiveRecord
+      class HasAndBelongsToMany
+        def self.call(args)
+          new(args).call
+        end
+
+        extend Forwardable
+
+        def_delegators(
+          :arguments,
+          :attribute_name,
+          :attribute_default_values_by_name,
+        )
+
+        def initialize(args)
+          @arguments = CreateModelArguments::HasMany.wrap(args)
+        end
+
+        def call
+          parent_child_table_creator.call
+          child_model_creator.call
+          parent_model_creator.call
+        end
+
+        protected
+
+        attr_reader :arguments
+
+        private
+
+        alias_method :association_name, :attribute_name
+        alias_method :parent_model_creator_arguments, :arguments
+
+        def parent_child_table_creator
+          @_parent_child_table_creator ||=
+            UnitTests::ActiveRecord::CreateTable.new(
+              parent_child_table_name,
+              foreign_key_for_child_model => :integer,
+              foreign_key_for_parent_model => :integer,
+              :id => false
+            )
+        end
+
+        def child_model_creator
+          @_child_model_creator ||=
+            UnitTests::ModelCreationStrategies::ActiveRecord.new(
+              child_model_name
+            )
+        end
+
+        def parent_model_creator
+          @_parent_model_creator ||= begin
+            model_creator = UnitTests::ModelCreators::ActiveRecord.new(
+              parent_model_creator_arguments
+            )
+
+            # TODO: doesn't this need to be a has_many :through?
+            model_creator.customize_model do |model|
+              model.has_many(association_name)
+            end
+
+            model_creator
+          end
+        end
+
+        def foreign_key_for_child_model
+          child_model_name.foreign_key
+        end
+
+        def foreign_key_for_parent_model
+          parent_model_name.foreign_key
+        end
+
+        def parent_child_table_name
+          "#{child_model_name.pluralize}#{parent_model_name}".tableize
+        end
+
+        def parent_model_name
+          parent_model_creator.model_name
+        end
+
+        def child_model_name
+          association_name.to_s.classify
+        end
+      end
+    end
+
+    register(:"active_record/habtm", ActiveRecord::HasAndBelongsToMany)
+  end
+end

--- a/spec/support/unit/model_creators/active_record/has_many.rb
+++ b/spec/support/unit/model_creators/active_record/has_many.rb
@@ -1,0 +1,67 @@
+require_relative '../../model_creators'
+require 'forwardable'
+
+module UnitTests
+  module ModelCreators
+    class ActiveRecord
+      class HasMany
+        def self.call(args)
+          new(args).call
+        end
+
+        extend Forwardable
+
+        def_delegators(
+          :arguments,
+          :attribute_name,
+          :attribute_default_values_by_name,
+        )
+
+        def initialize(args)
+          @arguments = CreateModelArguments::HasMany.wrap(args)
+        end
+
+        def call
+          child_model_creator.call
+          parent_model_creator.call
+        end
+
+        protected
+
+        attr_reader :arguments
+
+        private
+
+        alias_method :association_name, :attribute_name
+        alias_method :parent_model_creator_arguments, :arguments
+
+        def child_model_creator
+          @_child_model_creator ||=
+            UnitTests::ModelCreationStrategies::ActiveRecord.new(
+              child_model_name
+            )
+        end
+
+        def parent_model_creator
+          @_parent_model_creator ||= begin
+            model_creator = UnitTests::ModelCreators::ActiveRecord.new(
+              parent_model_creator_arguments
+            )
+
+            model_creator.customize_model do |model|
+              model.has_many(association_name)
+            end
+
+            model_creator
+          end
+        end
+
+        def child_model_name
+          association_name.to_s.classify
+        end
+      end
+    end
+
+    register(:"active_record/has_many", ActiveRecord::HasMany)
+  end
+end

--- a/spec/support/unit/model_creators/active_record/uniqueness_matcher.rb
+++ b/spec/support/unit/model_creators/active_record/uniqueness_matcher.rb
@@ -1,0 +1,42 @@
+require_relative '../../model_creators'
+require 'forwardable'
+
+module UnitTests
+  module ModelCreators
+    class ActiveRecord
+      class UniquenessMatcher
+        def self.call(args)
+          new(args).call
+        end
+
+        extend Forwardable
+
+        def_delegators(
+          :arguments,
+          :attribute_name,
+          :attribute_default_values_by_name,
+        )
+
+        def initialize(args)
+          @arguments = CreateModelArguments::UniquenessMatcher.wrap(args)
+          @model_creator = UnitTests::ModelCreators::ActiveRecord.new(
+            arguments
+          )
+        end
+
+        def call
+          model_creator.call
+        end
+
+        protected
+
+        attr_reader :arguments, :model_creator
+      end
+    end
+
+    register(
+      :"active_record/uniqueness_matcher",
+      ActiveRecord::UniquenessMatcher
+    )
+  end
+end

--- a/spec/support/unit/model_creators/basic.rb
+++ b/spec/support/unit/model_creators/basic.rb
@@ -1,0 +1,92 @@
+require 'forwardable'
+
+module UnitTests
+  module ModelCreators
+    class Basic
+      def self.call(args)
+        new(args).call
+      end
+
+      extend Forwardable
+
+      def_delegators :arguments, :attribute_name, :model_name
+      def_delegators :model_creator, :customize_model
+
+      def initialize(arguments)
+        @arguments = arguments
+        @model_creator = build_model_creator
+      end
+
+      def call
+        model_creator.call
+      end
+
+      protected
+
+      attr_reader :arguments, :model_creator
+
+      private
+
+      def_delegators(
+        :arguments,
+        :additional_model_creation_strategy_args,
+        :all_attribute_overrides,
+        :columns,
+        :custom_validation?,
+        :model_creation_strategy,
+        :validation_name,
+        :validation_options,
+        :column_type,
+      )
+
+      def build_model_creator
+        model_creator = model_creation_strategy.new(
+          model_name,
+          columns,
+          arguments
+        )
+
+        model_creator.customize_model do |model|
+          add_validation_to(model)
+          possibly_override_attribute_writer_method_for(model)
+        end
+
+        model_creator
+      end
+
+      def add_validation_to(model)
+        if custom_validation?
+          _attribute_name = attribute_name
+
+          model.send(:define_method, :custom_validation) do
+            custom_validation.call(self, _attribute_name)
+          end
+
+          model.validate(:custom_validation)
+        else
+          model.public_send(validation_name, attribute_name, validation_options)
+        end
+      end
+
+      def possibly_override_attribute_writer_method_for(model)
+        all_attribute_overrides.each do |attribute_name, overrides|
+          if overrides.key?(:changing_values_with)
+            _change_value = method(:change_value)
+
+            model.send(:define_method, "#{attribute_name}=") do |value|
+              new_value = _change_value.call(
+                value,
+                overrides[:changing_values_with]
+              )
+              super(new_value)
+            end
+          end
+        end
+      end
+
+      def change_value(value, value_changer)
+        UnitTests::ChangeValue.call(column_type, value, value_changer)
+      end
+    end
+  end
+end

--- a/spec/support/unit/shared_examples/ignoring_interference_by_writer.rb
+++ b/spec/support/unit/shared_examples/ignoring_interference_by_writer.rb
@@ -1,0 +1,102 @@
+shared_examples_for 'ignoring_interference_by_writer' do |common_config|
+  valid_tests = [
+    :raise_if_not_qualified,
+    :accept_if_qualified_but_changing_value_does_not_interfere,
+    :reject_if_qualified_but_changing_value_interferes
+  ]
+  tests = common_config.fetch(:tests)
+  tests.assert_valid_keys(valid_tests)
+
+  define_method(:common_config) { common_config }
+
+  context 'when the writer method for the attribute changes incoming values' do
+    context 'and the matcher has not been qualified with ignoring_interference_by_writer' do
+      config_for_test = tests[:raise_if_not_qualified]
+
+      if config_for_test
+        it 'raises an AttributeChangedValueError' do
+          args = build_args(config_for_test)
+          scenario = build_scenario_for_validation_matcher(args)
+          matcher = matcher_from(scenario)
+
+          assertion = lambda do
+            expect(scenario.record).to matcher
+          end
+
+          expect(&assertion).to raise_error(
+            Shoulda::Matchers::ActiveModel::AllowValueMatcher::AttributeChangedValueError
+          )
+        end
+      end
+    end
+
+    context 'and the matcher has been qualified with ignoring_interference_by_writer' do
+      context 'and the value change does not cause a test failure' do
+        config_for_test = tests[:accept_if_qualified_but_changing_value_does_not_interfere]
+
+        if config_for_test
+          it 'accepts (and does not raise an error)' do
+            args = build_args(config_for_test)
+            scenario = build_scenario_for_validation_matcher(args)
+            matcher = matcher_from(scenario)
+
+            expect(scenario.record).to matcher.ignoring_interference_by_writer
+          end
+        end
+      end
+
+      context 'and the value change causes a test failure' do
+        config_for_test = tests[:reject_if_qualified_but_changing_value_interferes]
+
+        if config_for_test
+          it 'lists how the value got changed in the failure message' do
+            args = build_args(config_for_test)
+            scenario = build_scenario_for_validation_matcher(args)
+            matcher = matcher_from(scenario)
+
+            assertion = lambda do
+              expect(scenario.record).to matcher.ignoring_interference_by_writer
+            end
+
+            if config_for_test.key?(:expected_message_includes)
+              message = config_for_test[:expected_message_includes]
+              expect(&assertion).to fail_with_message_including(message)
+            else
+              message = config_for_test.fetch(:expected_message)
+              expect(&assertion).to fail_with_message(message)
+            end
+          end
+        end
+      end
+    end
+  end
+
+  def build_args(config_for_test)
+    args_from_common_config.merge(args_from_config_for_test(config_for_test))
+  end
+
+  def args_from_common_config
+    common_config.slice(
+      :column_type,
+      :model_creator,
+    )
+  end
+
+  def args_from_config_for_test(config)
+    config.slice(
+      :attribute_name,
+      :attribute_overrides,
+      :changing_values_with,
+      :default_value,
+      :model_name,
+    )
+  end
+
+  def matcher_from(scenario)
+    scenario.matcher.tap do |matcher|
+      if respond_to?(:configure_validation_matcher)
+        configure_validation_matcher(matcher)
+      end
+    end
+  end
+end

--- a/spec/support/unit/validation_matcher_scenario.rb
+++ b/spec/support/unit/validation_matcher_scenario.rb
@@ -1,0 +1,62 @@
+require 'forwardable'
+
+module UnitTests
+  class ValidationMatcherScenario
+    extend Forwardable
+
+    attr_reader :matcher
+
+    def initialize(arguments)
+      @arguments = arguments.deep_dup
+      @matcher_proc = @arguments.delete(:matcher_proc)
+
+      @specified_model_creator = @arguments.delete(:model_creator) do
+        raise KeyError.new(<<-MESSAGE)
+:model_creator is missing. You can either provide it as an option or as
+a method.
+        MESSAGE
+      end
+
+      @model_creator = model_creator_class.new(@arguments)
+    end
+
+    def record
+      @_record ||= model.new.tap do |record|
+        attribute_default_values_by_name.each do |attribute_name, default_value|
+          record.public_send("#{attribute_name}=", default_value)
+        end
+      end
+    end
+
+    def model
+      @_model ||= model_creator.call
+    end
+
+    def matcher
+      @_matcher ||= matcher_proc.call(attribute_name)
+    end
+
+    protected
+
+    attr_reader(
+      :arguments,
+      :existing_value,
+      :matcher_proc,
+      :model_creator,
+      :specified_model_creator,
+    )
+
+    private
+
+    def_delegators(
+      :model_creator,
+      :attribute_name,
+      :attribute_default_values_by_name,
+    )
+
+    def model_creator_class
+      UnitTests::ModelCreators.retrieve(specified_model_creator) ||
+        specified_model_creator
+    end
+  end
+end

--- a/spec/unit/shoulda/matchers/active_model/allow_mass_assignment_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/allow_mass_assignment_of_matcher_spec.rb
@@ -108,4 +108,8 @@ describe Shoulda::Matchers::ActiveModel::AllowMassAssignmentOfMatcher, type: :mo
       end
     end
   end
+
+  def define_model(name, columns, &block)
+    super(name, columns, whitelist_attributes: false, &block)
+  end
 end

--- a/spec/unit/shoulda/matchers/active_model/allow_value_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/allow_value_matcher_spec.rb
@@ -433,11 +433,11 @@ invalid and to raise a validation exception with message matching
 
       context 'when the attribute cannot be changed from non-nil to nil' do
         it 'raises an AttributeChangedValueError' do
-          model = define_active_model_class 'Example' do
-            attr_reader :name
-
+          model = define_active_model_class 'Example', accessors: [:name] do
             def name=(value)
-              @name = value unless value.nil?
+              if value
+                super(value)
+              end
             end
           end
 

--- a/spec/unit/shoulda/matchers/active_model/allow_value_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/allow_value_matcher_spec.rb
@@ -641,4 +641,16 @@ value", but that attribute does not exist.
       end
     end
   end
+
+  context 'given an ActiveRecord model' do
+    context 'where the attribute under test is an enum and the given value is a value in that enum' do
+      it 'accepts' do
+        model = define_model('Shipment', status: :integer) do
+          enum status: { pending: 1, shipped: 2, delivered: 3 }
+        end
+
+        expect(model.new).to allow_value(1).for(:status)
+      end
+    end
+  end
 end

--- a/spec/unit/shoulda/matchers/active_model/validate_absence_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_absence_of_matcher_spec.rb
@@ -32,7 +32,27 @@ describe Shoulda::Matchers::ActiveModel::ValidateAbsenceOfMatcher, type: :model 
             expect(validating_absence_of(:attr, {}, type: type)).
               to validate_absence_of(:attr)
           end
+
+          it_supports(
+            'ignoring_interference_by_writer',
+            tests: {
+              raise_if_not_qualified: {
+                changing_values_with: :next_value
+              },
+              accept_if_qualified_but_changing_value_does_not_interfere: {
+                changing_values_with: :next_value
+              },
+            }
+          )
+
+          define_method(:validation_matcher_scenario_args) do |*args|
+            super(*args).deep_merge(column_type: type)
+          end
         end
+      end
+
+      def validation_matcher_scenario_args
+        super.deep_merge(model_creator: :active_record)
       end
     end
 
@@ -62,6 +82,22 @@ Example did not properly validate that :attr is empty/falsy.
       it 'does not override the default message with a blank' do
         expect(active_model_validating_absence_of(:attr)).to validate_absence_of(:attr).with_message(nil)
       end
+
+      it_supports(
+        'ignoring_interference_by_writer',
+        tests: {
+          raise_if_not_qualified: {
+            changing_values_with: :upcase
+          },
+          accept_if_qualified_but_changing_value_does_not_interfere: {
+            changing_values_with: :upcase
+          },
+        }
+      )
+
+      def validation_matcher_scenario_args
+        super.deep_merge(model_creator: :active_model)
+      end
     end
 
     context 'an ActiveModel class without an absence validation' do
@@ -73,7 +109,7 @@ Example did not properly validate that :attr is empty/falsy.
         MESSAGE
 
         assertion = lambda do
-           expect(active_model_with(:attr)).to validate_absence_of(:attr)
+          expect(active_model_with(:attr)).to validate_absence_of(:attr)
         end
 
         expect(&assertion).to fail_with_message(message)
@@ -83,6 +119,22 @@ Example did not properly validate that :attr is empty/falsy.
     context 'a has_many association with an absence validation' do
       it 'requires the attribute to not be set' do
         expect(having_many(:children, absence: true)).to validate_absence_of(:children)
+      end
+
+      it_supports(
+        'ignoring_interference_by_writer',
+        tests: {
+          raise_if_not_qualified: {
+            changing_values_with: :next_value
+          },
+          accept_if_qualified_but_changing_value_does_not_interfere: {
+            changing_values_with: :next_value
+          },
+        }
+      )
+
+      def validation_matcher_scenario_args
+        super.deep_merge(model_creator: :"active_record/has_many")
       end
     end
 
@@ -97,6 +149,22 @@ Example did not properly validate that :attr is empty/falsy.
       it 'accepts' do
         model = having_and_belonging_to_many(:children, absence: true)
         expect(model).to validate_absence_of(:children)
+      end
+
+      it_supports(
+        'ignoring_interference_by_writer',
+        tests: {
+          raise_if_not_qualified: {
+            changing_values_with: :next_value
+          },
+          accept_if_qualified_but_changing_value_does_not_interfere: {
+            changing_values_with: :next_value
+          },
+        }
+      )
+
+      def validation_matcher_scenario_args
+        super.deep_merge(model_creator: :"active_record/habtm")
       end
     end
 
@@ -145,14 +213,28 @@ Parent did not properly validate that :children is empty/falsy.
       end
     end
 
-    def validating_absence_of(attr, validation_options = {}, given_column_options = {})
+    def define_model_validating_absence_of(attr, validation_options = {}, given_column_options = {})
       default_column_options = { type: :string, options: {} }
       column_options = default_column_options.merge(given_column_options)
 
-      define_model :example, attr => column_options do
-        validates_absence_of attr, validation_options
-      end.new
+      define_model :example, attr => column_options do |model|
+        model.validates_absence_of(attr, validation_options)
+
+        if block_given?
+          yield model
+        end
+      end
     end
+
+    def validating_absence_of(attr, validation_options = {}, given_column_options = {})
+      model = define_model_validating_absence_of(
+        attr,
+        validation_options,
+        given_column_options
+      )
+      model.new
+    end
+    alias_method :build_record_validating_absence_of, :validating_absence_of
 
     def active_model_with(attr, &block)
       define_active_model_class('Example', accessors: [attr], &block).new
@@ -187,6 +269,10 @@ Parent did not properly validate that :children is empty/falsy.
           validates_absence_of plural_name
         end
       end.new
+    end
+
+    def validation_matcher_scenario_args
+      super.deep_merge(matcher_name: :validate_absence_of)
     end
   end
 end

--- a/spec/unit/shoulda/matchers/active_model/validate_acceptance_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_acceptance_of_matcher_spec.rb
@@ -9,6 +9,35 @@ describe Shoulda::Matchers::ActiveModel::ValidateAcceptanceOfMatcher, type: :mod
     it 'does not overwrite the default message with nil' do
       expect(record_validating_acceptance).to matcher.with_message(nil)
     end
+
+    it_supports(
+      'ignoring_interference_by_writer',
+      tests: {
+        raise_if_not_qualified: {
+          changing_values_with: :never_falsy,
+        },
+        accept_if_qualified_but_changing_value_does_not_interfere: {
+          changing_values_with: :never_falsy,
+        },
+        reject_if_qualified_but_changing_value_interferes: {
+          model_name: 'Example',
+          attribute_name: :attr,
+          changing_values_with: :always_nil,
+          expected_message: <<-MESSAGE.strip
+Example did not properly validate that :attr has been set to "1".
+  After setting :attr to ‹false› -- which was read back as ‹nil› -- the
+  matcher expected the Example to be invalid, but it was valid instead.
+
+  As indicated in the message above, :attr seems to be changing certain
+  values as they are set, and this could have something to do with why
+  this test is failing. If you've overridden the writer method for this
+  attribute, then you may need to change it to make this test pass, or
+  do something else entirely.
+          MESSAGE
+        },
+      },
+      model_creator: :active_model
+    )
   end
 
   context 'a model without an acceptance validation' do
@@ -33,8 +62,9 @@ describe Shoulda::Matchers::ActiveModel::ValidateAcceptanceOfMatcher, type: :mod
     validate_acceptance_of(:attr)
   end
 
-  def model_validating_nothing(&block)
-    define_active_model_class(:example, accessors: [:attr], &block)
+  def model_validating_nothing(options = {}, &block)
+    attribute_name = options.fetch(:attribute_name, :attr)
+    define_active_model_class(:example, accessors: [attribute_name], &block)
   end
 
   def record_validating_nothing
@@ -42,12 +72,23 @@ describe Shoulda::Matchers::ActiveModel::ValidateAcceptanceOfMatcher, type: :mod
   end
 
   def model_validating_acceptance(options = {})
-    model_validating_nothing do
-      validates_acceptance_of :attr, options
+    attribute_name = options.fetch(:attribute_name, :attr)
+
+    model_validating_nothing(attribute_name: attribute_name) do
+      validates_acceptance_of attribute_name, options
     end
   end
 
+  alias_method :define_model_validating_acceptance, :model_validating_acceptance
+
   def record_validating_acceptance(options = {})
     model_validating_acceptance(options).new
+  end
+
+  alias_method :build_record_validating_acceptance,
+    :record_validating_acceptance
+
+  def validation_matcher_scenario_args
+    { matcher_name: :validate_acceptance_of }
   end
 end

--- a/spec/unit/shoulda/matchers/active_model/validate_exclusion_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_exclusion_of_matcher_spec.rb
@@ -16,6 +16,44 @@ describe Shoulda::Matchers::ActiveModel::ValidateExclusionOfMatcher, type: :mode
       expect(validating_exclusion(in: 2..5)).
         to validate_exclusion_of(:attr).in_range(2..5).with_message(nil)
     end
+
+    it_supports(
+      'ignoring_interference_by_writer',
+      tests: {
+        raise_if_not_qualified: {
+          changing_values_with: :next_value,
+        },
+        reject_if_qualified_but_changing_value_interferes: {
+          model_name: 'Example',
+          attribute_name: :attr,
+          changing_values_with: :next_value,
+          expected_message: <<-MESSAGE.strip
+Example did not properly validate that :attr lies outside the range ‹2›
+to ‹5›.
+  After setting :attr to ‹1› -- which was read back as ‹2› -- the
+  matcher expected the Example to be valid, but it was invalid instead,
+  producing these validation errors:
+
+  * attr: ["is reserved"]
+
+  As indicated in the message above, :attr seems to be changing certain
+  values as they are set, and this could have something to do with why
+  this test is failing. If you've overridden the writer method for this
+  attribute, then you may need to change it to make this test pass, or
+  do something else entirely.
+          MESSAGE
+        },
+      },
+      model_creator: :active_model
+    ) do
+      def validation_matcher_scenario_args
+        super.deep_merge(validation_options: { in: 2..5 })
+      end
+
+      def configure_validation_matcher(matcher)
+        matcher.in_range(2..5)
+      end
+    end
   end
 
   context 'an attribute which must be excluded from a range with excluded end' do
@@ -110,16 +148,66 @@ describe Shoulda::Matchers::ActiveModel::ValidateExclusionOfMatcher, type: :mode
       end
     end
 
-    def validating_exclusion(options)
-      define_model(:example, attr: :string) do
-        validates_exclusion_of :attr, options
-      end.new
+    it_supports(
+      'ignoring_interference_by_writer',
+      tests: {
+        raise_if_not_qualified: {
+          changing_values_with: :next_value,
+        },
+        reject_if_qualified_but_changing_value_interferes: {
+          model_name: 'Example',
+          attribute_name: :attr,
+          changing_values_with: :next_value,
+          expected_message: <<-MESSAGE.strip
+Example did not properly validate that :attr is neither ‹"one"› nor
+‹"two"›.
+  After setting :attr to ‹"one"› -- which was read back as ‹"onf"› --
+  the matcher expected the Example to be invalid, but it was valid
+  instead.
+
+  As indicated in the message above, :attr seems to be changing certain
+  values as they are set, and this could have something to do with why
+  this test is failing. If you've overridden the writer method for this
+  attribute, then you may need to change it to make this test pass, or
+  do something else entirely.
+        MESSAGE
+        },
+      },
+      model_creator: :active_model
+    ) do
+      def validation_matcher_scenario_args
+        super.deep_merge(validation_options: { in: ['one', 'two'] })
+      end
+
+      def configure_validation_matcher(matcher)
+        matcher.in_array(['one', 'two'])
+      end
+    end
+
+    def define_model_validating_exclusion(options)
+      options = options.dup
+      column_type = options.delete(:column_type) { :string }
+      super options.merge(column_type: column_type)
+    end
+  end
+
+  def define_model_validating_exclusion(options)
+    options = options.dup
+    attribute_name = options.delete(:attribute_name) { :attr }
+    column_type = options.delete(:column_type) { :integer }
+
+    define_model(:example, attribute_name => column_type) do |model|
+      model.validates_exclusion_of(attribute_name, options)
     end
   end
 
   def validating_exclusion(options)
-    define_model(:example, attr: :integer) do
-      validates_exclusion_of :attr, options
-    end.new
+    define_model_validating_exclusion(options).new
+  end
+
+  alias_method :build_record_validating_exclusion, :validating_exclusion
+
+  def validation_matcher_scenario_args
+    super.deep_merge(matcher_name: :validate_exclusion_of)
   end
 end

--- a/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb
@@ -18,7 +18,6 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
           matches_or_not.reverse!
           to_or_not_to.reverse!
         end
-
       end
     end
 
@@ -48,6 +47,10 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
 
       def add_outside_value_to(values)
         values + [values.last + 1]
+      end
+
+      def validation_matcher_scenario_args
+        super.deep_merge(column_type: :integer, default_value: 1)
       end
     end
 
@@ -95,6 +98,10 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
       def add_outside_value_to(values)
         values + [values.last + 1]
       end
+
+      def validation_matcher_scenario_args
+        super.deep_merge(column_type: :float, default_value: 1.0)
+      end
     end
 
     context 'against a decimal attribute' do
@@ -119,10 +126,19 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
       def add_outside_value_to(values)
         values + [values.last + 1]
       end
+
+      def validation_matcher_scenario_args
+        super.deep_merge(
+          column_type: :decimal,
+          default_value: BigDecimal.new('1.0')
+        )
+      end
     end
 
     context 'against a date attribute' do
       today = Date.today
+
+      define_method(:today) { today }
 
       it_behaves_like 'it supports in_array',
         possible_values: (1..5).map { |n| today + n },
@@ -141,10 +157,16 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
       def add_outside_value_to(values)
         values + [values.last + 1]
       end
+
+      def validation_matcher_scenario_args
+        super.deep_merge(column_type: :date, default_value: today)
+      end
     end
 
     context 'against a datetime attribute' do
       now = DateTime.now
+
+      define_method(:now) { now }
 
       it_behaves_like 'it supports in_array',
         possible_values: (1..5).map { |n| now + n },
@@ -163,10 +185,16 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
       def add_outside_value_to(values)
         values + [values.last + 1]
       end
+
+      def validation_matcher_scenario_args
+        super.deep_merge(column_type: :datetime, default_value: now)
+      end
     end
 
     context 'against a time attribute' do
       now = Time.now
+
+      define_method(:now) { now }
 
       it_behaves_like 'it supports in_array',
         possible_values: (1..5).map { |n| now + n },
@@ -185,6 +213,10 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
       def add_outside_value_to(values)
         values + [values.last + 1]
       end
+
+      def validation_matcher_scenario_args
+        super.deep_merge(column_type: :time, default_value: now)
+      end
     end
 
     context 'against a string attribute' do
@@ -202,6 +234,10 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
       def add_outside_value_to(values)
         values + %w(qux)
       end
+
+      def validation_matcher_scenario_args
+        super.deep_merge(column_type: :string)
+      end
     end
   end
 
@@ -210,7 +246,10 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
 
     testing_values_of_option 'allow_nil' do |option_args, matches_or_not, to_or_not_to|
       it "#{matches_or_not[0]} when the validation specifies allow_nil" do
-        builder = build_object_allowing(valid_values, allow_nil: true)
+        builder = build_object_allowing(
+          valid_values,
+          validation_options: { allow_nil: true }
+        )
 
         __send__("expect_#{to_or_not_to[0]}_match_on_values", builder, valid_values) do |matcher|
           matcher.allow_nil(*option_args)
@@ -225,6 +264,37 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
         end
       end
     end
+
+    it_supports(
+      'ignoring_interference_by_writer',
+      tests: {
+        raise_if_not_qualified: {
+          changing_values_with: :next_value,
+        },
+        accept_if_qualified_but_changing_value_does_not_interfere: {
+          changing_values_with: -> (value) { value || valid_values.first }
+        },
+        reject_if_qualified_but_changing_value_interferes: {
+          attribute_name: :attr,
+          changing_values_with: :never_falsy,
+          expected_message_includes: <<-MESSAGE.strip
+  As indicated in the message above, :attr seems to be changing certain
+  values as they are set, and this could have something to do with why
+  this test is failing. If you've overridden the writer method for this
+  attribute, then you may need to change it to make this test pass, or
+  do something else entirely.
+          MESSAGE
+        }
+      }
+    )
+
+    def validation_matcher_scenario_args
+      super.deep_merge(validation_options: { allow_nil: true })
+    end
+
+    def configure_validation_matcher(matcher)
+      super(matcher).allow_nil
+    end
   end
 
   shared_examples_for 'it supports allow_blank' do |args|
@@ -232,7 +302,10 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
 
     testing_values_of_option 'allow_blank' do |option_args, matches_or_not, to_or_not_to|
       it "#{matches_or_not[0]} when the validation specifies allow_blank" do
-        builder = build_object_allowing(valid_values, allow_blank: true)
+        builder = build_object_allowing(
+          valid_values,
+          validation_options: { allow_blank: true }
+        )
 
         __send__("expect_#{to_or_not_to[0]}_match_on_values", builder, valid_values) do |matcher|
           matcher.allow_blank(*option_args)
@@ -247,6 +320,39 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
         end
       end
     end
+
+    it_supports(
+      'ignoring_interference_by_writer',
+      tests: {
+        raise_if_not_qualified: {
+          changing_values_with: :next_value,
+        },
+        accept_if_qualified_but_changing_value_does_not_interfere: {
+          changing_values_with: -> (value) {
+            value.presence || valid_values.first
+          }
+        },
+        reject_if_qualified_but_changing_value_interferes: {
+          attribute_name: :attr,
+          changing_values_with: :never_blank,
+          expected_message_includes: <<-MESSAGE.strip
+  As indicated in the message above, :attr seems to be changing certain
+  values as they are set, and this could have something to do with why
+  this test is failing. If you've overridden the writer method for this
+  attribute, then you may need to change it to make this test pass, or
+  do something else entirely.
+          MESSAGE
+        }
+      }
+    )
+
+    def validation_matcher_scenario_args
+      super.deep_merge(validation_options: { allow_blank: true })
+    end
+
+    def configure_validation_matcher(matcher)
+      super(matcher).allow_blank
+    end
   end
 
   shared_examples_for 'it supports with_message' do |args|
@@ -254,7 +360,10 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
 
     context 'given a string' do
       it 'matches when validation uses given message' do
-        builder = build_object_allowing(valid_values, message: 'a message')
+        builder = build_object_allowing(
+          valid_values,
+          validation_options: { message: 'a message' }
+        )
 
         expect_to_match_on_values(builder, valid_values) do |matcher|
           matcher.with_message('a message')
@@ -270,7 +379,10 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
       end
 
       it 'does not match when validation uses a message but it is not same as given' do
-        builder = build_object_allowing(valid_values, message: 'a different message')
+        builder = build_object_allowing(
+          valid_values,
+          validation_options: { message: 'a different message' }
+        )
 
         expect_not_to_match_on_values(builder, valid_values) do |matcher|
           matcher.with_message('a message')
@@ -280,7 +392,10 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
 
     context 'given a regex' do
       it 'matches when validation uses a message that matches the regex' do
-        builder = build_object_allowing(valid_values, message: 'this is a message')
+        builder = build_object_allowing(
+          valid_values,
+          validation_options: { message: 'this is a message' }
+        )
 
         expect_to_match_on_values(builder, valid_values) do |matcher|
           matcher.with_message(/a message/)
@@ -296,7 +411,10 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
       end
 
       it 'does not match when validation uses a message but it does not match regex' do
-        builder = build_object_allowing(valid_values, message: 'a different message')
+        builder = build_object_allowing(
+          valid_values,
+          validation_options: { message: 'a different message' }
+        )
 
         expect_not_to_match_on_values(builder, valid_values) do |matcher|
           matcher.with_message(/a message/)
@@ -319,6 +437,8 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
     possible_values = args.fetch(:possible_values)
     zero = args[:zero]
     reserved_outside_value = args.fetch(:reserved_outside_value)
+
+    define_method(:valid_values) { args.fetch(:possible_values) }
 
     it 'does not match a record with no validations' do
       builder = build_object
@@ -364,7 +484,10 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
       context '+ strict' do
         context 'when the validation specifies strict' do
           it 'matches when the given values match the valid values' do
-            builder = build_object_allowing(possible_values, strict: true)
+            builder = build_object_allowing(
+              possible_values,
+              validation_options: { strict: true }
+            )
 
             expect_to_match_on_values(builder, possible_values) do |matcher|
               matcher.strict
@@ -372,7 +495,10 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
           end
 
           it 'does not match when the given values do not match the valid values' do
-            builder = build_object_allowing(possible_values, strict: true)
+            builder = build_object_allowing(
+              possible_values,
+              validation_options: { strict: true }
+            )
 
             values = add_outside_value_to(possible_values)
             expect_not_to_match_on_values(builder, values) do |matcher|
@@ -393,6 +519,26 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
       end
     end
 
+    it_supports(
+      'ignoring_interference_by_writer',
+      tests: {
+        raise_if_not_qualified: {
+          changing_values_with: :next_value,
+        },
+        reject_if_qualified_but_changing_value_interferes: {
+          attribute_name: :attr,
+          changing_values_with: :next_value,
+          expected_message_includes: <<-MESSAGE.strip
+  As indicated in the message above, :attr seems to be changing certain
+  values as they are set, and this could have something to do with why
+  this test is failing. If you've overridden the writer method for this
+  attribute, then you may need to change it to make this test pass, or
+  do something else entirely.
+          MESSAGE
+        }
+      }
+    )
+
     def expect_to_match_on_values(builder, values, &block)
       expect_to_match_in_array(builder, values, &block)
     end
@@ -400,10 +546,20 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
     def expect_not_to_match_on_values(builder, values, &block)
       expect_not_to_match_in_array(builder, values, &block)
     end
+
+    def validation_matcher_scenario_args
+      super.deep_merge(validation_options: { in: valid_values })
+    end
+
+    def configure_validation_matcher(matcher)
+      super(matcher).in_array(valid_values)
+    end
   end
 
   shared_examples_for 'it supports in_range' do |args|
     possible_values = args[:possible_values]
+
+    define_method(:valid_values) { args.fetch(:possible_values) }
 
     it 'does not match a record with no validations' do
       builder = build_object
@@ -451,7 +607,10 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
       context '+ strict' do
         context 'when the validation specifies strict' do
           it 'matches when the given range matches the range in the validation' do
-            builder = build_object_allowing(possible_values, strict: true)
+            builder = build_object_allowing(
+              possible_values,
+              validation_options: { strict: true }
+            )
 
             expect_to_match_on_values(builder, possible_values) do |matcher|
               matcher.strict
@@ -459,7 +618,10 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
           end
 
           it 'matches when the given range does not match the range in the validation' do
-            builder = build_object_allowing(possible_values, strict: true)
+            builder = build_object_allowing(
+              possible_values,
+              validation_options: { strict: true }
+            )
 
             range = Range.new(possible_values.first, possible_values.last + 1)
             expect_not_to_match_on_values(builder, range) do |matcher|
@@ -480,12 +642,40 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
       end
     end
 
+    it_supports(
+      'ignoring_interference_by_writer',
+      tests: {
+        raise_if_not_qualified: {
+          changing_values_with: :next_value,
+        },
+        reject_if_qualified_but_changing_value_interferes: {
+          attribute_name: :attr,
+          changing_values_with: :next_value,
+          expected_message_includes: <<-MESSAGE.strip
+  As indicated in the message above, :attr seems to be changing certain
+  values as they are set, and this could have something to do with why
+  this test is failing. If you've overridden the writer method for this
+  attribute, then you may need to change it to make this test pass, or
+  do something else entirely.
+          MESSAGE
+        }
+      }
+    )
+
     def expect_to_match_on_values(builder, range, &block)
       expect_to_match_in_range(builder, range, &block)
     end
 
     def expect_not_to_match_on_values(builder, range, &block)
       expect_not_to_match_in_range(builder, range, &block)
+    end
+
+    def validation_matcher_scenario_args
+      super.deep_merge(validation_options: { in: valid_values })
+    end
+
+    def configure_validation_matcher(matcher)
+      super(matcher).in_range(valid_values)
     end
   end
 
@@ -537,6 +727,8 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
     context 'against a timestamp column' do
       now = DateTime.now
 
+      define_method(:now) { now }
+
       it_behaves_like 'it supports in_array',
         possible_values: (1..5).map { |n| now + n },
         reserved_outside_value: described_class::ARBITRARY_OUTSIDE_DATETIME
@@ -553,6 +745,10 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
 
       def add_outside_value_to(values)
         values + [values.last + 1]
+      end
+
+      def validation_matcher_scenario_args
+        super.deep_merge(column_type: :timestamp, default_value: now)
       end
     end
 
@@ -615,27 +811,12 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
       end
     end
 
-    def build_object_with_generic_attribute(options = {}, &block)
-      attribute_name = :attr
-      column_type = options.fetch(:column_type)
-      column_options = {
-        type: column_type,
-        options: options.fetch(:column_options, {})
-      }
-      validation_options = options[:validation_options]
-      custom_validation = options[:custom_validation]
+    def define_simple_model(attribute_name: :attr, column_options: {}, &block)
+      define_model('Example', attribute_name => column_options, &block)
+    end
 
-      model = define_model :example, attribute_name => column_options
-      customize_model_class(
-        model,
-        attribute_name,
-        validation_options,
-        custom_validation
-      )
-
-      object = model.new
-
-      object_builder_class.new(attribute_name, object, validation_options)
+    def validation_matcher_scenario_args
+      super.deep_merge(model_creator: :active_record)
     end
   end
 
@@ -658,24 +839,12 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
       end
     end
 
-    def build_object_with_generic_attribute(options = {}, &block)
-      attribute_name = :attr
-      validation_options = options[:validation_options]
-      custom_validation = options[:custom_validation]
-      value = options[:value]
+    def define_simple_model(attribute_name: :attr, column_options: {}, &block)
+      define_active_model_class('Example', accessors: [attribute_name], &block)
+    end
 
-      model = define_active_model_class :example, accessors: [attribute_name]
-      customize_model_class(
-        model,
-        attribute_name,
-        validation_options,
-        custom_validation
-      )
-
-      object = model.new
-      object.__send__("#{attribute_name}=", value)
-
-      object_builder_class.new(attribute_name, object, validation_options)
+    def validation_matcher_scenario_args
+      super.deep_merge(model_creator: :active_model)
     end
   end
 
@@ -727,24 +896,63 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
     @_object_builder_class ||= Struct.new(:attribute, :object, :validation_options)
   end
 
-  def customize_model_class(klass, attribute_name, validation_options, custom_validation)
-    klass.class_eval do
+  def build_object_with_generic_attribute(
+    attribute_name: :attr,
+    validation_options: nil,
+    value: nil,
+    **other_options
+  )
+    model = define_model_validating_inclusion(
+      attribute_name: attribute_name,
+      validation_options: validation_options,
+      **other_options
+    )
+
+    object = model.new
+    object.__send__("#{attribute_name}=", value)
+
+    object_builder_class.new(attribute_name, object, validation_options)
+  end
+
+  def define_model_validating_inclusion(
+    attribute_name: :attr,
+    column_type: :string,
+    column_options: {},
+    validation_options: nil,
+    custom_validation: nil,
+    customize_model_class: -> (object) { }
+  )
+    column_options = { type: column_type, options: column_options }
+
+    define_simple_model(
+      attribute_name: attribute_name,
+      column_options: column_options
+    ) do |model|
       if validation_options
-        validates_inclusion_of attribute_name, validation_options
+        model.validates_inclusion_of(attribute_name, validation_options)
       end
 
       if custom_validation
-        define_method :custom_validation do
-          instance_exec(attribute_name, &custom_validation)
-        end
+        model.class_eval do
+          define_method :custom_validation do
+            custom_validation.call(self, attribute_name)
+          end
 
-        validate :custom_validation
+          validate :custom_validation
+        end
+      end
+
+      if customize_model_class
+        model.instance_eval(&customize_model_class)
       end
     end
   end
 
-  def build_object_allowing(values, options = {})
-    build_object(validation_options: options.merge(in: values))
+  def build_object_allowing(values, validation_options: {}, **other_options)
+    build_object(
+      validation_options: validation_options.merge(in: values),
+      **other_options
+    )
   end
 
   def expect_to_match(builder)
@@ -791,13 +999,13 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
     low_message = 'too low'
     high_message = 'too high'
 
-    builder = build_object custom_validation: ->(attribute) {
-      value = __send__(attribute)
+    builder = build_object custom_validation: -> (object, attribute) {
+      value = object.public_send(attribute)
 
       if value < low_value
-        errors.add(attribute, low_message)
+        object.errors.add(attribute, low_message)
       elsif value > high_value
-        errors.add(attribute, high_message)
+        object.errors.add(attribute, high_message)
       end
     }
 
@@ -807,5 +1015,9 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
         with_low_message(low_message).
         with_high_message(high_message)
     end
+  end
+
+  def validation_matcher_scenario_args
+    super.deep_merge(matcher_name: :validate_inclusion_of)
   end
 end

--- a/spec/unit/shoulda/matchers/active_model/validate_numericality_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_numericality_of_matcher_spec.rb
@@ -127,6 +127,34 @@ describe Shoulda::Matchers::ActiveModel::ValidateNumericalityOfMatcher, type: :m
         expect(record).to validate_numericality
       end
 
+      it_supports(
+        'ignoring_interference_by_writer',
+        tests: {
+          raise_if_not_qualified: {
+            changing_values_with: :next_value,
+          },
+          accept_if_qualified_but_changing_value_does_not_interfere: {
+            changing_values_with: :next_value,
+          },
+          reject_if_qualified_but_changing_value_interferes: {
+            model_name: 'Example',
+            attribute_name: :attr,
+            changing_values_with: :numeric_value,
+            expected_message: <<-MESSAGE.strip
+Example did not properly validate that :attr looks like a number.
+  After setting :attr to ‹"abcd"› -- which was read back as ‹"1"› -- the
+  matcher expected the Example to be invalid, but it was valid instead.
+
+  As indicated in the message above, :attr seems to be changing certain
+  values as they are set, and this could have something to do with why
+  this test is failing. If you've overridden the writer method for this
+  attribute, then you may need to change it to make this test pass, or
+  do something else entirely.
+            MESSAGE
+          }
+        }
+      )
+
       context 'when the column is an integer column' do
         it 'raises an IneffectiveTestError' do
           record = build_record_validating_numericality(
@@ -187,6 +215,47 @@ Example did not properly validate that :attr looks like a number.
         record = build_record_validating_numericality(allow_nil: true)
         expect(record).to validate_numericality.allow_nil
       end
+
+      it_supports(
+        'ignoring_interference_by_writer',
+        tests: {
+          raise_if_not_qualified: {
+            changing_values_with: :next_value_or_numeric_value,
+          },
+          accept_if_qualified_but_changing_value_does_not_interfere: {
+            changing_values_with: :next_value_or_numeric_value,
+          },
+          reject_if_qualified_but_changing_value_interferes: {
+            model_name: 'Example',
+            attribute_name: :attr,
+            changing_values_with: :next_value_or_non_numeric_value,
+            expected_message: <<-MESSAGE.strip
+Example did not properly validate that :attr looks like a number, but
+only if it is not nil.
+  In checking that Example allows :attr to be ‹nil›, after setting :attr
+  to ‹nil› -- which was read back as ‹"a"› -- the matcher expected the
+  Example to be valid, but it was invalid instead, producing these
+  validation errors:
+
+  * attr: ["is not a number"]
+
+  As indicated in the message above, :attr seems to be changing certain
+  values as they are set, and this could have something to do with why
+  this test is failing. If you've overridden the writer method for this
+  attribute, then you may need to change it to make this test pass, or
+  do something else entirely.
+            MESSAGE
+          }
+        }
+      ) do
+        def validation_matcher_scenario_args
+          super.deep_merge(validation_options: { allow_nil: true })
+        end
+
+        def configure_validation_matcher(matcher)
+          matcher.allow_nil
+        end
+      end
     end
 
     context 'and not validating with allow_nil' do
@@ -218,6 +287,42 @@ only if it is not nil.
         record = build_record_validating_numericality(only_integer: true)
         expect(record).to validate_numericality.only_integer
       end
+
+      it_supports(
+        'ignoring_interference_by_writer',
+        tests: {
+          raise_if_not_qualified: {
+            changing_values_with: :next_value,
+          },
+          accept_if_qualified_but_changing_value_does_not_interfere: {
+            changing_values_with: :next_value,
+          },
+          reject_if_qualified_but_changing_value_interferes: {
+            model_name: 'Example',
+            attribute_name: :attr,
+            changing_values_with: :numeric_value,
+            expected_message: <<-MESSAGE.strip
+Example did not properly validate that :attr looks like an integer.
+  After setting :attr to ‹"0.1"› -- which was read back as ‹"1"› -- the
+  matcher expected the Example to be invalid, but it was valid instead.
+
+  As indicated in the message above, :attr seems to be changing certain
+  values as they are set, and this could have something to do with why
+  this test is failing. If you've overridden the writer method for this
+  attribute, then you may need to change it to make this test pass, or
+  do something else entirely.
+            MESSAGE
+          }
+        }
+      ) do
+        def validation_matcher_scenario_args
+          super.deep_merge(validation_options: { only_integer: true })
+        end
+
+        def configure_validation_matcher(matcher)
+          matcher.only_integer
+        end
+      end
     end
 
     context 'and not validating with only_integer' do
@@ -244,6 +349,42 @@ Example did not properly validate that :attr looks like an integer.
       it 'accepts' do
         record = build_record_validating_numericality(odd: true)
         expect(record).to validate_numericality.odd
+      end
+
+      it_supports(
+        'ignoring_interference_by_writer',
+        tests: {
+          raise_if_not_qualified: {
+            changing_values_with: :next_next_value,
+          },
+          accept_if_qualified_but_changing_value_does_not_interfere: {
+            changing_values_with: :next_next_value,
+          },
+          reject_if_qualified_but_changing_value_interferes: {
+            model_name: 'Example',
+            attribute_name: :attr,
+            changing_values_with: :next_value,
+            expected_message: <<-MESSAGE.strip
+Example did not properly validate that :attr looks like an odd number.
+  After setting :attr to ‹"2"› -- which was read back as ‹"3"› -- the
+  matcher expected the Example to be invalid, but it was valid instead.
+
+  As indicated in the message above, :attr seems to be changing certain
+  values as they are set, and this could have something to do with why
+  this test is failing. If you've overridden the writer method for this
+  attribute, then you may need to change it to make this test pass, or
+  do something else entirely.
+            MESSAGE
+          }
+        }
+      ) do
+        def validation_matcher_scenario_args
+          super.deep_merge(validation_options: { odd: true })
+        end
+
+        def configure_validation_matcher(matcher)
+          matcher.odd
+        end
       end
 
       context 'when the column is an integer column' do
@@ -306,6 +447,42 @@ Example did not properly validate that :attr looks like an odd number.
         expect(record).to validate_numericality.even
       end
 
+      it_supports(
+        'ignoring_interference_by_writer',
+        tests: {
+          raise_if_not_qualified: {
+            changing_values_with: :next_next_value,
+          },
+          accept_if_qualified_but_changing_value_does_not_interfere: {
+            changing_values_with: :next_next_value,
+          },
+          reject_if_qualified_but_changing_value_interferes: {
+            model_name: 'Example',
+            attribute_name: :attr,
+            changing_values_with: :next_value,
+            expected_message: <<-MESSAGE.strip
+Example did not properly validate that :attr looks like an even number.
+  After setting :attr to ‹"1"› -- which was read back as ‹"2"› -- the
+  matcher expected the Example to be invalid, but it was valid instead.
+
+  As indicated in the message above, :attr seems to be changing certain
+  values as they are set, and this could have something to do with why
+  this test is failing. If you've overridden the writer method for this
+  attribute, then you may need to change it to make this test pass, or
+  do something else entirely.
+            MESSAGE
+          }
+        }
+      ) do
+        def validation_matcher_scenario_args
+          super.deep_merge(validation_options: { even: true })
+        end
+
+        def configure_validation_matcher(matcher)
+          matcher.even
+        end
+      end
+
       context 'when the column is an integer column' do
         it 'accepts (and does not raise an error)' do
           record = build_record_validating_numericality(
@@ -366,6 +543,45 @@ Example did not properly validate that :attr looks like an even number.
           less_than_or_equal_to: 18
         )
         expect(record).to validate_numericality.is_less_than_or_equal_to(18)
+      end
+
+      it_supports(
+        'ignoring_interference_by_writer',
+        tests: {
+          raise_if_not_qualified: {
+            changing_values_with: :next_value,
+          },
+          reject_if_qualified_but_changing_value_interferes: {
+            model_name: 'Example',
+            attribute_name: :attr,
+            changing_values_with: :next_value,
+            expected_message: <<-MESSAGE.strip
+Example did not properly validate that :attr looks like a number less
+than or equal to 18.
+  After setting :attr to ‹"18"› -- which was read back as ‹"19"› -- the
+  matcher expected the Example to be valid, but it was invalid instead,
+  producing these validation errors:
+
+  * attr: ["must be less than or equal to 18"]
+
+  As indicated in the message above, :attr seems to be changing certain
+  values as they are set, and this could have something to do with why
+  this test is failing. If you've overridden the writer method for this
+  attribute, then you may need to change it to make this test pass, or
+  do something else entirely.
+            MESSAGE
+          }
+        }
+      ) do
+        def validation_matcher_scenario_args
+          super.deep_merge(
+            validation_options: { less_than_or_equal_to: 18 }
+          )
+        end
+
+        def configure_validation_matcher(matcher)
+          matcher.is_less_than_or_equal_to(18)
+        end
       end
 
       context 'when the column is an integer column' do
@@ -431,6 +647,43 @@ than or equal to 18.
           is_less_than(18)
       end
 
+      it_supports(
+        'ignoring_interference_by_writer',
+        tests: {
+          raise_if_not_qualified: {
+            changing_values_with: :next_value,
+          },
+          reject_if_qualified_but_changing_value_interferes: {
+            model_name: 'Example',
+            attribute_name: :attr,
+            changing_values_with: :next_value,
+            expected_message: <<-MESSAGE.strip
+Example did not properly validate that :attr looks like a number less
+than 18.
+  After setting :attr to ‹"17"› -- which was read back as ‹"18"› -- the
+  matcher expected the Example to be valid, but it was invalid instead,
+  producing these validation errors:
+
+  * attr: ["must be less than 18"]
+
+  As indicated in the message above, :attr seems to be changing certain
+  values as they are set, and this could have something to do with why
+  this test is failing. If you've overridden the writer method for this
+  attribute, then you may need to change it to make this test pass, or
+  do something else entirely.
+            MESSAGE
+          }
+        }
+      ) do
+        def validation_matcher_scenario_args
+          super.deep_merge(validation_options: { less_than: 18 })
+        end
+
+        def configure_validation_matcher(matcher)
+          matcher.is_less_than(18)
+        end
+      end
+
       context 'when the column is an integer column' do
         it 'accepts (and does not raise an error)' do
           record = build_record_validating_numericality(
@@ -490,6 +743,43 @@ than 18.
       it 'accepts' do
         record = build_record_validating_numericality(equal_to: 18)
         expect(record).to validate_numericality.is_equal_to(18)
+      end
+
+      it_supports(
+        'ignoring_interference_by_writer',
+        tests: {
+          raise_if_not_qualified: {
+            changing_values_with: :next_value,
+          },
+          reject_if_qualified_but_changing_value_interferes: {
+            model_name: 'Example',
+            attribute_name: :attr,
+            changing_values_with: :next_value,
+            expected_message: <<-MESSAGE.strip
+Example did not properly validate that :attr looks like a number equal
+to 18.
+  After setting :attr to ‹"18"› -- which was read back as ‹"19"› -- the
+  matcher expected the Example to be valid, but it was invalid instead,
+  producing these validation errors:
+
+  * attr: ["must be equal to 18"]
+
+  As indicated in the message above, :attr seems to be changing certain
+  values as they are set, and this could have something to do with why
+  this test is failing. If you've overridden the writer method for this
+  attribute, then you may need to change it to make this test pass, or
+  do something else entirely.
+            MESSAGE
+          }
+        }
+      ) do
+        def validation_matcher_scenario_args
+          super.deep_merge(validation_options: { equal_to: 18 })
+        end
+
+        def configure_validation_matcher(matcher)
+          matcher.is_equal_to(18)
+        end
       end
 
       context 'when the column is an integer column' do
@@ -555,6 +845,42 @@ to 18.
         expect(record).
           to validate_numericality.
           is_greater_than_or_equal_to(18)
+      end
+
+      it_supports(
+        'ignoring_interference_by_writer',
+        tests: {
+          raise_if_not_qualified: {
+            changing_values_with: :next_value,
+          },
+          reject_if_qualified_but_changing_value_interferes: {
+            model_name: 'Example',
+            attribute_name: :attr,
+            changing_values_with: :next_value,
+            expected_message: <<-MESSAGE.strip
+Example did not properly validate that :attr looks like a number greater
+than or equal to 18.
+  After setting :attr to ‹"17"› -- which was read back as ‹"18"› -- the
+  matcher expected the Example to be invalid, but it was valid instead.
+
+  As indicated in the message above, :attr seems to be changing certain
+  values as they are set, and this could have something to do with why
+  this test is failing. If you've overridden the writer method for this
+  attribute, then you may need to change it to make this test pass, or
+  do something else entirely.
+            MESSAGE
+          }
+        }
+      ) do
+        def validation_matcher_scenario_args
+          super.deep_merge(
+            validation_options: { greater_than_or_equal_to: 18 }
+          )
+        end
+
+        def configure_validation_matcher(matcher)
+          matcher.is_greater_than_or_equal_to(18)
+        end
       end
 
       context 'when the column is an integer column' do
@@ -625,6 +951,40 @@ than or equal to 18.
         expect(record).
           to validate_numericality.
           is_greater_than(18)
+      end
+
+      it_supports(
+        'ignoring_interference_by_writer',
+        tests: {
+          raise_if_not_qualified: {
+            changing_values_with: :next_value,
+          },
+          reject_if_qualified_but_changing_value_interferes: {
+            model_name: 'Example',
+            attribute_name: :attr,
+            changing_values_with: :next_value,
+            expected_message: <<-MESSAGE.strip
+Example did not properly validate that :attr looks like a number greater
+than 18.
+  After setting :attr to ‹"18"› -- which was read back as ‹"19"› -- the
+  matcher expected the Example to be invalid, but it was valid instead.
+
+  As indicated in the message above, :attr seems to be changing certain
+  values as they are set, and this could have something to do with why
+  this test is failing. If you've overridden the writer method for this
+  attribute, then you may need to change it to make this test pass, or
+  do something else entirely.
+            MESSAGE
+          }
+        }
+      ) do
+        def validation_matcher_scenario_args
+          super.deep_merge(validation_options: { greater_than: 18 })
+        end
+
+        def configure_validation_matcher(matcher)
+          matcher.is_greater_than(18)
+        end
       end
 
       context 'when the column is an integer column' do
@@ -1252,6 +1612,38 @@ greater than 18 and less than 99.
 
       expect(model.new).to validate_numericality_of(:attr)
     end
+
+    it_supports(
+      'ignoring_interference_by_writer',
+      tests: {
+        raise_if_not_qualified: {
+          changing_values_with: :next_value,
+        },
+        accept_if_qualified_but_changing_value_does_not_interfere: {
+          changing_values_with: :next_value,
+        },
+        reject_if_qualified_but_changing_value_interferes: {
+          model_name: 'Example',
+          attribute_name: :attr,
+          changing_values_with: :numeric_value,
+          expected_message: <<-MESSAGE.strip
+Example did not properly validate that :attr looks like a number.
+  After setting :attr to ‹"abcd"› -- which was read back as ‹1› -- the
+  matcher expected the Example to be invalid, but it was valid instead.
+
+  As indicated in the message above, :attr seems to be changing certain
+  values as they are set, and this could have something to do with why
+  this test is failing. If you've overridden the writer method for this
+  attribute, then you may need to change it to make this test pass, or
+  do something else entirely.
+          MESSAGE
+        }
+      }
+    )
+
+    def validation_matcher_scenario_args
+      super.deep_merge(model_creator: :active_model)
+    end
   end
 
   describe '#description' do
@@ -1389,5 +1781,12 @@ greater than 18 and less than 99.
 
   def attribute_name
     :attr
+  end
+
+  def validation_matcher_scenario_args
+    super.deep_merge(
+      matcher_name: :validate_numericality_of,
+      model_creator: :active_record
+    )
   end
 end

--- a/spec/unit_spec_helper.rb
+++ b/spec/unit_spec_helper.rb
@@ -23,6 +23,7 @@ RSpec.configure do |config|
   UnitTests::ActiveModelVersions.configure_example_group(config)
   UnitTests::DatabaseHelpers.configure_example_group(config)
   UnitTests::ColumnTypeHelpers.configure_example_group(config)
+  UnitTests::ValidationMatcherScenarioHelpers.configure_example_group(config)
 
   config.include UnitTests::Matchers
 


### PR DESCRIPTION
This is basically an answer to #799, #800, #819, and other issues, and also supercedes #820. 

The idea here is to add `ignoring_interference_by_writer` to all matchers (except for `allow_value`) -- but with a key twist, which is that matchers are still aware of when attributes change values, but it will only let the user know about them if the matcher in question fails. This way, the user (and I) still have a window in what is going on under the hood, but it won't disrupt what the user is trying to do normally.