### PR TITLE
require date for ValidateInclusionOfMatcher

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
@@ -1,4 +1,5 @@
 require 'bigdecimal'
+require 'date'
 
 module Shoulda
   module Matchers


### PR DESCRIPTION
Hi,

I'm attempting to package shoulda-matchers for the GNU Guix package manager, and came across what I imagine to be a rather obscure bug:
```
/tmp/nix-build-ruby-shoulda-matchers-3.0.1.drv-0/gem/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb:269:in `<class:ValidateInclusionOfMatcher>': uninitialized constant Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher::Date (NameError)
	from /tmp/nix-build-ruby-shoulda-matchers-3.0.1.drv-0/gem/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb:265:in `<module:ActiveModel>'
	from /tmp/nix-build-ruby-shoulda-matchers-3.0.1.drv-0/gem/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb:5:in `<module:Matchers>'
	from /tmp/nix-build-ruby-shoulda-matchers-3.0.1.drv-0/gem/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb:4:in `<module:Shoulda>'
	from /tmp/nix-build-ruby-shoulda-matchers-3.0.1.drv-0/gem/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb:3:in `<top (required)>'
	from /gnu/store/15i5z93xj8v1myqdh5d4d3apqyqzlnza-ruby-2.2.3/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:121:in `require'
	from /gnu/store/15i5z93xj8v1myqdh5d4d3apqyqzlnza-ruby-2.2.3/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:121:in `require'
	from /tmp/nix-build-ruby-shoulda-matchers-3.0.1.drv-0/gem/lib/shoulda/matchers/active_model.rb:8:in `<top (required)>'
	from /gnu/store/15i5z93xj8v1myqdh5d4d3apqyqzlnza-ruby-2.2.3/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:121:in `require'
	from /gnu/store/15i5z93xj8v1myqdh5d4d3apqyqzlnza-ruby-2.2.3/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:121:in `require'
	from /tmp/nix-build-ruby-shoulda-matchers-3.0.1.drv-0/gem/lib/shoulda/matchers.rb:13:in `<top (required)>'
	from /gnu/store/15i5z93xj8v1myqdh5d4d3apqyqzlnza-ruby-2.2.3/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /gnu/store/15i5z93xj8v1myqdh5d4d3apqyqzlnza-ruby-2.2.3/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /tmp/nix-build-ruby-shoulda-matchers-3.0.1.drv-0/gem/lib/shoulda-matchers.rb:1:in `<top (required)>'
	from /gnu/store/15i5z93xj8v1myqdh5d4d3apqyqzlnza-ruby-2.2.3/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /gnu/store/15i5z93xj8v1myqdh5d4d3apqyqzlnza-ruby-2.2.3/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
```
I think it is just a simple matter of requiring date as in the attached patch to fix. I presume that this error does not occur in most environments, but I'm operating in a quite restricted one while building shoulda-matchers, and I imagine that is the reason this issue hasn't been noticed before.
```
$ gem list
activesupport (4.2.4)
bigdecimal (1.2.6)
i18n (0.7.0)
io-console (0.4.3)
json (1.8.3, 1.8.1)
minitest (5.7.0, 5.4.3)
power_assert (0.2.2)
psych (2.0.8)
rake (10.4.2)
rdoc (4.2.0)
test-unit (3.0.8)
thread_safe (0.3.5)
tzinfo (1.2.2)
```