### PR TITLE
Change in? to include?

### DIFF
--- a/lib/shoulda/matchers/action_controller/route_params.rb
+++ b/lib/shoulda/matchers/action_controller/route_params.rb
@@ -42,7 +42,7 @@ module Shoulda
         end
 
         def symbolize_or_stringify(key, value)
-          if key.in?(PARAMS_TO_SYMBOLIZE)
+          if PARAMS_TO_SYMBOLIZE.include?(key)
             value.to_sym
           else
             stringify(value)

--- a/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
+++ b/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
@@ -697,7 +697,7 @@ module Shoulda
         end
 
         def boolean_value?(value)
-          value.in?([true, false])
+          [true, false].include?(value)
         end
 
         def defined_as_enum?(scope)

--- a/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
@@ -1307,7 +1307,7 @@ Example did not properly validate that :name is case-sensitively unique.
       SecureRandom.uuid
     elsif value.is_a?(Time)
       value + 1
-    elsif value.in?([true, false])
+    elsif [true, false].include?(value)
       !value
     elsif value.respond_to?(:next)
       value.next


### PR DESCRIPTION
Use ```include?``` to check membership of an array instead of ```in?```.

Fixes #877 

All tests passing in this branch.
```
>> bundle check --gemfile='/Users/oogali/shoulda-matchers/gemfiles/4.0.0.gemfile' || bundle install --gemfile='/Users/oogali/shoulda-matchers/gemfiles/4.0.0.gemfile'
Warning: the running version of Bundler is older than the version that created the lockfile. We suggest you upgrade to the latest version of Bundler by running `gem install bundler`.
The Gemfile's dependencies are satisfied
>> bundle check --gemfile='/Users/oogali/shoulda-matchers/gemfiles/4.0.1.gemfile' || bundle install --gemfile='/Users/oogali/shoulda-matchers/gemfiles/4.0.1.gemfile'
Warning: the running version of Bundler is older than the version that created the lockfile. We suggest you upgrade to the latest version of Bundler by running `gem install bundler`.
The Gemfile's dependencies are satisfied
>> bundle check --gemfile='/Users/oogali/shoulda-matchers/gemfiles/4.1.gemfile' || bundle install --gemfile='/Users/oogali/shoulda-matchers/gemfiles/4.1.gemfile'
Warning: the running version of Bundler is older than the version that created the lockfile. We suggest you upgrade to the latest version of Bundler by running `gem install bundler`.
The Gemfile's dependencies are satisfied
>> bundle check --gemfile='/Users/oogali/shoulda-matchers/gemfiles/4.2.gemfile' || bundle install --gemfile='/Users/oogali/shoulda-matchers/gemfiles/4.2.gemfile'
Warning: the running version of Bundler is older than the version that created the lockfile. We suggest you upgrade to the latest version of Bundler by running `gem install bundler`.
The Gemfile's dependencies are satisfied
>> BUNDLE_GEMFILE=/Users/oogali/shoulda-matchers/gemfiles/4.2.gemfile bundle exec rake --trace
** Invoke default (first_time)
** Execute default
rake spec:unit --trace
** Invoke spec:unit (first_time)
** Execute spec:unit

Randomized with seed 62006
....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 1 minute 4.08 seconds (files took 7.64 seconds to load)
1668 examples, 0 failures

Randomized with seed 62006


Non shoulda-matchers warnings were raised during the test run. These have been written to /Users/oogali/shoulda-matchers/tmp/irrelevant_warnings.txt.
All warnings were written to /Users/oogali/shoulda-matchers/tmp/all_warnings.txt.

rake spec:acceptance --trace
** Invoke spec:acceptance (first_time)
** Execute spec:acceptance

Randomized with seed 41061
........

Finished in 1 minute 1.09 seconds (files took 0.51343 seconds to load)
8 examples, 0 failures

Randomized with seed 41061
```