### PR TITLE
Restoring setting attribute via __send__

### DIFF
--- a/lib/shoulda/matchers/active_model/allow_value_matcher/attribute_setter.rb
+++ b/lib/shoulda/matchers/active_model/allow_value_matcher/attribute_setter.rb
@@ -80,7 +80,7 @@ module Shoulda
           end
 
           def set
-            object.public_send("#{attribute_name}=", value_written)
+            object.__send__("#{attribute_name}=", value_written)
             after_set_callback.call
 
             @result_of_checking = successful_check
@@ -154,7 +154,7 @@ module Shoulda
             if active_resource_object?
               object.known_attributes.include?(attribute_name.to_s)
             else
-              object.respond_to?("#{attribute_name}=")
+              object.respond_to?("#{attribute_name}=", true)
             end
           end
 

--- a/spec/unit/shoulda/matchers/active_model/validate_presence_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_presence_of_matcher_spec.rb
@@ -37,6 +37,27 @@ Example did not properly validate that :attr cannot be empty/falsy.
     )
   end
 
+  context 'a model with a private setter method' do
+    let(:record) do
+      class ModelWithPrivateAttribute
+        include ActiveModel::Validations
+        validates :attr, presence: true
+        def initialize(options = {})
+          self.attr = options.fetch(:attr)
+        end
+        attr_accessor :attr
+        private :attr=
+      end.new(:attr => 'hello')
+    end
+    it 'will not throw an exception' do
+      assertion = lambda do
+        expect(record).to matcher
+      end
+
+      expect(&assertion).to_not raise_error
+    end
+  end
+
   context 'a model without a presence validation' do
     it 'rejects with the correct failure message' do
       record = define_model(:example, attr: :string).new


### PR DESCRIPTION
The following commit @296211211497e624dde87adae68b385ad4cdae3a changed
the setting of attributes from `__send__` to `public_send`. This does
not account for situations in which the setter method is private.

``` ruby
class ModelWithPrivateAttribute
  def initialize(name:)
    self.name = name
  end

  include ActiveModel::Validations
  validates :name, presence: true

  attr_accessor :name
  private :name=
end
```

Closes #887
