### PR TITLE
Require ActiveSupport's `try` core extension

### DIFF
--- a/lib/shoulda/matchers.rb
+++ b/lib/shoulda/matchers.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/object/try'
+
 require 'shoulda/matchers/configuration'
 require 'shoulda/matchers/doublespeak'
 require 'shoulda/matchers/error'


### PR DESCRIPTION
Usage of `try` throughout shoulda-matchers is broken when this file is not required
