### PR TITLE
Fix permit matcher for multiple instances of params

### DIFF
--- a/lib/shoulda/matchers/action_controller/permit_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/permit_matcher.rb
@@ -336,7 +336,7 @@ module Shoulda
         # @private
         class CompositeParametersDoubleRegistry
           def initialize
-            @parameters_double_registries_by_params = {}
+            @parameters_double_registries = []
           end
 
           def register
@@ -347,20 +347,19 @@ module Shoulda
               params = call.return_value
               parameters_double_registry = ParametersDoubleRegistry.new(params)
               parameters_double_registry.register
-              parameters_double_registries_by_params[params] =
-                parameters_double_registry
+              parameters_double_registries << parameters_double_registry
             end
           end
 
           def permitted_parameter_names(options = {})
-            parameters_double_registries_by_params.flat_map do |params, double_registry|
+            parameters_double_registries.flat_map do |double_registry|
               double_registry.permitted_parameter_names(options)
             end
           end
 
           protected
 
-          attr_reader :parameters_double_registries_by_params
+          attr_reader :parameters_double_registries
         end
 
         # @private

--- a/spec/unit/shoulda/matchers/action_controller/permit_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/action_controller/permit_matcher_spec.rb
@@ -190,6 +190,15 @@ describe Shoulda::Matchers::ActionController::PermitMatcher, type: :controller d
       for(:update, params: { id: 1 })
   end
 
+  it 'works when multiple ActionController::Parameters were instantiated' do
+    define_controller_with_strong_parameters(action: :create) do
+      params.permit(:name)
+      params.dup
+    end
+
+    expect(controller).to permit(:name).for(:create)
+  end
+
   describe '#matches?' do
     it 'does not raise an error when #fetch was used instead of #require (issue #495)' do
       matcher = permit(:eta, :diner_id).for(:create)


### PR DESCRIPTION
When the permit matcher is used without `#on`, the controller does not use `params#require`, and the params object gets duplicated, the matcher did not recognize the `#permit` call inside the controller. This happened because the matcher overwrote double registries with the same parameter hash whenever ActionController::Parameters was instantiated. The duplication happens unintentionally when passing the params to a model's method that ends up calling `#assign_attributes`, like `#new`.
This is related to #899.

Here's the part of the call stack that was doing the duplication in Rails:

```
/home/ari/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/activesupport-4.2.5.1/lib/active_support/hash_with_indifferent_access.rb:190:in `dup'
/home/ari/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/actionpack-4.2.5.1/lib/action_controller/metal/strong_parameters.rb:438:in `dup'
/home/ari/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/activesupport-4.2.5.1/lib/active_support/hash_with_indifferent_access.rb:232:in `stringify_keys'
/home/ari/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/protected_attributes-1.1.3/lib/active_record/mass_assignment_security/attribute_assignment.rb:51:in `assign_attributes'
/home/ari/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/protected_attributes-1.1.3/lib/active_record/mass_assignment_security/persistence.rb:64:in `block in update'
```
