### PR TITLE
Allow to use the matchers with just rspec expectations gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,30 @@ describe Person do
 end
 ```
 
+### RSpec-Expectations
+
+Use this instead of the RSpec ifself in case you just use the specific module gem
+'rspec-expectations' to test webpart(s).
+
+Include `shoulda-matchers` in your Gemfile:
+
+``` ruby
+group :test do
+  gem 'shoulda-matchers'
+end
+```
+
+Then, configure the gem to integrate with RSpec specifying the test framework as `:rspec_exp`:
+
+    Shoulda::Matchers.configure do |config|
+      config.integrate do |with|
+        with.test_framework :rspec_exp
+        # ...
+      end
+    end
+
+Now you can use matchers in your tests as for RSpec part.
+
 ### Minitest
 
 Shoulda Matchers was originally a component of [Shoulda][shoulda], a gem that

--- a/lib/shoulda/matchers/integrations/test_frameworks.rb
+++ b/lib/shoulda/matchers/integrations/test_frameworks.rb
@@ -3,6 +3,7 @@ require 'shoulda/matchers/integrations/test_frameworks/minitest_4'
 require 'shoulda/matchers/integrations/test_frameworks/minitest_5'
 require 'shoulda/matchers/integrations/test_frameworks/missing_test_framework'
 require 'shoulda/matchers/integrations/test_frameworks/rspec'
+require 'shoulda/matchers/integrations/test_frameworks/rspec_expectations'
 require 'shoulda/matchers/integrations/test_frameworks/test_unit'
 
 module Shoulda

--- a/lib/shoulda/matchers/integrations/test_frameworks/rspec_expectations.rb
+++ b/lib/shoulda/matchers/integrations/test_frameworks/rspec_expectations.rb
@@ -1,0 +1,34 @@
+module Shoulda
+  module Matchers
+    module Integrations
+      module TestFrameworks
+        # @private
+        class RspecExpectations
+          Integrations.register_test_framework(self, :rspec_exp)
+
+          def validate!
+            return if defined? RSpec::Matchers
+            raise TestFrameworkNotFound, <<-EOT
+You need to include the 'rspec-expectations' gem to Gemfile, and add
+the line before requiring the shoulda matchers:
+
+require 'rspec/expectations'
+EOT
+          end
+
+          def include(*modules, **_options)
+            RSpec::Matchers.send(:include, *modules)
+          end
+
+          def n_unit?
+            false
+          end
+
+          def present?
+            true
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/acceptance/rspec_expectation_test_framework_integration_spec.rb
+++ b/spec/acceptance/rspec_expectation_test_framework_integration_spec.rb
@@ -1,0 +1,59 @@
+require 'acceptance_spec_helper'
+
+describe 'shoulda-matchers integrates libs for rspec-expectations framework' do
+  before do
+    create_rails_application
+
+    write_file 'db/migrate/1_create_users.rb', <<-FILE
+      class CreateUsers < ActiveRecord::Migration
+        def self.up
+          create_table :users do |t|
+            t.string :name
+          end
+        end
+      end
+    FILE
+
+    run_rake_tasks!(*%w(db:drop db:create db:migrate))
+
+    write_file 'app/models/user.rb', <<-FILE
+      class User < ActiveRecord::Base
+        validates_presence_of :name
+        validates_uniqueness_of :name
+      end
+    FILE
+
+    append_rake_task 'rspec_exp', 'environment', <<-CODE
+  require 'rspec/expectations'
+  require 'shoulda-matchers'
+  require_relative 'test/test_helper.rb'
+
+  def expect(value, &block)
+    ::RSpec::Expectations::ExpectationTarget.for(value, block)
+  end
+
+  def validate_presence_of(value)
+    ::ActiveSupport::TestCase.validate_presence_of(value)
+  end
+
+  it = User.create name: 'Vasja'
+  expect(User.first).to validate_presence_of(:name)
+  puts "Passed"
+    CODE
+
+    updating_bundle do
+      add_rspec_expectations_to_project!
+      add_shoulda_matchers_to_project(
+        test_frameworks: [:rspec_exp],
+        libraries: [:active_record, :active_model],
+      )
+    end
+  end
+
+  context 'when using both active_record and active_model libraries' do
+    it 'allows the use of matchers from both libraries' do
+      result = run_rake_tasks 'rspec_exp'
+      expect(result).to have_output('Passed')
+    end
+  end
+end

--- a/spec/support/acceptance/adds_shoulda_matchers_to_project.rb
+++ b/spec/support/acceptance/adds_shoulda_matchers_to_project.rb
@@ -94,7 +94,8 @@ module AcceptanceTests
       files = []
 
       if integrates_with_nunit_and_rails?(test_framework, libraries) ||
-        integrates_with_nunit_only?(test_framework)
+          integrates_with_nunit_only?(test_framework) ||
+          integrates_with_rspec_expectations?(test_framework)
         files << 'test/test_helper.rb'
       end
 
@@ -116,6 +117,10 @@ module AcceptanceTests
 
     def integrates_with_rspec?(test_framework)
       test_framework == :rspec
+    end
+
+    def integrates_with_rspec_expectations?(test_framework)
+      test_framework == :rspec_exp
     end
 
     def integrates_with_rspec_rails_3_x?(test_framework, libraries)

--- a/spec/support/acceptance/helpers/command_helpers.rb
+++ b/spec/support/acceptance/helpers/command_helpers.rb
@@ -51,5 +51,18 @@ module AcceptanceTests
       args = ['rake', *tasks, '--trace'] + [options]
       run_command_within_bundle!(*args)
     end
+
+    def append_rake_task(task, depends_on, code)
+      file = File.join(fs.project_directory, 'Rakefile')
+      if IO.read(file).split("\n").grep("task :#{task}").empty?
+        depend_line = [depends_on].flatten.map { |x| ":#{x}" }.join(', ')
+        task_code = <<-CODE
+task :#{task} => [ #{depend_line} ] do
+  #{code.strip}
+end
+        CODE
+        append_to_file file, task_code
+      end
+    end
   end
 end

--- a/spec/support/acceptance/helpers/step_helpers.rb
+++ b/spec/support/acceptance/helpers/step_helpers.rb
@@ -112,6 +112,10 @@ module AcceptanceTests
       run_command_within_bundle 'rspec --format documentation --backtrace', *paths
     end
 
+    def add_rspec_expectations_to_project!
+      add_gem 'rspec-expectations', rspec_expectations_version
+    end
+
     def run_rspec_suite
       run_rake_tasks('spec', env: { SPEC_OPTS: '-fd' })
     end


### PR DESCRIPTION
Allow to use the matchers for the just rspec expectations, apart the whole

RSpec.
- It adds the specific test framework that just includes the specified
  libraries directly to RSpec::Matchers.

The addition is covered with an acceptance test.
