### PR TITLE
fix #867 by adding keyword argument params

### DIFF
--- a/lib/shoulda/matchers/action_controller/permit_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/permit_matcher.rb
@@ -250,7 +250,7 @@ module Shoulda
           parameters_double_registry.register
 
           Doublespeak.with_doubles_activated do
-            context.__send__(verb, action, request_params)
+            context.__send__(verb, action, params: request_params)
           end
 
           unpermitted_parameter_names.empty?


### PR DESCRIPTION
Stops triggering the deprecation warning: ActionController::TestCase HTTP request methods will accept only keyword arguments in future Rails versions.
