### PR TITLE
Correct typo in docs

### DIFF
--- a/lib/shoulda/matchers/active_record/define_enum_for_matcher.rb
+++ b/lib/shoulda/matchers/active_record/define_enum_for_matcher.rb
@@ -11,7 +11,6 @@ module Shoulda
       #     # RSpec
       #     describe Process do
       #       it { should define_enum_for(:status) }
-      #       end
       #     end
       #
       #     # Minitest (Shoulda)


### PR DESCRIPTION
A leftover `end` was left from the boilerplate.