### PR TITLE
Fix enums with hashes

### DIFF
--- a/lib/shoulda/matchers/active_record/define_enum_for_matcher.rb
+++ b/lib/shoulda/matchers/active_record/define_enum_for_matcher.rb
@@ -64,7 +64,7 @@ module Shoulda
 
         def matches?(subject)
           @record = subject
-          enum_defined? && enum_values_match? && column_type_is_integer?
+          enum_defined? && enum_values_match?
         end
 
         def failure_message
@@ -83,8 +83,6 @@ module Shoulda
           if options[:expected_enum_values]
             desc << " with #{options[:expected_enum_values]}"
           end
-
-          desc << " and store the value in a column with an integer type"
 
           desc
         end
@@ -111,14 +109,6 @@ module Shoulda
 
         def enum_values_match?
           expected_enum_values.empty? || actual_enum_values == expected_enum_values
-        end
-
-        def column_type_is_integer?
-          column.type == :integer
-        end
-
-        def column
-          model.columns_hash[attribute_name.to_s]
         end
 
         def model

--- a/spec/unit/shoulda/matchers/active_record/define_enum_for_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/define_enum_for_matcher_spec.rb
@@ -6,7 +6,7 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
       it 'rejects' do
         record = record_with_array_values
         plural_enum_attribute = enum_attribute.to_s.pluralize
-        message = "Expected #{record.class} to define :#{plural_enum_attribute} as an enum and store the value in a column with an integer type"
+        message = "Expected #{record.class} to define :#{plural_enum_attribute} as an enum"
 
         assertion = lambda do
           expect(record).to define_enum_for(plural_enum_attribute)
@@ -22,7 +22,7 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
           def self.statuses; end
         end
 
-        message = "Expected #{model} to define :statuses as an enum and store the value in a column with an integer type"
+        message = "Expected #{model} to define :statuses as an enum"
 
         assertion = lambda do
           expect(model.new).to define_enum_for(:statuses)
@@ -38,7 +38,7 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
       end
 
       it "rejects a record where the attribute is not defined as an enum" do
-        message = "Expected #{record_with_array_values.class} to define :#{non_enum_attribute} as an enum and store the value in a column with an integer type"
+        message = "Expected #{record_with_array_values.class} to define :#{non_enum_attribute} as an enum"
 
         assertion = lambda do
           expect(record_with_array_values).
@@ -49,7 +49,7 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
       end
 
       it "rejects a record where the attribute is not defined as an enum with should not" do
-        message = "Did not expect #{record_with_array_values.class} to define :#{enum_attribute} as an enum and store the value in a column with an integer type"
+        message = "Did not expect #{record_with_array_values.class} to define :#{enum_attribute} as an enum"
 
         assertion = lambda do
           expect(record_with_array_values).
@@ -62,7 +62,7 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
       context 'if the column storing the attribute is not an integer type' do
         it 'rejects' do
           record = record_with_array_values(column_type: :string)
-          message = "Expected #{record.class} to define :statuses as an enum and store the value in a column with an integer type"
+          message = "Expected #{record.class} to define :statuses as an enum"
 
           assertion = lambda do
             expect(record).to define_enum_for(:statuses)
@@ -81,7 +81,7 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
         end
 
         it "accepts a record where the attribute is not defined as an enum" do
-          message = %{Expected #{record_with_array_values.class} to define :#{non_enum_attribute} as an enum with ["open", "close"] and store the value in a column with an integer type}
+          message = %{Expected #{record_with_array_values.class} to define :#{non_enum_attribute} as an enum with ["open", "close"]}
 
           assertion = lambda do
             expect(record_with_array_values).
@@ -92,7 +92,7 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
         end
 
         it "accepts a record where the attribute is defined as an enum but the enum values do not match" do
-          message = %{Expected #{record_with_array_values.class} to define :#{enum_attribute} as an enum with ["open", "close"] and store the value in a column with an integer type}
+          message = %{Expected #{record_with_array_values.class} to define :#{enum_attribute} as an enum with ["open", "close"]}
 
           assertion = lambda do
             expect(record_with_array_values).
@@ -114,7 +114,7 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
         end
 
         it "accepts a record where the attribute is defined as an enum but the enum values do not match" do
-          message = %{Expected #{record_with_hash_values.class} to define :#{enum_attribute} as an enum with {:active=>5, :archived=>10} and store the value in a column with an integer type}
+          message = %{Expected #{record_with_hash_values.class} to define :#{enum_attribute} as an enum with {:active=>5, :archived=>10}}
 
           assertion = lambda do
             expect(record_with_hash_values).
@@ -126,7 +126,7 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
         end
 
         it "rejects a record where the attribute is not defined as an enum" do
-          message = %{Expected #{record_with_hash_values.class} to define :record_with_hash_values as an enum with {:active=>5, :archived=>10} and store the value in a column with an integer type}
+          message = %{Expected #{record_with_hash_values.class} to define :record_with_hash_values as an enum with {:active=>5, :archived=>10}}
 
           assertion = lambda do
             expect(record_with_hash_values).


### PR DESCRIPTION
Because if you are using a hash instead of a list, you probably should not be using integers as values.

Fixes issue #912 
