### PR TITLE
ActiveModel: clear errors before calling 'valid?'

### DIFF
--- a/lib/shoulda/matchers/active_model/validator.rb
+++ b/lib/shoulda/matchers/active_model/validator.rb
@@ -90,6 +90,7 @@ module Shoulda
         end
 
         def perform_validation
+          record.errors.clear
           if context
             record.valid?(context)
           else


### PR DESCRIPTION
Some form libraries, such as Reform, can use ActiveModel
validations but don't clear errors between validations (like the
ActiveModel + ActiveRecord combination does).

This change manually clears the errors before calling valid? allowing
matchers that call valid? multiple times (such as validate_length_of) to
be used with Reform and Trailblazer contracts.