### PR TITLE
Use methods that actually persist objects for uniqueness examples

### DIFF
--- a/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
+++ b/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
@@ -80,7 +80,7 @@ module Shoulda
       #
       #     RSpec.describe Post, type: :model do
       #       describe "validations" do
-      #         subject { Post.new(content: "Here is the content") }
+      #         subject { Post.create(content: "Here is the content") }
       #         it { should validate_uniqueness_of(:title) }
       #       end
       #     end
@@ -92,7 +92,7 @@ module Shoulda
       #
       #     RSpec.describe Post, type: :model do
       #       describe "validations" do
-      #         subject { FactoryGirl.build(:post) }
+      #         subject { FactoryGirl.create(:post) }
       #         it { should validate_uniqueness_of(:title) }
       #       end
       #     end


### PR DESCRIPTION
The methods in the documentation currently just build the objects and
don't save them to the database which doesn't actually solve the
no pre-existing object error.

Think these were just typos.
