### PR TITLE
Fix weird error message on should_not validate_inclusion_of(:attribute) fixes #939

### DIFF
--- a/lib/shoulda/matchers/active_model/errors.rb
+++ b/lib/shoulda/matchers/active_model/errors.rb
@@ -47,6 +47,23 @@ Please use a #{record_name} with an empty `password` instead.
           model_name.humanize.downcase
         end
       end
+
+      # @private
+      class NoRangeOrArrayDefinedForInclusionError < Shoulda::Matchers::Error
+        def self.create(attribute)
+          super(attribute: attribute)
+        end
+
+        attr_accessor :attribute
+
+        def message
+          <<-EOT.strip
+You are using the `validate_inclusion_of` matcher without specifying the values that the matcher should use to test the inclusion validation. You'll need to provide the matcher with either a range or an array. For instance:
+  should validate_inclusion_of(:#{attribute}).in_range(0..10)
+  should validate_inclusion_of(:#{attribute}).in_array(['one', 'two', 'three'])
+          EOT
+        end
+      end
     end
   end
 end

--- a/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
@@ -359,7 +359,7 @@ EOT
           if @range
             "validate that :#{@attribute} lies inside the range " +
               Shoulda::Matchers::Util.inspect_range(@range)
-          else
+          elsif @array
             description = "validate that :#{@attribute}"
 
             if @array.many?
@@ -386,6 +386,8 @@ EOT
               @failure_message = "#{@array} doesn't match array in validation"
               false
             end
+          else
+            raise NoRangeOrArrayDefinedForInclusionError.create(@attribute)
           end
         end
 


### PR DESCRIPTION
@mcmire as we talked on #939, here's my fix to that message. Test for failure is pending, but you said you could handle it.

My tests were (with my current application)

> it { should validate_inclusion_of(:atribute) } fails with message `should have range or array to validate`
> it { should_not validate_inclusion_of(:atribute) } passes with message `should have range or array to validate`

Before the change, the first case failed and the second passes with the following message

> example at ./spec/models/model_spec.rb:<a line code> (Got an error when generating description from matcher: NoMethodError: undefined method `many?' for nil:NilClass -- <gems path>/gems/shoulda-matchers-3.1.1/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb:365:in`simple_description') (FAILED - 1)

I thought on raising an error to that, but it doesn't make sense to raise an error on `should_not validate_inclusion_of(:atribute)` without range, since the intention is to NOT validate inclusion of something
