### PR TITLE
Support qualifier(optional, required) of 'belongs_to'

### DIFF
--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -255,6 +255,46 @@ module Shoulda
       #
       # @return [AssociationMatcher]
       #
+      # ##### required
+      #
+      # Use `required` to assert that the `:required` option was specified.
+      #
+      #     class Person < ActiveRecord::Base
+      #       belongs_to :organization, required: true
+      #     end
+      #
+      #     # RSpec
+      #     describe Person
+      #       it { should belong_to(:organization).required }
+      #     end
+      #
+      #     # Minitest (Shoulda)
+      #     class PersonTest < ActiveSupport::TestCase
+      #       should belong_to(:organization).required
+      #     end
+      #
+      # @return [AssociationMatcher]
+      #
+      # ##### optional
+      #
+      # Use `optional` to assert that the `:optional` option was specified.
+      #
+      #     class Person < ActiveRecord::Base
+      #       belongs_to :organization, optional: true
+      #     end
+      #
+      #     # RSpec
+      #     describe Person
+      #       it { should belong_to(:organization).optional }
+      #     end
+      #
+      #     # Minitest (Shoulda)
+      #     class PersonTest < ActiveSupport::TestCase
+      #       should belong_to(:organization).optional
+      #     end
+      #
+      # @return [AssociationMatcher]
+      #
       def belong_to(name)
         AssociationMatcher.new(:belongs_to, name)
       end

--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -937,6 +937,7 @@ module Shoulda
           self
         end
 
+        # TODO: Removed when Rails 4.x support is finished.
         def required(required = true)
           @options[:required] = required
           self
@@ -980,7 +981,7 @@ module Shoulda
             primary_key_exists? &&
             class_name_correct? &&
             join_table_correct? &&
-            required_correct? &&
+            required_correct? && # TODO: Removed when Rails 4.x support is finished.
             autosave_correct? &&
             conditions_correct? &&
             validate_correct? &&
@@ -1136,6 +1137,7 @@ module Shoulda
           end
         end
 
+        # TODO: Removed when Rails 4.x support is finished.
         def required_correct?
           if options.key?(:required)
             if option_verifier.correct_for_boolean?(:required, options[:required])

--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -937,6 +937,11 @@ module Shoulda
           self
         end
 
+        def required(required = true)
+          @options[:required] = required
+          self
+        end
+
         def validate(validate = true)
           @options[:validate] = validate
           self
@@ -975,6 +980,7 @@ module Shoulda
             primary_key_exists? &&
             class_name_correct? &&
             join_table_correct? &&
+            required_correct? &&
             autosave_correct? &&
             conditions_correct? &&
             validate_correct? &&
@@ -1123,6 +1129,32 @@ module Shoulda
               true
             else
               @missing = "#{name} should have autosave set to #{options[:autosave]}"
+              false
+            end
+          else
+            true
+          end
+        end
+
+        def required_correct?
+          if options.key?(:required)
+            if option_verifier.correct_for_boolean?(:required, options[:required])
+              true
+            else
+              @missing = "#{name} should have required set to #{options[:required]}"
+              false
+            end
+          else
+            true
+          end
+        end
+
+        def optional_correct?
+          if options.key?(:optional)
+            if option_verifier.correct_for_boolean?(:optional, options[:optional])
+              true
+            else
+              @missing = "#{name} should have optional set to #{options[:optional]}"
               false
             end
           else

--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -1149,19 +1149,6 @@ module Shoulda
           end
         end
 
-        def optional_correct?
-          if options.key?(:optional)
-            if option_verifier.correct_for_boolean?(:optional, options[:optional])
-              true
-            else
-              @missing = "#{name} should have optional set to #{options[:optional]}"
-              false
-            end
-          else
-            true
-          end
-        end
-
         def conditions_correct?
           if options.key?(:conditions)
             if option_verifier.correct_for_relation_clause?(:conditions, options[:conditions])

--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -937,7 +937,7 @@ module Shoulda
           self
         end
 
-        # TODO: Removed when Rails 4.x support is finished.
+        # TODO: Removed when Rails 4.2 support finished.
         def required(required = true)
           @options[:required] = required
           self
@@ -986,7 +986,7 @@ module Shoulda
             primary_key_exists? &&
             class_name_correct? &&
             join_table_correct? &&
-            required_correct? && # TODO: Removed when Rails 4.x support is finished.
+            required_correct? && # TODO: Removed when Rails 4.2 support finished.
             optional_correct? &&
             autosave_correct? &&
             conditions_correct? &&
@@ -1143,7 +1143,7 @@ module Shoulda
           end
         end
 
-        # TODO: Removed when Rails 4.x support is finished.
+        # TODO: Removed when Rails 4.2 support finished.
         def required_correct?
           if options.key?(:required)
             if option_verifier.correct_for_boolean?(:required, options[:required])

--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -943,6 +943,11 @@ module Shoulda
           self
         end
 
+        def optional(optional = true)
+          @options[:optional] = optional
+          self
+        end
+
         def validate(validate = true)
           @options[:validate] = validate
           self
@@ -982,6 +987,7 @@ module Shoulda
             class_name_correct? &&
             join_table_correct? &&
             required_correct? && # TODO: Removed when Rails 4.x support is finished.
+            optional_correct? &&
             autosave_correct? &&
             conditions_correct? &&
             validate_correct? &&
@@ -1144,6 +1150,19 @@ module Shoulda
               true
             else
               @missing = "#{name} should have required set to #{options[:required]}"
+              false
+            end
+          else
+            true
+          end
+        end
+
+        def optional_correct?
+          if options.key?(:optional)
+            if option_verifier.correct_for_boolean?(:optional, options[:optional])
+              true
+            else
+              @missing = "#{name} should have optional set to #{options[:optional]}"
               false
             end
           else

--- a/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -54,13 +54,21 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
     end
 
     it 'accepts an association with a valid :required option' do
-      expect(belonging_to_parent(required: true)).
-        to belong_to(:parent).required
+      begin
+        expect(belonging_to_parent(required: true)).
+          to belong_to(:parent).required
+      rescue
+        skip 'This version does not support required qualifier'
+      end
     end
 
     it 'accepts an association with a valid :required option' do
-      expect(belonging_to_parent(required: false)).
-        not_to belong_to(:parent).required
+      begin
+        expect(belonging_to_parent(required: false)).
+          not_to belong_to(:parent).required
+      rescue
+        skip 'This version does not support required qualifier'
+      end
     end
 
     it 'accepts an association with a valid :dependent option' do

--- a/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -53,6 +53,16 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
       expect(Child.new).to belong_to(:parent)
     end
 
+    it 'accepts an association with a valid :required option' do
+      expect(belonging_to_parent(required: true)).
+        to belong_to(:parent).required
+    end
+
+    it 'accepts an association with a valid :required option' do
+      expect(belonging_to_parent(required: false)).
+        not_to belong_to(:parent).required
+    end
+
     it 'accepts an association with a valid :dependent option' do
       expect(belonging_to_parent(dependent: :destroy)).
         to belong_to(:parent).dependent(:destroy)

--- a/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -53,7 +53,7 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
       expect(Child.new).to belong_to(:parent)
     end
 
-    # TODO: Removed when Rails 4.x support is finished.
+    # TODO: Removed when Rails 4.2 support finished.
     it 'accepts an association with a valid :required option' do
       begin
         expect(belonging_to_parent(required: true)).
@@ -63,7 +63,7 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
       end
     end
 
-    # TODO: Removed when Rails 4.x support is finished.
+    # TODO: Removed when Rails 4.2 support finished.
     it 'accepts an association with a valid :required option' do
       begin
         expect(belonging_to_parent(required: false)).

--- a/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -73,6 +73,24 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
       end
     end
 
+    it 'accepts an association with a valid :optional option' do
+      begin
+        expect(belonging_to_parent(optional: true)).
+          to belong_to(:parent).optional
+      rescue
+        skip 'This version does not support optional qualifier'
+      end
+    end
+
+    it 'accepts an association with a valid :optional option' do
+      begin
+        expect(belonging_to_parent(optional: false)).
+          not_to belong_to(:parent).optional
+      rescue
+        skip 'This version does not support optional qualifier'
+      end
+    end
+
     it 'accepts an association with a valid :dependent option' do
       expect(belonging_to_parent(dependent: :destroy)).
         to belong_to(:parent).dependent(:destroy)

--- a/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -53,6 +53,7 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
       expect(Child.new).to belong_to(:parent)
     end
 
+    # TODO: Removed when Rails 4.x support is finished.
     it 'accepts an association with a valid :required option' do
       begin
         expect(belonging_to_parent(required: true)).
@@ -62,6 +63,7 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
       end
     end
 
+    # TODO: Removed when Rails 4.x support is finished.
     it 'accepts an association with a valid :required option' do
       begin
         expect(belonging_to_parent(required: false)).


### PR DESCRIPTION
related to #870, #861 

This is to support qualifiers(optional, required) of `belongs_to`, Please review and let me know if it seems good. Then I will write documents for this :)

btw, there is one problem, test suites require `protected_attributes` gem so that we could not run test with rails 5 environment. ;(
Hence, I could grant `required` works well(with rails 4.2) with test, but not `optional` with rails 5.x.
Because of this, I had to confirm whether these work well or not in my personal rails 5 project.
anyway, we need to support test with rails 5 environment.

Thanks for reading this. 👍
