### PR TITLE
Proof of concept for issue #904

### DIFF
--- a/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb
@@ -1013,3 +1013,18 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
     super.deep_merge(matcher_name: :validate_inclusion_of)
   end
 end
+
+class Person
+  include ActiveModel::Model
+
+  attr_accessor :sex
+
+  # Spec works correctly if the following line is uncommented.
+  # validates :sex, inclusion: %w[male female]
+end
+
+RSpec.describe Person, type: :model do
+  it do
+    is_expected.to validate_inclusion_of(:sex).in_array(%w[male female])
+  end
+end


### PR DESCRIPTION
Running specs result in the error mentioned on issue #904:

```
Failures:

  1) Person should validate that :sex is either ‹"male"› or ‹"female"›
     Failure/Error: attribute_setter = result.attribute_setter

     NoMethodError:
       undefined method `attribute_setter' for nil:NilClass
     # ./lib/shoulda/matchers/active_model/allow_value_matcher.rb:405:in `failure_message'
     # ./lib/shoulda/matchers/active_model/validation_matcher.rb:129:in `failure_reason'
     # ./lib/shoulda/matchers/active_model/validation_matcher.rb:56:in `block in failure_message'
     # ./lib/shoulda/matchers/active_model/validation_matcher.rb:55:in `tap'
     # ./lib/shoulda/matchers/active_model/validation_matcher.rb:55:in `failure_message'
     # ./spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb:1027:in `block (2 levels) in <top (required)>'
```