### PR TITLE
Scope parameters according to Rails version

### DIFF
--- a/lib/shoulda/matchers/action_controller/permit_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/permit_matcher.rb
@@ -250,7 +250,10 @@ module Shoulda
           parameters_double_registry.register
 
           Doublespeak.with_doubles_activated do
-            context.__send__(verb, action, request_params)
+            scoped = ::ActionPack::VERSION::MAJOR >= 5
+            params = scoped ? { params: request_params } : request_params
+
+            context.__send__(verb, action, params)
           end
 
           unpermitted_parameter_names.empty?


### PR DESCRIPTION
Rails 5 has deprecated the keywords arguments for #permit. This patch scopes the request params according to the version of Rails.

Fixes #867.  Supercedes #917 with passing tests.

Thank you to @freesteph for helpin' out!
