### PR TITLE
Fix #913 for Serialize Matcher error undefined method `cast_type' in Rails 5

### DIFF
--- a/lib/shoulda/matchers/rails_shim.rb
+++ b/lib/shoulda/matchers/rails_shim.rb
@@ -23,9 +23,11 @@ module Shoulda
         if defined?(::ActiveRecord::Type::Serialized)
           # Rails 5+
           model.columns.select do |column|
-            column.cast_type.is_a?(::ActiveRecord::Type::Serialized)
+            model.type_for_attribute(column.name).is_a?(
+              ::ActiveRecord::Type::Serialized,
+            )
           end.inject({}) do |hash, column|
-            hash[column.name.to_s] = column.cast_type.coder
+            hash[column.name.to_s] = model.type_for_attribute(column.name).coder
             hash
           end
         else


### PR DESCRIPTION
This patch is based on the discussed held in issue #913, and a solution
that I've proposed and others have confirmed as good to go :clap:.

Oh, it also fixes spec breakage (for the existing spec).

Ref: https://github.com/thoughtbot/shoulda-matchers/issues/913#issuecomment-219187051
