### PR TITLE
pass correct object type to association reflection

### DIFF
--- a/lib/shoulda/matchers/active_record/association_matchers/model_reflection.rb
+++ b/lib/shoulda/matchers/active_record/association_matchers/model_reflection.rb
@@ -35,12 +35,12 @@ module Shoulda
             join_table_name.to_s
           end
 
-          def association_relation
+          def association_relation(related_instance)
             relation = associated_class.all
 
             if reflection.scope
               # Source: AR::Associations::AssociationScope#eval_scope
-              relation.instance_exec(subject, &reflection.scope)
+              relation.instance_exec(related_instance, &reflection.scope)
             else
               relation
             end

--- a/lib/shoulda/matchers/active_record/association_matchers/model_reflector.rb
+++ b/lib/shoulda/matchers/active_record/association_matchers/model_reflector.rb
@@ -7,7 +7,6 @@ module Shoulda
           delegate(
             :associated_class,
             :association_foreign_key,
-            :association_relation,
             :foreign_key,
             :has_and_belongs_to_many_name,
             :join_table_name,
@@ -25,6 +24,10 @@ module Shoulda
           def initialize(subject, name)
             @subject = subject
             @name = name
+          end
+
+          def association_relation
+            reflection.association_relation(subject)
           end
 
           def reflection


### PR DESCRIPTION
This is to make the association relation receive the expected parameter
(a AR instance, not its class). fix #952 