### PR TITLE
uniqueness: don't use a private Rails API

### DIFF
--- a/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
+++ b/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
@@ -396,7 +396,7 @@ module Shoulda
         end
 
         def validations
-          model._validators[@attribute].select do |validator|
+          model.validators_on(@attribute).select do |validator|
             validator.is_a?(::ActiveRecord::Validations::UniquenessValidator)
           end
         end


### PR DESCRIPTION
`ActiveRecord::Validations#_validations` is a private API.

Fortunately, Rails provides an API that does exactly what's needed here, and it's been in Rails since at least 3.0.0, so let's use that instead.

***

I ran into an issue using shoulda-matchers with [schema_validations](https://github.com/SchemaPlus/schema_validations). It overrides the public `ActiveModel::Validations` methods to dynamically add validations based on the database schema. Since shoulda-matchers accesses validations using a private API, it incorrectly causes test failures.