### PR TITLE
Fix validate number comparison with strict error

### DIFF
--- a/lib/shoulda/matchers/active_model/validation_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validation_matcher.rb
@@ -24,8 +24,8 @@ module Shoulda
           self
         end
 
-        def strict
-          @expects_strict = true
+        def strict(expects_strict = true)
+          @expects_strict = expects_strict
           self
         end
 

--- a/spec/unit/shoulda/matchers/active_model/validate_numericality_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_numericality_of_matcher_spec.rb
@@ -60,7 +60,12 @@ describe Shoulda::Matchers::ActiveModel::ValidateNumericalityOfMatcher, type: :m
           name: :on,
           argument: :customizable,
           validation_name: :on,
-          validation_value: :customizable
+          validation_value: :customizable,
+        },
+        {
+          name: :strict,
+          validation_name: :strict,
+          validation_value: true,
         }
       ]
     end


### PR DESCRIPTION
Thanks first for this project, it saves so much time 😄 

I've encountered an `ArgumentError` with below context:
```Ruby
# app/models/foo.rb
validates :positive_integer_column,
  numericality: {
    only_integer: true,
    greater_than: 0
  },
  strict: true

# spec/models/foo.rb
it do
  should validate_numericality_of(:positive_integer_column)
           .only_integer
           .is_greater_than(0)
           .strict
end
```

This PR contains the fix for the combined usage of comparison and strict and add tests for it.

Thanks for the review in advance 😃 👍 