### PR TITLE
Validate confirmation of with integers

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_confirmation_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_confirmation_of_matcher.rb
@@ -109,8 +109,18 @@ module Shoulda
         end
 
         def allows_same_value
+          allows_same_value_as_int || allows_same_value_as_string
+        end
+
+        def allows_same_value_as_string
           allows_value_of('same value') do |matcher|
             qualify_matcher(matcher, 'same value')
+          end
+        end
+
+        def allows_same_value_as_int
+          allows_value_of(2) do |matcher|
+            qualify_matcher(matcher, 2)
           end
         end
 

--- a/lib/shoulda/matchers/active_model/validate_confirmation_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_confirmation_of_matcher.rb
@@ -94,38 +94,48 @@ module Shoulda
 
         def matches?(subject)
           super(subject)
-
-          disallows_different_value &&
-            allows_same_value &&
-            allows_missing_confirmation
+          type = find_type(subject)
+          disallows_different_value(type) &&
+            allows_same_value(type) &&
+            allows_missing_confirmation(type)
         end
 
         private
 
-        def disallows_different_value
-          disallows_value_of('different value') do |matcher|
-            qualify_matcher(matcher, 'some value')
+        def find_type(subject)
+          subject.class.columns_hash['attribute_to_confirm'].type rescue :string
+        end
+
+        def different_value
+          { integer: 3, string: 'different value' }
+        end
+
+        def some_value
+          { integer: 2, string: 'some value' }
+        end
+
+        def same_value
+          { integer: 2, string: 'same value' }
+        end
+
+        def any_value
+          { integer: 2, string: 'any value' }
+        end
+
+        def disallows_different_value(type)
+          disallows_value_of(different_value[type]) do |matcher|
+            qualify_matcher(matcher, some_value[type])
           end
         end
 
-        def allows_same_value
-          allows_same_value_as_int || allows_same_value_as_string
-        end
-
-        def allows_same_value_as_string
-          allows_value_of('same value') do |matcher|
-            qualify_matcher(matcher, 'same value')
+        def allows_same_value(type)
+          allows_value_of(same_value[type]) do |matcher|
+            qualify_matcher(matcher, same_value[type])
           end
         end
 
-        def allows_same_value_as_int
-          allows_value_of(2) do |matcher|
-            qualify_matcher(matcher, 2)
-          end
-        end
-
-        def allows_missing_confirmation
-          allows_value_of('any value') do |matcher|
+        def allows_missing_confirmation(type)
+          allows_value_of(any_value[type]) do |matcher|
             qualify_matcher(matcher, nil)
           end
         end

--- a/spec/support/unit/record_validating_confirmation_builder.rb
+++ b/spec/support/unit/record_validating_confirmation_builder.rb
@@ -43,7 +43,8 @@ module UnitTests
     private
 
     def create_model
-      define_model(model_name, attribute_to_confirm => :string) do |model|
+      type = options[:type] || :string
+      define_model(model_name, attribute_to_confirm => type) do |model|
         model.validates_confirmation_of(attribute_to_confirm, options)
       end
     end

--- a/spec/unit/shoulda/matchers/active_model/validate_confirmation_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_confirmation_of_matcher_spec.rb
@@ -146,4 +146,14 @@ Example did not properly validate that
   def validation_matcher_scenario_args
     super.deep_merge(matcher_name: :validate_confirmation_of)
   end
+
+  context 'when attribute to confirm is type integer' do
+    context 'when the model has a confirmation validation' do
+      it 'passes' do
+         builder = builder_for_record_validating_confirmation(type: :integer)
+      expect(builder.record).
+        to validate_confirmation_of(builder.attribute_to_confirm)
+      end
+    end
+  end 
 end

--- a/spec/unit/shoulda/matchers/active_model/validate_confirmation_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_confirmation_of_matcher_spec.rb
@@ -155,5 +155,27 @@ Example did not properly validate that
         to validate_confirmation_of(builder.attribute_to_confirm)
       end
     end
+
+    context 'when the model has all attributes, but does not have the confirmation'do
+      it 'fails with an appropriate error message' do
+         model = define_model(:example, attribute_to_confirm: :integer) do
+        attr_accessor :attribute_to_confirm_confirmation
+      end
+
+      assertion = lambda do
+        expect(model.new).to validate_confirmation_of(:attribute_to_confirm)
+      end
+
+message = <<-MESSAGE
+Example did not properly validate that
+:attribute_to_confirm_confirmation matches :attribute_to_confirm.
+  After setting :attribute_to_confirm_confirmation to ‹2›, then setting
+  :attribute_to_confirm to ‹3›, the matcher expected the Example to be
+  invalid, but it was valid instead.
+      MESSAGE
+
+      expect(&assertion).to fail_with_message(message)
+      end
+    end
   end 
 end


### PR DESCRIPTION
In response to issue #865 to allow `validate_confirmation_of` with integers, instead of just strings.

