### PR TITLE
Changes string_of_length to handle arrays

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,20 +9,20 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    appraisal (2.1.0)
+    appraisal (2.2.0)
       bundler
       rake
       thor (>= 0.14.0)
     byebug (9.0.6)
     coderay (1.1.1)
-    diff-lcs (1.2.5)
+    diff-lcs (1.3)
     fssm (0.2.10)
     method_source (0.8.2)
     multi_json (1.12.1)
     pry-byebug (3.4.2)
       byebug (~> 9.0)
       pry (~> 0.10)
-    pygments.rb (1.1.1)
+    pygments.rb (1.1.2)
       multi_json (>= 1.0.0)
     rake (10.5.0)
     redcarpet (3.4.0)
@@ -40,11 +40,12 @@ GEM
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
     thor (0.19.4)
-    yard (0.9.6)
-    zeus (0.15.12)
+    yard (0.9.9)
+    zeus (0.15.13)
       method_source (>= 0.6.7)
 
 PLATFORMS
+  java
   ruby
 
 DEPENDENCIES
@@ -61,4 +62,4 @@ DEPENDENCIES
   zeus
 
 BUNDLED WITH
-   1.13.6
+   1.14.3

--- a/gemfiles/4.0.0.gemfile
+++ b/gemfiles/4.0.0.gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gem "appraisal", "~> 2.0"
 gem "bundler", "~> 1.1"
-gem "pry", :github => "pry/pry"
+gem "pry", :git => "https://github.com/pry/pry.git"
 gem "pry-byebug"
 gem "rake", ">= 10.5.0", "< 11"
 gem "rspec", "~> 3.2"

--- a/gemfiles/4.0.0.gemfile.lock
+++ b/gemfiles/4.0.0.gemfile.lock
@@ -1,11 +1,10 @@
 GIT
-  remote: git://github.com/pry/pry.git
-  revision: 3c138cbf94a44f7a6696afdab1ab5149d7541974
+  remote: https://github.com/pry/pry.git
+  revision: 1f64463184e0a160d0b41d1a1f92b8e2f230278c
   specs:
-    pry (0.10.1)
+    pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
-      slop (~> 3.4)
 
 GEM
   remote: https://rubygems.org/
@@ -48,7 +47,7 @@ GEM
     builder (3.1.4)
     byebug (5.0.0)
       columnize (= 0.9.0)
-    coderay (1.1.0)
+    coderay (1.1.1)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -149,7 +148,6 @@ GEM
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
     shoulda-context (1.2.1)
-    slop (3.6.0)
     spring (1.4.0)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -220,4 +218,4 @@ DEPENDENCIES
   zeus
 
 BUNDLED WITH
-   1.11.2
+   1.14.3

--- a/gemfiles/4.0.1.gemfile
+++ b/gemfiles/4.0.1.gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gem "appraisal", "~> 2.0"
 gem "bundler", "~> 1.1"
-gem "pry", :github => "pry/pry"
+gem "pry", :git => "https://github.com/pry/pry.git"
 gem "pry-byebug"
 gem "rake", ">= 10.5.0", "< 11"
 gem "rspec", "~> 3.2"

--- a/gemfiles/4.0.1.gemfile.lock
+++ b/gemfiles/4.0.1.gemfile.lock
@@ -1,11 +1,10 @@
 GIT
-  remote: git://github.com/pry/pry.git
-  revision: 3c138cbf94a44f7a6696afdab1ab5149d7541974
+  remote: https://github.com/pry/pry.git
+  revision: 1f64463184e0a160d0b41d1a1f92b8e2f230278c
   specs:
-    pry (0.10.1)
+    pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
-      slop (~> 3.4)
 
 GEM
   remote: https://rubygems.org/
@@ -50,7 +49,7 @@ GEM
     builder (3.1.4)
     byebug (5.0.0)
       columnize (= 0.9.0)
-    coderay (1.1.0)
+    coderay (1.1.1)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -151,7 +150,6 @@ GEM
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
     shoulda-context (1.2.1)
-    slop (3.6.0)
     spring (1.4.0)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -222,4 +220,4 @@ DEPENDENCIES
   zeus
 
 BUNDLED WITH
-   1.11.2
+   1.14.3

--- a/gemfiles/4.1.gemfile
+++ b/gemfiles/4.1.gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gem "appraisal", "~> 2.0"
 gem "bundler", "~> 1.1"
-gem "pry", :github => "pry/pry"
+gem "pry", :git => "https://github.com/pry/pry.git"
 gem "pry-byebug"
 gem "rake", ">= 10.5.0", "< 11"
 gem "rspec", "~> 3.2"

--- a/gemfiles/4.1.gemfile.lock
+++ b/gemfiles/4.1.gemfile.lock
@@ -1,11 +1,10 @@
 GIT
-  remote: git://github.com/pry/pry.git
-  revision: 3c138cbf94a44f7a6696afdab1ab5149d7541974
+  remote: https://github.com/pry/pry.git
+  revision: 1f64463184e0a160d0b41d1a1f92b8e2f230278c
   specs:
-    pry (0.10.1)
+    pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
-      slop (~> 3.4)
 
 GEM
   remote: https://rubygems.org/
@@ -50,7 +49,7 @@ GEM
     builder (3.2.2)
     byebug (5.0.0)
       columnize (= 0.9.0)
-    coderay (1.1.0)
+    coderay (1.1.1)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -148,7 +147,6 @@ GEM
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
     shoulda-context (1.2.1)
-    slop (3.6.0)
     spring (1.4.0)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -217,4 +215,4 @@ DEPENDENCIES
   zeus
 
 BUNDLED WITH
-   1.11.2
+   1.14.3

--- a/gemfiles/4.2.gemfile
+++ b/gemfiles/4.2.gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gem "appraisal", "~> 2.0"
 gem "bundler", "~> 1.1"
-gem "pry", :github => "pry/pry"
+gem "pry", :git => "https://github.com/pry/pry.git"
 gem "pry-byebug"
 gem "rake", ">= 10.5.0", "< 11"
 gem "rspec", "~> 3.2"

--- a/gemfiles/4.2.gemfile.lock
+++ b/gemfiles/4.2.gemfile.lock
@@ -1,11 +1,10 @@
 GIT
-  remote: git://github.com/pry/pry.git
-  revision: 3c138cbf94a44f7a6696afdab1ab5149d7541974
+  remote: https://github.com/pry/pry.git
+  revision: 1f64463184e0a160d0b41d1a1f92b8e2f230278c
   specs:
-    pry (0.10.1)
+    pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
-      slop (~> 3.4)
 
 GEM
   remote: https://rubygems.org/
@@ -59,7 +58,7 @@ GEM
     builder (3.2.2)
     byebug (5.0.0)
       columnize (= 0.9.0)
-    coderay (1.1.0)
+    coderay (1.1.1)
     coffee-rails (4.1.0)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -174,7 +173,6 @@ GEM
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
     shoulda-context (1.2.1)
-    slop (3.6.0)
     spring (1.4.0)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -240,4 +238,4 @@ DEPENDENCIES
   zeus
 
 BUNDLED WITH
-   1.11.2
+   1.14.3

--- a/lib/shoulda/matchers/active_model/validate_length_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_length_of_matcher.rb
@@ -368,15 +368,19 @@ module Shoulda
         end
 
         def allows_length_of?(length, message)
-          allows_value_of(string_of_length(length), message)
+          allows_value_of(string_or_array_of_length(length), message)
         end
 
         def disallows_length_of?(length, message)
-          disallows_value_of(string_of_length(length), message)
+          disallows_value_of(string_or_array_of_length(length), message)
         end
 
-        def string_of_length(length)
-          'x' * length
+        def string_or_array_of_length(length)
+          if @attribute.is_a? String
+            'x' * length
+          else
+            ['x'] * length
+          end
         end
       end
     end


### PR DESCRIPTION
# Changes `string_of_length` to handle arrays

I recently discovered an error on a valid use case of the `validates_length_of` in the `shoulda-matchers` gem. I was attempting to test the length of an associated array, but kept receiving the same error:
```
NoMethodError:
       undefined method `each' for "":String
```
[Here is the issue I submitted to Thoughtbot](https://github.com/thoughtbot/shoulda-matchers/issues/1007)

Here is my suggested fix. I am new to contributing, so any feedback would be greatly appreciated!