### PR TITLE
Rails 5: Skip array-column-related tests for uniqueness matcher

### DIFF
--- a/spec/support/unit/helpers/active_record_versions.rb
+++ b/spec/support/unit/helpers/active_record_versions.rb
@@ -28,5 +28,9 @@ module UnitTests
     def active_record_supports_more_dependent_options?
       active_record_version >= 4
     end
+
+    def active_record_uniqueness_supports_array_columns?
+      active_record_version < 5
+    end
   end
 end

--- a/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
@@ -808,7 +808,11 @@ within the scope of :scope1.
       end
     end
 
-    if database_supports_array_columns? && active_record_supports_array_columns?
+    if (
+      database_supports_array_columns? &&
+      active_record_supports_array_columns? &&
+      active_record_uniqueness_supports_array_columns?
+    )
       context 'when one of the scoped attributes is a array-of-string column' do
         include_examples 'it supports scoped attributes of a certain type',
           column_type: :string,


### PR DESCRIPTION
For some reason, in Rails 5, the uniqueness validation has stopped
working for array columns. What this means is that if you try to use an
array column for a scope, then the query that the validation performs
blows up because the value in the query for the scope is not an array
but a regular scalar value. This does not seem to be documented
anywhere, so perhaps this never worked to begin with, or it accidentally
worked in Rails 4. Until we solve this mystery, skip the tests that have
to do with array columns.