### PR TITLE
Doublespeak: Define #respond_to_missing? on ObjectDouble

### DIFF
--- a/lib/shoulda/matchers/doublespeak/object_double.rb
+++ b/lib/shoulda/matchers/doublespeak/object_double.rb
@@ -14,11 +14,11 @@ module Shoulda
           @calls_by_method_name[method_name] || []
         end
 
-        def respond_to?(name, include_private = nil)
+        def respond_to?(_name, _include_private = nil)
           true
         end
 
-        def respond_to_missing?(name, include_all)
+        def respond_to_missing?(_name, _include_all)
           true
         end
 

--- a/lib/shoulda/matchers/doublespeak/object_double.rb
+++ b/lib/shoulda/matchers/doublespeak/object_double.rb
@@ -18,6 +18,10 @@ module Shoulda
           true
         end
 
+        def respond_to_missing?(name, include_all)
+          true
+        end
+
         def method_missing(method_name, *args, &block)
           call = MethodCall.new(
             method_name: method_name,


### PR DESCRIPTION
The `delegate_method` matcher uses Doublespeak internally to do its job.
The delegate object is completely stubbed using an ObjectDouble,
available from Doublespeak, which is shoulda-matchers's own test double
library. ObjectDouble is a class that responds to every
method by implementing `method_missing`.

Say you are using Ruby 2.4 and you are testing a class that uses the
Forwardable module to do some delegation, and you are using
`delegate_method` in your test. When you run your test you will a
warning that looks something like:

    Courier#deliver at ~/.rvm/rubies/ruby-2.4.0/lib/ruby/2.4.0/forwardable.rb:156 forwarding to private method #deliver

Why is this happening? When the code in your class gets exercised,
Forwardable will delegate the delegate method in question to
ObjectDouble, and the method will get intercepted by its
`method_missing` method. The fact that this is actually a private method
is what Forwardable is complaining about.

To fix this, all we need to do is add `respond_to_missing?` in addition
to `method_missing?`. This is explained here:

https://bugs.ruby-lang.org/issues/13326

---

This fixes #1006.