### PR TITLE
Use model class' DB connection in have_db_index matcher

### DIFF
--- a/lib/shoulda/matchers/active_record/have_db_index_matcher.rb
+++ b/lib/shoulda/matchers/active_record/have_db_index_matcher.rb
@@ -136,7 +136,7 @@ module Shoulda
         end
 
         def indexes
-          ::ActiveRecord::Base.connection.indexes(table_name)
+          model_class.connection.indexes(table_name)
         end
 
         def expectation


### PR DESCRIPTION
**Why**
If a rails project connects to mutliple distinct databases, then it will
only be able to connect to the primary application DB if
ActiveRecord::Base.connection is used to find indexes. By using the
model class under test's connection, we ensure that we get the
appropriate set of indexes for our test.

**What**
Uses `model_class.connection.indexes` to get indexes for a table instead
of `ActiveRecord::Base.connection.indexes`.