### PR TITLE
Drop legacy callback matchers under Rails 5

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,12 @@ is now:
 * Drop support for Rails 4.0 and 4.1 as well as Ruby 2.0 and 2.1, since they've
   been end-of-lifed. The gem now supports Ruby 2.2+ and Rails 4.2+.
 
+* `use_before_filter`, `use_after_filter`, and `use_around_filter` are no longer
+  usable when using shoulda-matchers under Rails 5.x, as the corresponding
+  controller callback don't exist there.
+
+  * *PR: [#1054]*
+
 ### Bug fixes
 
 * Fix association matchers when used under Rails 5.x so that they make use of
@@ -56,6 +62,7 @@ is now:
 [#964]: https://github.com/thoughtbot/shoulda-matchers/pulls/964
 [#917]: https://github.com/thoughtbot/shoulda-matchers/pulls/917
 [#867]: https://github.com/thoughtbot/shoulda-matchers/issues/867
+[#1054]: https://github.com/thoughtbot/shoulda-matchers/pulls/1054
 
 ### Improvements
 

--- a/lib/shoulda/matchers/action_controller/callback_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/callback_matcher.rb
@@ -20,10 +20,14 @@ module Shoulda
       #       should_not use_before_filter(:prevent_ssl)
       #     end
       #
+      # @note This method is only available when using shoulda-matchers under
+      # Rails 4.x.
       # @return [CallbackMatcher]
       #
-      def use_before_filter(callback)
-        CallbackMatcher.new(callback, :before, :filter)
+      if RailsShim.action_pack_lt_5?
+        def use_before_filter(callback)
+          CallbackMatcher.new(callback, :before, :filter)
+        end
       end
 
       # The `use_after_filter` matcher is used to test that an after_filter
@@ -45,10 +49,14 @@ module Shoulda
       #       should_not use_after_filter(:destroy_user)
       #     end
       #
+      # @note This method is only available when using shoulda-matchers under
+      # Rails 4.x.
       # @return [CallbackMatcher]
       #
-      def use_after_filter(callback)
-        CallbackMatcher.new(callback, :after, :filter)
+      if RailsShim.action_pack_lt_5?
+        def use_after_filter(callback)
+          CallbackMatcher.new(callback, :after, :filter)
+        end
       end
 
       # The `use_before_action` matcher is used to test that a before_action
@@ -120,10 +128,14 @@ module Shoulda
       #       should_not use_around_filter(:save_view_context)
       #     end
       #
+      # @note This method is only available when using shoulda-matchers under
+      # Rails 4.x.
       # @return [CallbackMatcher]
       #
-      def use_around_filter(callback)
-        CallbackMatcher.new(callback, :around, :filter)
+      if RailsShim.action_pack_lt_5?
+        def use_around_filter(callback)
+          CallbackMatcher.new(callback, :around, :filter)
+        end
       end
 
       # The `use_around_action` matcher is used to test that an around_action

--- a/lib/shoulda/matchers/rails_shim.rb
+++ b/lib/shoulda/matchers/rails_shim.rb
@@ -1,7 +1,7 @@
 module Shoulda
   module Matchers
     # @private
-    class RailsShim
+    module RailsShim
       class << self
         def action_pack_gte_4_1?
           Gem::Requirement.new('>= 4.1').satisfied_by?(action_pack_version)
@@ -11,12 +11,20 @@ module Shoulda
           Gem::Requirement.new('>= 5').satisfied_by?(action_pack_version)
         end
 
+        def action_pack_lt_5?
+          Gem::Requirement.new('< 5').satisfied_by?(action_pack_version)
+        end
+
         def action_pack_version
           Gem::Version.new(::ActionPack::VERSION::STRING)
+        rescue NameError
+          Gem::Version.new('0')
         end
 
         def active_record_major_version
           ::ActiveRecord::VERSION::MAJOR
+        rescue NameError
+          Gem::Version.new('0')
         end
 
         def generate_validation_message(

--- a/spec/support/unit/helpers/action_pack_versions.rb
+++ b/spec/support/unit/helpers/action_pack_versions.rb
@@ -8,7 +8,11 @@ module UnitTests
     end
 
     def action_pack_gte_5?
-      action_pack_version =~ '>= 5'
+      action_pack_version >= 5
+    end
+
+    def action_pack_lt_5?
+      action_pack_version < 5
     end
 
     def action_pack_version

--- a/spec/support/unit/helpers/rails_versions.rb
+++ b/spec/support/unit/helpers/rails_versions.rb
@@ -31,7 +31,7 @@ module UnitTests
       rails_version >= 4.2
     end
 
-    def rails_lte_5?
+    def rails_lt_5?
       rails_version < 5
     end
   end

--- a/spec/unit/shoulda/matchers/action_controller/callback_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/action_controller/callback_matcher_spec.rb
@@ -54,29 +54,29 @@ describe Shoulda::Matchers::ActionController::CallbackMatcher, type: :controller
     end
   end
 
-  describe '#use_before_filter' do
-    it_behaves_like 'CallbackMatcher', :before, :filter
-  end
-
-  describe '#use_after_filter' do
-    it_behaves_like 'CallbackMatcher', :after, :filter
-  end
-
-  describe '#use_around_filter' do
-    it_behaves_like 'CallbackMatcher', :around, :filter
-  end
-
-  if rails_4_x?
-    describe '#use_before_action' do
-      it_behaves_like 'CallbackMatcher', :before, :action
+  if action_pack_lt_5?
+    describe '#use_before_filter' do
+      it_behaves_like 'CallbackMatcher', :before, :filter
     end
 
-    describe '#use_after_action' do
-      it_behaves_like 'CallbackMatcher', :after, :action
+    describe '#use_after_filter' do
+      it_behaves_like 'CallbackMatcher', :after, :filter
     end
 
-    describe '#use_around_action' do
-      it_behaves_like 'CallbackMatcher', :around, :action
+    describe '#use_around_filter' do
+      it_behaves_like 'CallbackMatcher', :around, :filter
     end
+  end
+
+  describe '#use_before_action' do
+    it_behaves_like 'CallbackMatcher', :before, :action
+  end
+
+  describe '#use_after_action' do
+    it_behaves_like 'CallbackMatcher', :after, :action
+  end
+
+  describe '#use_around_action' do
+    it_behaves_like 'CallbackMatcher', :around, :action
   end
 end

--- a/spec/unit/shoulda/matchers/active_model/allow_mass_assignment_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/allow_mass_assignment_of_matcher_spec.rb
@@ -1,7 +1,7 @@
 require 'unit_spec_helper'
 
 describe Shoulda::Matchers::ActiveModel::AllowMassAssignmentOfMatcher, type: :model do
-  if rails_lte_5?
+  if action_pack_lt_5?
     context '#description' do
       context 'without a role' do
         it 'includes the attribute name' do


### PR DESCRIPTION
Rails 5 dropped the legacy controller callbacks `before_filter`,
`after_filter` and `around_filter`, so the matchers for these callbacks
are useless.