### PR TITLE
Update ruby 2.2.7 to 2.2.8 for travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
 rvm:
   - 2.4.1
   - 2.3.4
-  - 2.2.7
+  - 2.2.8
 
 gemfile:
   - gemfiles/4.2.gemfile


### PR DESCRIPTION
Hello there,

I upgraded the `.travis.yml` settings for ruby version `2.2.7` to `2.2.8`

I did the same for the other versions. I'm not sure how the policies for this project are and what versions you guys want to keep, therefore I'll create those separately. 

Cheers
Markus