### PR TITLE
Update ruby 2.4.1 to 2.4.2 for travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   - DATABASE_ADAPTER=postgresql
 
 rvm:
-  - 2.4.1
+  - 2.4.2
   - 2.3.4
   - 2.2.7
 


### PR DESCRIPTION
Hello there,

I upgraded the `.travis.yml` settings for ruby version `2.4.1` to `2.4.2`

I did the same for the other versions. I'm not sure how the policies for this project are and what versions you guys want to keep, therefore I'll create those separately. 

Cheers
Markus