### PR TITLE
Allow specifying a non-integer column type for define_enum_for

### DIFF
--- a/lib/shoulda/matchers/active_record/define_enum_for_matcher.rb
+++ b/lib/shoulda/matchers/active_record/define_enum_for_matcher.rb
@@ -61,9 +61,14 @@ module Shoulda
           self
         end
 
+        def backed_by_column_of_type(expected_column_type)
+          options[:expected_column_type] = expected_column_type
+          self
+        end
+
         def matches?(subject)
           @record = subject
-          enum_defined? && enum_values_match? && column_type_is_integer?
+          enum_defined? && enum_values_match? && column_type_matches?
         end
 
         def failure_message
@@ -83,7 +88,7 @@ module Shoulda
             desc << " with #{options[:expected_enum_values]}"
           end
 
-          desc << " and store the value in a column with an integer type"
+          desc << " and store the value in a column with an #{expected_column_type} type"
 
           desc
         end
@@ -112,8 +117,12 @@ module Shoulda
           expected_enum_values.empty? || actual_enum_values == expected_enum_values
         end
 
-        def column_type_is_integer?
-          column.type == :integer
+        def expected_column_type
+          options[:expected_column_type] || :integer
+        end
+
+        def column_type_matches?
+          column.type == expected_column_type.to_sym
         end
 
         def column

--- a/lib/shoulda/matchers/active_record/define_enum_for_matcher.rb
+++ b/lib/shoulda/matchers/active_record/define_enum_for_matcher.rb
@@ -88,7 +88,7 @@ module Shoulda
             desc << " with #{options[:expected_enum_values]}"
           end
 
-          desc << " and store the value in a column with an #{expected_column_type} type"
+          desc << " and store the value in a column of type #{expected_column_type}"
 
           desc
         end

--- a/spec/unit/shoulda/matchers/active_record/define_enum_for_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/define_enum_for_matcher_spec.rb
@@ -139,6 +139,29 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
       end
     end
 
+    describe 'with the backing column specified to be a string type' do
+      context 'if the column storing the attribute is a string type' do
+        it 'accepts' do
+          record = record_with_array_values(column_type: :string)
+
+          expect(record).to define_enum_for(enum_attribute).backed_by_column_of_type(:string)
+        end
+      end
+
+      context 'if the column storing the attribute is an integer type' do
+        it 'rejects' do
+          record = record_with_array_values(column_type: :integer)
+          message = "Expected #{record.class} to define :#{enum_attribute} as an enum and store the value in a column with an string type"
+
+          assertion = lambda do
+            expect(record).to define_enum_for(enum_attribute).backed_by_column_of_type(:string)
+          end
+
+          expect(&assertion).to fail_with_message(message)
+        end
+      end
+    end
+
     def enum_attribute
       :status
     end

--- a/spec/unit/shoulda/matchers/active_record/define_enum_for_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/define_enum_for_matcher_spec.rb
@@ -6,7 +6,7 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
       it 'rejects' do
         record = record_with_array_values
         plural_enum_attribute = enum_attribute.to_s.pluralize
-        message = "Expected #{record.class} to define :#{plural_enum_attribute} as an enum and store the value in a column with an integer type"
+        message = "Expected #{record.class} to define :#{plural_enum_attribute} as an enum and store the value in a column of type integer"
 
         assertion = lambda do
           expect(record).to define_enum_for(plural_enum_attribute)
@@ -22,7 +22,7 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
           def self.statuses; end
         end
 
-        message = "Expected #{model} to define :statuses as an enum and store the value in a column with an integer type"
+        message = "Expected #{model} to define :statuses as an enum and store the value in a column of type integer"
 
         assertion = lambda do
           expect(model.new).to define_enum_for(:statuses)
@@ -38,7 +38,7 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
       end
 
       it "rejects a record where the attribute is not defined as an enum" do
-        message = "Expected #{record_with_array_values.class} to define :#{non_enum_attribute} as an enum and store the value in a column with an integer type"
+        message = "Expected #{record_with_array_values.class} to define :#{non_enum_attribute} as an enum and store the value in a column of type integer"
 
         assertion = lambda do
           expect(record_with_array_values).
@@ -49,7 +49,7 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
       end
 
       it "rejects a record where the attribute is not defined as an enum with should not" do
-        message = "Did not expect #{record_with_array_values.class} to define :#{enum_attribute} as an enum and store the value in a column with an integer type"
+        message = "Did not expect #{record_with_array_values.class} to define :#{enum_attribute} as an enum and store the value in a column of type integer"
 
         assertion = lambda do
           expect(record_with_array_values).
@@ -62,7 +62,7 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
       context 'if the column storing the attribute is not an integer type' do
         it 'rejects' do
           record = record_with_array_values(column_type: :string)
-          message = "Expected #{record.class} to define :statuses as an enum and store the value in a column with an integer type"
+          message = "Expected #{record.class} to define :statuses as an enum and store the value in a column of type integer"
 
           assertion = lambda do
             expect(record).to define_enum_for(:statuses)
@@ -81,7 +81,7 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
         end
 
         it "accepts a record where the attribute is not defined as an enum" do
-          message = %{Expected #{record_with_array_values.class} to define :#{non_enum_attribute} as an enum with ["open", "close"] and store the value in a column with an integer type}
+          message = %{Expected #{record_with_array_values.class} to define :#{non_enum_attribute} as an enum with ["open", "close"] and store the value in a column of type integer}
 
           assertion = lambda do
             expect(record_with_array_values).
@@ -92,7 +92,7 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
         end
 
         it "accepts a record where the attribute is defined as an enum but the enum values do not match" do
-          message = %{Expected #{record_with_array_values.class} to define :#{enum_attribute} as an enum with ["open", "close"] and store the value in a column with an integer type}
+          message = %{Expected #{record_with_array_values.class} to define :#{enum_attribute} as an enum with ["open", "close"] and store the value in a column of type integer}
 
           assertion = lambda do
             expect(record_with_array_values).
@@ -114,7 +114,7 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
         end
 
         it "accepts a record where the attribute is defined as an enum but the enum values do not match" do
-          message = %{Expected #{record_with_hash_values.class} to define :#{enum_attribute} as an enum with {:active=>5, :archived=>10} and store the value in a column with an integer type}
+          message = %{Expected #{record_with_hash_values.class} to define :#{enum_attribute} as an enum with {:active=>5, :archived=>10} and store the value in a column of type integer}
 
           assertion = lambda do
             expect(record_with_hash_values).
@@ -126,7 +126,7 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
         end
 
         it "rejects a record where the attribute is not defined as an enum" do
-          message = %{Expected #{record_with_hash_values.class} to define :record_with_hash_values as an enum with {:active=>5, :archived=>10} and store the value in a column with an integer type}
+          message = %{Expected #{record_with_hash_values.class} to define :record_with_hash_values as an enum with {:active=>5, :archived=>10} and store the value in a column of type integer}
 
           assertion = lambda do
             expect(record_with_hash_values).
@@ -151,7 +151,7 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
       context 'if the column storing the attribute is an integer type' do
         it 'rejects' do
           record = record_with_array_values(column_type: :integer)
-          message = "Expected #{record.class} to define :#{enum_attribute} as an enum and store the value in a column with an string type"
+          message = "Expected #{record.class} to define :#{enum_attribute} as an enum and store the value in a column of type string"
 
           assertion = lambda do
             expect(record).to define_enum_for(enum_attribute).backed_by_column_of_type(:string)


### PR DESCRIPTION
This is my attempt at fixing #912.

I tried to keep my changes to a minimum, so I left the default `:integer` check in place, and introduced a new `.backed_by_column_of_type` qualifier. I also rephrased the message slightly to avoid "an string" / "a integer" -type situations.

Let me know what you think. :) I'm very much open to suggestions if you would prefer a different qualifier name, or differently structured tests.