### PR TITLE
Make `shoulda-matchers` warning free

### DIFF
--- a/lib/shoulda/matchers/active_model/allow_value_matcher/attribute_setter.rb
+++ b/lib/shoulda/matchers/active_model/allow_value_matcher/attribute_setter.rb
@@ -225,10 +225,6 @@ module Shoulda
           def active_resource_object?
             object.respond_to?(:known_attributes)
           end
-
-          def model
-            object.class
-          end
         end
       end
     end

--- a/lib/shoulda/matchers/active_model/validate_absence_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_absence_of_matcher.rb
@@ -105,7 +105,7 @@ module Shoulda
           else
             case column_type
             when :integer, :float then 1
-            when :decimal then BigDecimal.new(1, 0)
+            when :decimal then BigDecimal(1, 0)
             when :datetime, :time, :timestamp then Time.now
             when :date then Date.new
             when :binary then '0'

--- a/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
@@ -270,7 +270,7 @@ module Shoulda
       class ValidateInclusionOfMatcher < ValidationMatcher
         ARBITRARY_OUTSIDE_STRING = 'shoulda-matchers test string'
         ARBITRARY_OUTSIDE_INTEGER = 123456789
-        ARBITRARY_OUTSIDE_DECIMAL = BigDecimal.new('0.123456789')
+        ARBITRARY_OUTSIDE_DECIMAL = BigDecimal('0.123456789')
         ARBITRARY_OUTSIDE_DATE = Date.jd(9999999)
         ARBITRARY_OUTSIDE_DATETIME = DateTime.jd(9999999)
         ARBITRARY_OUTSIDE_TIME = Time.at(9999999999)

--- a/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb
@@ -107,18 +107,18 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
     context 'against a decimal attribute' do
       it_behaves_like 'it supports in_array',
         possible_values: [1.0, 2.0, 3.0, 4.0, 5.0].map { |number|
-          BigDecimal.new(number.to_s)
+          BigDecimal(number.to_s)
         },
-        zero: BigDecimal.new('0.0'),
+        zero: BigDecimal('0.0'),
         reserved_outside_value: described_class::ARBITRARY_OUTSIDE_DECIMAL
 
       it_behaves_like 'it supports in_range',
-        possible_values: BigDecimal.new('1.0') .. BigDecimal.new('5.0'),
-        zero: BigDecimal.new('0.0')
+        possible_values: BigDecimal('1.0') .. BigDecimal('5.0'),
+        zero: BigDecimal('0.0')
 
       def build_object(options = {}, &block)
         build_object_with_generic_attribute(
-          options.merge(column_type: :decimal, value: BigDecimal.new('1.0')),
+          options.merge(column_type: :decimal, value: BigDecimal('1.0')),
           &block
         )
       end
@@ -130,7 +130,7 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
       def validation_matcher_scenario_args
         super.deep_merge(
           column_type: :decimal,
-          default_value: BigDecimal.new('1.0')
+          default_value: BigDecimal('1.0')
         )
       end
     end


### PR DESCRIPTION
The warnings that were quelled are:

- Use `BigDecimal()` over `BigDecimal.new`.

  Since https://github.com/ruby/bigdecimal/commit/533737338db915b00dc7168c3602e4b462b23503

- Remove duplicated method `model`.