### PR TITLE
Add prefix and suffix to define enum for

### DIFF
--- a/lib/shoulda/matchers/active_record/define_enum_for_matcher.rb
+++ b/lib/shoulda/matchers/active_record/define_enum_for_matcher.rb
@@ -20,10 +20,10 @@ module Shoulda
       #
       # #### Qualifiers
       #
-      # ##### with
+      # ##### with_values
       #
-      # Use `with` to test that the attribute has been defined with a certain
-      # set of known values.
+      # Use `with_values` to test that the attribute has been defined with a
+      # certain set of possible values.
       #
       #     class Process < ActiveRecord::Base
       #       enum status: [:running, :stopped, :suspended]
@@ -33,14 +33,14 @@ module Shoulda
       #     RSpec.describe Process, type: :model do
       #       it do
       #         should define_enum_for(:status).
-      #           with([:running, :stopped, :suspended])
+      #           with_values([:running, :stopped, :suspended])
       #       end
       #     end
       #
       #     # Minitest (Shoulda)
       #     class ProcessTest < ActiveSupport::TestCase
       #       should define_enum_for(:status).
-      #         with([:running, :stopped, :suspended])
+      #         with_values([:running, :stopped, :suspended])
       #     end
       #
       # ##### backed_by_column_of_type
@@ -60,7 +60,7 @@ module Shoulda
       #     RSpec.describe LoanApplication, type: :model do
       #       it do
       #         should define_enum_for(:status).
-      #           with(
+      #           with_values(
       #             active: "active",
       #             pending: "pending",
       #             rejected: "rejected"
@@ -72,7 +72,7 @@ module Shoulda
       #     # Minitest (Shoulda)
       #     class LoanApplicationTest < ActiveSupport::TestCase
       #       should define_enum_for(:status).
-      #         with(
+      #         with_values(
       #           active: "active",
       #           pending: "pending",
       #           rejected: "rejected"
@@ -94,9 +94,17 @@ module Shoulda
           @options = {}
         end
 
-        def with(expected_enum_values)
+        def with_values(expected_enum_values)
           options[:expected_enum_values] = expected_enum_values
           self
+        end
+
+        def with(expected_enum_values)
+          Shoulda::Matchers.warn_about_deprecated_method(
+            'The `with` qualifier on `define_enum_for`',
+            '`with_values`'
+          )
+          with_values(expected_enum_values)
         end
 
         def backed_by_column_of_type(expected_column_type)

--- a/lib/shoulda/matchers/util.rb
+++ b/lib/shoulda/matchers/util.rb
@@ -41,7 +41,14 @@ module Shoulda
       end
 
       def self.inspect_value(value)
-        "‹#{value.inspect}›"
+        case value
+        when Hash
+          inspect_hash(value)
+        when Range
+          inspect_range(value)
+        else
+          "‹#{value.inspect}›"
+        end
       end
 
       def self.inspect_values(values)
@@ -50,6 +57,20 @@ module Shoulda
 
       def self.inspect_range(range)
         "#{inspect_value(range.first)} to #{inspect_value(range.last)}"
+      end
+
+      def self.inspect_hash(hash)
+        output = '‹{'
+
+        output << hash.map { |key, value|
+          if key.is_a?(Symbol)
+            "#{key}: #{value.inspect}"
+          else
+            "#{key.inspect} => #{value.inspect}"
+          end
+        }.join(', ')
+
+        output << '}›'
       end
 
       def self.dummy_value_for(column_type, array: false)

--- a/lib/shoulda/matchers/util/word_wrap.rb
+++ b/lib/shoulda/matchers/util/word_wrap.rb
@@ -1,9 +1,13 @@
 module Shoulda
   module Matchers
     # @private
-    def self.word_wrap(document, options = {})
-      Document.new(document, options).wrap
+    module WordWrap
+      def word_wrap(document, options = {})
+        Document.new(document, options).wrap
+      end
     end
+
+    extend WordWrap
 
     # @private
     class Document

--- a/spec/support/unit/helpers/active_record_versions.rb
+++ b/spec/support/unit/helpers/active_record_versions.rb
@@ -9,10 +9,6 @@ module UnitTests
       Tests::Version.new(::ActiveRecord::VERSION::STRING)
     end
 
-    def active_record_supports_enum?
-      defined?(::ActiveRecord::Enum)
-    end
-
     def active_record_supports_has_secure_password?
       active_record_version >= 3.1
     end

--- a/spec/support/unit/helpers/active_record_versions.rb
+++ b/spec/support/unit/helpers/active_record_versions.rb
@@ -9,6 +9,10 @@ module UnitTests
       Tests::Version.new(::ActiveRecord::VERSION::STRING)
     end
 
+    def active_record_enum_supports_prefix_and_suffix?
+      active_record_version >= 5
+    end
+
     def active_record_supports_has_secure_password?
       active_record_version >= 3.1
     end

--- a/spec/support/unit/helpers/message_helpers.rb
+++ b/spec/support/unit/helpers/message_helpers.rb
@@ -1,0 +1,13 @@
+module UnitTests
+  module MessageHelpers
+    include Shoulda::Matchers::WordWrap
+
+    def self.configure_example_group(example_group)
+      example_group.include(self)
+    end
+
+    def format_message(message)
+      word_wrap(message.strip_heredoc.strip)
+    end
+  end
+end

--- a/spec/unit/shoulda/matchers/active_model/allow_value_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/allow_value_matcher_spec.rb
@@ -815,16 +815,14 @@ value", but that attribute does not exist.
     end
   end
 
-  if active_record_supports_enum?
-    context 'given an ActiveRecord model' do
-      context 'where the attribute under test is an enum and the given value is a value in that enum' do
-        it 'accepts' do
-          model = define_model('Shipment', status: :integer) do
-            enum status: { pending: 1, shipped: 2, delivered: 3 }
-          end
-
-          expect(model.new).to allow_value(1).for(:status)
+  context 'given an ActiveRecord model' do
+    context 'where the attribute under test is an enum and the given value is a value in that enum' do
+      it 'accepts' do
+        model = define_model('Shipment', status: :integer) do
+          enum status: { pending: 1, shipped: 2, delivered: 3 }
         end
+
+        expect(model.new).to allow_value(1).for(:status)
       end
     end
   end

--- a/spec/unit/shoulda/matchers/active_record/define_enum_for_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/define_enum_for_matcher_spec.rb
@@ -123,7 +123,7 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
           MESSAGE
 
           assertion = lambda do
-            expect(record).to define_enum_for(:attr).with(['open', 'close'])
+            expect(record).to define_enum_for(:attr).with_values(['open', 'close'])
           end
 
           expect(&assertion).to fail_with_message(message)
@@ -144,7 +144,7 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
             MESSAGE
 
             assertion = lambda do
-              expect(record).to define_enum_for(:attr).with(['open', 'close'])
+              expect(record).to define_enum_for(:attr).with_values(['open', 'close'])
             end
 
             expect(&assertion).to fail_with_message(message)
@@ -159,7 +159,7 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
             )
 
             expect(record).to define_enum_for(:attr).
-              with(['published', 'unpublished', 'draft'])
+              with_values(['published', 'unpublished', 'draft'])
           end
         end
       end
@@ -180,7 +180,7 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
           assertion = lambda do
             expect(record).
               to define_enum_for(:attr).
-              with(active: 5, archived: 10)
+              with_values(active: 5, archived: 10)
           end
 
           expect(&assertion).to fail_with_message(message)
@@ -203,7 +203,7 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
             assertion = lambda do
               expect(record).
                 to define_enum_for(:attr).
-                with(active: 5, archived: 10)
+                with_values(active: 5, archived: 10)
             end
 
             expect(&assertion).to fail_with_message(message)
@@ -220,7 +220,7 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
 
               expect(record).
                 to define_enum_for(:attr).
-                with(active: 0, archived: 1)
+                with_values(active: 0, archived: 1)
             end
           end
 
@@ -233,11 +233,29 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
 
               expect(record).
                 to define_enum_for(:attr).
-                with(['active', 'archived'])
+                with_values(['active', 'archived'])
             end
           end
         end
       end
+    end
+  end
+
+  context 'with values specified using #with' do
+    it 'produces a warning' do
+      record = build_record_with_array_values(
+        attribute_name: :attr,
+        values: [:foo, :bar],
+      )
+
+      assertion = lambda do
+        expect(record).to define_enum_for(:attr).with([:foo, :bar])
+      end
+
+      expect(&assertion).to deprecate(
+        'The `with` qualifier on `define_enum_for`',
+        '`with_values`',
+      )
     end
   end
 

--- a/spec/unit/shoulda/matchers/active_record/define_enum_for_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/define_enum_for_matcher_spec.rb
@@ -1,47 +1,116 @@
 require 'unit_spec_helper'
 
 describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
-  if active_record_supports_enum?
-    context 'if the attribute is given in plural form accidentally' do
+  context 'if the attribute is given in plural form accidentally' do
+    it 'rejects with an appropriate failure message' do
+      record = build_record_with_array_values(
+        model_name: 'Example',
+        attribute_name: :attr,
+        column_type: :integer,
+      )
+      message = as_one_line(<<~MESSAGE)
+        Expected Example to define :attrs as an enum and store the value in a
+        column of type integer
+      MESSAGE
+
+      assertion = lambda do
+        expect(record).to define_enum_for(:attrs)
+      end
+
+      expect(&assertion).to fail_with_message(message)
+    end
+  end
+
+  context 'if a method to hold enum values exists on the model but was not created via the enum macro' do
+    it 'rejects with an appropriate failure message' do
+      model = define_model 'Example' do
+        def self.statuses; end
+      end
+
+      message = as_one_line(<<~MESSAGE)
+        Expected Example to define :statuses as an enum and store the value in a
+        column of type integer
+      MESSAGE
+
+      assertion = lambda do
+        expect(model.new).to define_enum_for(:statuses)
+      end
+
+      expect(&assertion).to fail_with_message(message)
+    end
+  end
+
+  describe 'with only the attribute name specified' do
+    context 'if the attribute is not defined as an enum' do
+      it 'rejects with an appropriate failure message' do
+        record = build_record_with_non_enum_attribute(
+          model_name: 'Example',
+          attribute_name: :attr,
+        )
+        message = as_one_line(<<~MESSAGE)
+          Expected Example to define :attr as an enum and store the value in a
+          column of type integer
+        MESSAGE
+
+        assertion = lambda do
+          expect(record).to define_enum_for(:attr)
+        end
+
+        expect(&assertion).to fail_with_message(message)
+      end
+    end
+
+    context 'if the column storing the attribute is not an integer type' do
       it 'rejects with an appropriate failure message' do
         record = build_record_with_array_values(
           model_name: 'Example',
           attribute_name: :attr,
-          column_type: :integer,
+          column_type: :string,
         )
         message = as_one_line(<<~MESSAGE)
-          Expected Example to define :attrs as an enum and store the value in a
+          Expected Example to define :attr as an enum and store the value in a
           column of type integer
         MESSAGE
 
         assertion = lambda do
-          expect(record).to define_enum_for(:attrs)
+          expect(record).to define_enum_for(:attr)
         end
 
         expect(&assertion).to fail_with_message(message)
       end
     end
 
-    context 'if a method to hold enum values exists on the model but was not created via the enum macro' do
-      it 'rejects with an appropriate failure message' do
-        model = define_model 'Example' do
-          def self.statuses; end
+    context 'if the attribute is defined as an enum' do
+      it 'accepts' do
+        record = build_record_with_array_values(attribute_name: :attr)
+
+        expect(record).to define_enum_for(:attr)
+      end
+
+      context 'and the matcher is negated' do
+        it 'rejects with an appropriate failure message' do
+          record = build_record_with_array_values(
+            model_name: 'Example',
+            attribute_name: :attr,
+            column_type: :integer,
+          )
+          message = as_one_line(<<~MESSAGE)
+            Did not expect Example to define :attr as an enum and store the
+            value in a column of type integer
+          MESSAGE
+
+          assertion = lambda do
+            expect(record).not_to define_enum_for(:attr)
+          end
+
+          expect(&assertion).to fail_with_message(message)
         end
-
-        message = as_one_line(<<~MESSAGE)
-          Expected Example to define :statuses as an enum and store the value in a
-          column of type integer
-        MESSAGE
-
-        assertion = lambda do
-          expect(model.new).to define_enum_for(:statuses)
-        end
-
-        expect(&assertion).to fail_with_message(message)
       end
     end
+  end
 
-    describe 'with only the attribute name specified' do
+  describe 'with both attribute name and enum values specified' do
+    context 'when the actual enum values are an array' do
       context 'if the attribute is not defined as an enum' do
         it 'rejects with an appropriate failure message' do
           record = build_record_with_non_enum_attribute(
@@ -49,74 +118,25 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
             attribute_name: :attr,
           )
           message = as_one_line(<<~MESSAGE)
-            Expected Example to define :attr as an enum and store the value in a
-            column of type integer
+            Expected Example to define :attr as an enum with ["open", "close"]
+            and store the value in a column of type integer
           MESSAGE
 
           assertion = lambda do
-            expect(record).to define_enum_for(:attr)
+            expect(record).to define_enum_for(:attr).with(['open', 'close'])
           end
 
           expect(&assertion).to fail_with_message(message)
         end
       end
 
-      context 'if the column storing the attribute is not an integer type' do
-        it 'rejects with an appropriate failure message' do
-          record = build_record_with_array_values(
-            model_name: 'Example',
-            attribute_name: :attr,
-            column_type: :string,
-          )
-          message = as_one_line(<<~MESSAGE)
-            Expected Example to define :attr as an enum and store the value in a
-            column of type integer
-          MESSAGE
-
-          assertion = lambda do
-            expect(record).to define_enum_for(:attr)
-          end
-
-          expect(&assertion).to fail_with_message(message)
-        end
-      end
-
-      context 'if the attribute is defined as an enum' do
-        it 'accepts' do
-          record = build_record_with_array_values(attribute_name: :attr)
-
-          expect(record).to define_enum_for(:attr)
-        end
-
-        context 'and the matcher is negated' do
+      context 'if the attribute is defined as an enum and the enum values match' do
+        context 'but the enum values do not match' do
           it 'rejects with an appropriate failure message' do
             record = build_record_with_array_values(
               model_name: 'Example',
               attribute_name: :attr,
-              column_type: :integer,
-            )
-            message = as_one_line(<<~MESSAGE)
-              Did not expect Example to define :attr as an enum and store the
-              value in a column of type integer
-            MESSAGE
-
-            assertion = lambda do
-              expect(record).not_to define_enum_for(:attr)
-            end
-
-            expect(&assertion).to fail_with_message(message)
-          end
-        end
-      end
-    end
-
-    describe 'with both attribute name and enum values specified' do
-      context 'when the actual enum values are an array' do
-        context 'if the attribute is not defined as an enum' do
-          it 'rejects with an appropriate failure message' do
-            record = build_record_with_non_enum_attribute(
-              model_name: 'Example',
-              attribute_name: :attr,
+              values: ['published', 'unpublished', 'draft'],
             )
             message = as_one_line(<<~MESSAGE)
               Expected Example to define :attr as an enum with ["open", "close"]
@@ -131,47 +151,49 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
           end
         end
 
-        context 'if the attribute is defined as an enum and the enum values match' do
-          context 'but the enum values do not match' do
-            it 'rejects with an appropriate failure message' do
-              record = build_record_with_array_values(
-                model_name: 'Example',
-                attribute_name: :attr,
-                values: ['published', 'unpublished', 'draft'],
-              )
-              message = as_one_line(<<~MESSAGE)
-                Expected Example to define :attr as an enum with ["open", "close"]
-                and store the value in a column of type integer
-              MESSAGE
+        context 'and the enum values match' do
+          it 'accepts' do
+            record = build_record_with_array_values(
+              attribute_name: :attr,
+              values: ['published', 'unpublished', 'draft'],
+            )
 
-              assertion = lambda do
-                expect(record).to define_enum_for(:attr).with(['open', 'close'])
-              end
-
-              expect(&assertion).to fail_with_message(message)
-            end
-          end
-
-          context 'and the enum values match' do
-            it 'accepts' do
-              record = build_record_with_array_values(
-                attribute_name: :attr,
-                values: ['published', 'unpublished', 'draft'],
-              )
-
-              expect(record).to define_enum_for(:attr).
-                with(['published', 'unpublished', 'draft'])
-            end
+            expect(record).to define_enum_for(:attr).
+              with(['published', 'unpublished', 'draft'])
           end
         end
       end
+    end
 
-      context 'when the actual enum values are a hash' do
-        context 'if the attribute is not defined as an enum' do
+    context 'when the actual enum values are a hash' do
+      context 'if the attribute is not defined as an enum' do
+        it 'rejects with an appropriate failure message' do
+          record = build_record_with_non_enum_attribute(
+            model_name: 'Example',
+            attribute_name: :attr,
+          )
+          message = as_one_line(<<~MESSAGE)
+            Expected Example to define :attr as an enum with {:active=>5,
+            :archived=>10} and store the value in a column of type integer
+          MESSAGE
+
+          assertion = lambda do
+            expect(record).
+              to define_enum_for(:attr).
+              with(active: 5, archived: 10)
+          end
+
+          expect(&assertion).to fail_with_message(message)
+        end
+      end
+
+      context 'if the attribute is defined as an enum' do
+        context 'but the enum values do not match' do
           it 'rejects with an appropriate failure message' do
-            record = build_record_with_non_enum_attribute(
+            record = build_record_with_hash_values(
               model_name: 'Example',
               attribute_name: :attr,
+              values: { active: 0, archived: 1 },
             )
             message = as_one_line(<<~MESSAGE)
               Expected Example to define :attr as an enum with {:active=>5,
@@ -188,94 +210,70 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
           end
         end
 
-        context 'if the attribute is defined as an enum' do
-          context 'but the enum values do not match' do
-            it 'rejects with an appropriate failure message' do
+        context 'and the enum values match' do
+          context 'when expected enum values are a hash' do
+            it 'accepts' do
               record = build_record_with_hash_values(
-                model_name: 'Example',
                 attribute_name: :attr,
                 values: { active: 0, archived: 1 },
               )
-              message = as_one_line(<<~MESSAGE)
-                Expected Example to define :attr as an enum with {:active=>5,
-                :archived=>10} and store the value in a column of type integer
-              MESSAGE
 
-              assertion = lambda do
-                expect(record).
-                  to define_enum_for(:attr).
-                  with(active: 5, archived: 10)
-              end
-
-              expect(&assertion).to fail_with_message(message)
+              expect(record).
+                to define_enum_for(:attr).
+                with(active: 0, archived: 1)
             end
           end
 
-          context 'and the enum values match' do
-            context 'when expected enum values are a hash' do
-              it 'accepts' do
-                record = build_record_with_hash_values(
-                  attribute_name: :attr,
-                  values: { active: 0, archived: 1 },
-                )
+          context 'when expected enum values are an array' do
+            it 'accepts' do
+              record = build_record_with_hash_values(
+                attribute_name: :attr,
+                values: { active: 0, archived: 1 },
+              )
 
-                expect(record).
-                  to define_enum_for(:attr).
-                  with(active: 0, archived: 1)
-              end
-            end
-
-            context 'when expected enum values are an array' do
-              it 'accepts' do
-                record = build_record_with_hash_values(
-                  attribute_name: :attr,
-                  values: { active: 0, archived: 1 },
-                )
-
-                expect(record).
-                  to define_enum_for(:attr).
-                  with(['active', 'archived'])
-              end
+              expect(record).
+                to define_enum_for(:attr).
+                with(['active', 'archived'])
             end
           end
         end
       end
     end
+  end
 
-    describe 'with the backing column specified to be of some type' do
-      context 'if the column storing the attribute is of a different type' do
-        it 'rejects with an appropriate failure message' do
-          record = build_record_with_array_values(
-            model_name: 'Example',
-            attribute_name: :attr,
-            column_type: :integer,
-          )
-          message = as_one_line(<<~MESSAGE)
-            Expected Example to define :attr as an enum and store the value in a
-            column of type string
-          MESSAGE
+  describe 'with the backing column specified to be of some type' do
+    context 'if the column storing the attribute is of a different type' do
+      it 'rejects with an appropriate failure message' do
+        record = build_record_with_array_values(
+          model_name: 'Example',
+          attribute_name: :attr,
+          column_type: :integer,
+        )
+        message = as_one_line(<<~MESSAGE)
+          Expected Example to define :attr as an enum and store the value in a
+          column of type string
+        MESSAGE
 
-          assertion = lambda do
-            expect(record).
-              to define_enum_for(:attr).
-              backed_by_column_of_type(:string)
-          end
-
-          expect(&assertion).to fail_with_message(message)
-        end
-      end
-
-      context 'if the column storing the attribute is of the same type' do
-        it 'accepts' do
-          record = build_record_with_array_values(
-            attribute_name: :attr,
-            column_type: :string,
-          )
-
+        assertion = lambda do
           expect(record).
             to define_enum_for(:attr).
             backed_by_column_of_type(:string)
         end
+
+        expect(&assertion).to fail_with_message(message)
+      end
+    end
+
+    context 'if the column storing the attribute is of the same type' do
+      it 'accepts' do
+        record = build_record_with_array_values(
+          attribute_name: :attr,
+          column_type: :string,
+        )
+
+        expect(record).
+          to define_enum_for(:attr).
+          backed_by_column_of_type(:string)
       end
     end
   end

--- a/spec/unit/shoulda/matchers/active_record/define_enum_for_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/define_enum_for_matcher_spec.rb
@@ -1,15 +1,21 @@
-require "unit_spec_helper"
+require 'unit_spec_helper'
 
 describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
   if active_record_supports_enum?
     context 'if the attribute is given in plural form accidentally' do
-      it 'rejects' do
-        record = record_with_array_values
-        plural_enum_attribute = enum_attribute.to_s.pluralize
-        message = "Expected #{record.class} to define :#{plural_enum_attribute} as an enum and store the value in a column of type integer"
+      it 'rejects with an appropriate failure message' do
+        record = build_record_with_array_values(
+          model_name: 'Example',
+          attribute_name: :attr,
+          column_type: :integer,
+        )
+        message = as_one_line(<<~MESSAGE)
+          Expected Example to define :attrs as an enum and store the value in a
+          column of type integer
+        MESSAGE
 
         assertion = lambda do
-          expect(record).to define_enum_for(plural_enum_attribute)
+          expect(record).to define_enum_for(:attrs)
         end
 
         expect(&assertion).to fail_with_message(message)
@@ -17,12 +23,15 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
     end
 
     context 'if a method to hold enum values exists on the model but was not created via the enum macro' do
-      it 'rejects' do
-        model = define_model :example do
+      it 'rejects with an appropriate failure message' do
+        model = define_model 'Example' do
           def self.statuses; end
         end
 
-        message = "Expected #{model} to define :statuses as an enum and store the value in a column of type integer"
+        message = as_one_line(<<~MESSAGE)
+          Expected Example to define :statuses as an enum and store the value in a
+          column of type integer
+        MESSAGE
 
         assertion = lambda do
           expect(model.new).to define_enum_for(:statuses)
@@ -32,160 +41,291 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
       end
     end
 
-    describe "with only the attribute name specified" do
-      it "accepts a record where the attribute is defined as an enum" do
-        expect(record_with_array_values).to define_enum_for(enum_attribute)
-      end
+    describe 'with only the attribute name specified' do
+      context 'if the attribute is not defined as an enum' do
+        it 'rejects with an appropriate failure message' do
+          record = build_record_with_non_enum_attribute(
+            model_name: 'Example',
+            attribute_name: :attr,
+          )
+          message = as_one_line(<<~MESSAGE)
+            Expected Example to define :attr as an enum and store the value in a
+            column of type integer
+          MESSAGE
 
-      it "rejects a record where the attribute is not defined as an enum" do
-        message = "Expected #{record_with_array_values.class} to define :#{non_enum_attribute} as an enum and store the value in a column of type integer"
+          assertion = lambda do
+            expect(record).to define_enum_for(:attr)
+          end
 
-        assertion = lambda do
-          expect(record_with_array_values).
-            to define_enum_for(non_enum_attribute)
+          expect(&assertion).to fail_with_message(message)
         end
-
-        expect(&assertion).to fail_with_message(message)
-      end
-
-      it "rejects a record where the attribute is not defined as an enum with should not" do
-        message = "Did not expect #{record_with_array_values.class} to define :#{enum_attribute} as an enum and store the value in a column of type integer"
-
-        assertion = lambda do
-          expect(record_with_array_values).
-            not_to define_enum_for(enum_attribute)
-        end
-
-        expect(&assertion).to fail_with_message(message)
       end
 
       context 'if the column storing the attribute is not an integer type' do
-        it 'rejects' do
-          record = record_with_array_values(column_type: :string)
-          message = "Expected #{record.class} to define :statuses as an enum and store the value in a column of type integer"
+        it 'rejects with an appropriate failure message' do
+          record = build_record_with_array_values(
+            model_name: 'Example',
+            attribute_name: :attr,
+            column_type: :string,
+          )
+          message = as_one_line(<<~MESSAGE)
+            Expected Example to define :attr as an enum and store the value in a
+            column of type integer
+          MESSAGE
 
           assertion = lambda do
-            expect(record).to define_enum_for(:statuses)
-          end
-
-          expect(&assertion).to fail_with_message(message)
-        end
-      end
-    end
-
-    describe "with both attribute name and enum values specified" do
-      context "when the actual enum values are an array" do
-        it "accepts a record where the attribute is defined as an enum and the enum values match" do
-          expect(record_with_array_values).to define_enum_for(enum_attribute).
-            with(["published", "unpublished", "draft"])
-        end
-
-        it "accepts a record where the attribute is not defined as an enum" do
-          message = %{Expected #{record_with_array_values.class} to define :#{non_enum_attribute} as an enum with ["open", "close"] and store the value in a column of type integer}
-
-          assertion = lambda do
-            expect(record_with_array_values).
-              to define_enum_for(non_enum_attribute).with(['open', 'close'])
-          end
-
-          expect(&assertion).to fail_with_message(message)
-        end
-
-        it "accepts a record where the attribute is defined as an enum but the enum values do not match" do
-          message = %{Expected #{record_with_array_values.class} to define :#{enum_attribute} as an enum with ["open", "close"] and store the value in a column of type integer}
-
-          assertion = lambda do
-            expect(record_with_array_values).
-              to define_enum_for(enum_attribute).
-              with(["open", "close"])
+            expect(record).to define_enum_for(:attr)
           end
 
           expect(&assertion).to fail_with_message(message)
         end
       end
 
-      context "when the actual enum values are a hash" do
-        it "accepts a record where the attribute is defined as an enum and the enum values match" do
-          expect(record_with_hash_values).to define_enum_for(enum_attribute).with(active: 0, archived: 1)
-        end
-
-        it "accepts a record where the enum values match when expected enum values are given as an array" do
-          expect(record_with_hash_values).to define_enum_for(enum_attribute).with(["active", "archived"])
-        end
-
-        it "accepts a record where the attribute is defined as an enum but the enum values do not match" do
-          message = %{Expected #{record_with_hash_values.class} to define :#{enum_attribute} as an enum with {:active=>5, :archived=>10} and store the value in a column of type integer}
-
-          assertion = lambda do
-            expect(record_with_hash_values).
-              to define_enum_for(enum_attribute).
-              with(active: 5, archived: 10)
-          end
-
-          expect(&assertion).to fail_with_message(message)
-        end
-
-        it "rejects a record where the attribute is not defined as an enum" do
-          message = %{Expected #{record_with_hash_values.class} to define :record_with_hash_values as an enum with {:active=>5, :archived=>10} and store the value in a column of type integer}
-
-          assertion = lambda do
-            expect(record_with_hash_values).
-              to define_enum_for(:record_with_hash_values).
-              with(active: 5, archived: 10)
-          end
-
-          expect(&assertion).to fail_with_message(message)
-        end
-      end
-    end
-
-    describe 'with the backing column specified to be a string type' do
-      context 'if the column storing the attribute is a string type' do
+      context 'if the attribute is defined as an enum' do
         it 'accepts' do
-          record = record_with_array_values(column_type: :string)
+          record = build_record_with_array_values(attribute_name: :attr)
 
-          expect(record).to define_enum_for(enum_attribute).backed_by_column_of_type(:string)
+          expect(record).to define_enum_for(:attr)
+        end
+
+        context 'and the matcher is negated' do
+          it 'rejects with an appropriate failure message' do
+            record = build_record_with_array_values(
+              model_name: 'Example',
+              attribute_name: :attr,
+              column_type: :integer,
+            )
+            message = as_one_line(<<~MESSAGE)
+              Did not expect Example to define :attr as an enum and store the
+              value in a column of type integer
+            MESSAGE
+
+            assertion = lambda do
+              expect(record).not_to define_enum_for(:attr)
+            end
+
+            expect(&assertion).to fail_with_message(message)
+          end
+        end
+      end
+    end
+
+    describe 'with both attribute name and enum values specified' do
+      context 'when the actual enum values are an array' do
+        context 'if the attribute is not defined as an enum' do
+          it 'rejects with an appropriate failure message' do
+            record = build_record_with_non_enum_attribute(
+              model_name: 'Example',
+              attribute_name: :attr,
+            )
+            message = as_one_line(<<~MESSAGE)
+              Expected Example to define :attr as an enum with ["open", "close"]
+              and store the value in a column of type integer
+            MESSAGE
+
+            assertion = lambda do
+              expect(record).to define_enum_for(:attr).with(['open', 'close'])
+            end
+
+            expect(&assertion).to fail_with_message(message)
+          end
+        end
+
+        context 'if the attribute is defined as an enum and the enum values match' do
+          context 'but the enum values do not match' do
+            it 'rejects with an appropriate failure message' do
+              record = build_record_with_array_values(
+                model_name: 'Example',
+                attribute_name: :attr,
+                values: ['published', 'unpublished', 'draft'],
+              )
+              message = as_one_line(<<~MESSAGE)
+                Expected Example to define :attr as an enum with ["open", "close"]
+                and store the value in a column of type integer
+              MESSAGE
+
+              assertion = lambda do
+                expect(record).to define_enum_for(:attr).with(['open', 'close'])
+              end
+
+              expect(&assertion).to fail_with_message(message)
+            end
+          end
+
+          context 'and the enum values match' do
+            it 'accepts' do
+              record = build_record_with_array_values(
+                attribute_name: :attr,
+                values: ['published', 'unpublished', 'draft'],
+              )
+
+              expect(record).to define_enum_for(:attr).
+                with(['published', 'unpublished', 'draft'])
+            end
+          end
         end
       end
 
-      context 'if the column storing the attribute is an integer type' do
-        it 'rejects' do
-          record = record_with_array_values(column_type: :integer)
-          message = "Expected #{record.class} to define :#{enum_attribute} as an enum and store the value in a column of type string"
+      context 'when the actual enum values are a hash' do
+        context 'if the attribute is not defined as an enum' do
+          it 'rejects with an appropriate failure message' do
+            record = build_record_with_non_enum_attribute(
+              model_name: 'Example',
+              attribute_name: :attr,
+            )
+            message = as_one_line(<<~MESSAGE)
+              Expected Example to define :attr as an enum with {:active=>5,
+              :archived=>10} and store the value in a column of type integer
+            MESSAGE
+
+            assertion = lambda do
+              expect(record).
+                to define_enum_for(:attr).
+                with(active: 5, archived: 10)
+            end
+
+            expect(&assertion).to fail_with_message(message)
+          end
+        end
+
+        context 'if the attribute is defined as an enum' do
+          context 'but the enum values do not match' do
+            it 'rejects with an appropriate failure message' do
+              record = build_record_with_hash_values(
+                model_name: 'Example',
+                attribute_name: :attr,
+                values: { active: 0, archived: 1 },
+              )
+              message = as_one_line(<<~MESSAGE)
+                Expected Example to define :attr as an enum with {:active=>5,
+                :archived=>10} and store the value in a column of type integer
+              MESSAGE
+
+              assertion = lambda do
+                expect(record).
+                  to define_enum_for(:attr).
+                  with(active: 5, archived: 10)
+              end
+
+              expect(&assertion).to fail_with_message(message)
+            end
+          end
+
+          context 'and the enum values match' do
+            context 'when expected enum values are a hash' do
+              it 'accepts' do
+                record = build_record_with_hash_values(
+                  attribute_name: :attr,
+                  values: { active: 0, archived: 1 },
+                )
+
+                expect(record).
+                  to define_enum_for(:attr).
+                  with(active: 0, archived: 1)
+              end
+            end
+
+            context 'when expected enum values are an array' do
+              it 'accepts' do
+                record = build_record_with_hash_values(
+                  attribute_name: :attr,
+                  values: { active: 0, archived: 1 },
+                )
+
+                expect(record).
+                  to define_enum_for(:attr).
+                  with(['active', 'archived'])
+              end
+            end
+          end
+        end
+      end
+    end
+
+    describe 'with the backing column specified to be of some type' do
+      context 'if the column storing the attribute is of a different type' do
+        it 'rejects with an appropriate failure message' do
+          record = build_record_with_array_values(
+            model_name: 'Example',
+            attribute_name: :attr,
+            column_type: :integer,
+          )
+          message = as_one_line(<<~MESSAGE)
+            Expected Example to define :attr as an enum and store the value in a
+            column of type string
+          MESSAGE
 
           assertion = lambda do
-            expect(record).to define_enum_for(enum_attribute).backed_by_column_of_type(:string)
+            expect(record).
+              to define_enum_for(:attr).
+              backed_by_column_of_type(:string)
           end
 
           expect(&assertion).to fail_with_message(message)
         end
       end
-    end
 
-    def enum_attribute
-      :status
-    end
+      context 'if the column storing the attribute is of the same type' do
+        it 'accepts' do
+          record = build_record_with_array_values(
+            attribute_name: :attr,
+            column_type: :string,
+          )
 
-    def non_enum_attribute
-      :condition
+          expect(record).
+            to define_enum_for(:attr).
+            backed_by_column_of_type(:string)
+        end
+      end
     end
+  end
 
-    def record_with_array_values(column_type: :integer)
-      model = define_model(
-        :record_with_array_values,
-        enum_attribute => { type: column_type },
-      )
-      model.enum(enum_attribute => ['published', 'unpublished', 'draft'])
-      model.new
-    end
+  def build_record_with_array_values(
+    model_name: 'Example',
+    attribute_name: :attr,
+    column_type: :integer,
+    values: ['published', 'unpublished', 'draft']
+  )
+    build_record_with_enum_attribute(
+      model_name: model_name,
+      attribute_name: attribute_name,
+      column_type: column_type,
+      values: values,
+    )
+  end
 
-    def record_with_hash_values
-      model = define_model(
-        :record_with_hash_values,
-        enum_attribute => { type: :integer },
-      )
-      model.enum(enum_attribute => { active: 0, archived: 1 })
-      model.new
-    end
+  def build_record_with_hash_values(
+    model_name: 'Example',
+    attribute_name: :attr,
+    values: { active: 0, archived: 1 }
+  )
+    build_record_with_enum_attribute(
+      model_name: model_name,
+      attribute_name: attribute_name,
+      column_type: :integer,
+      values: values,
+    )
+  end
+
+  def build_record_with_enum_attribute(
+    model_name:,
+    attribute_name:,
+    column_type:,
+    values:
+  )
+    model = define_model(
+      model_name,
+      attribute_name => column_type,
+    )
+    model.enum(attribute_name => values)
+    model.new
+  end
+
+  def build_record_with_non_enum_attribute(model_name:, attribute_name:)
+    define_model(model_name, attribute_name => :integer).new
+  end
+
+  def as_one_line(message)
+    message.tr("\n", ' ').strip
   end
 end

--- a/spec/unit/shoulda/matchers/active_record/define_enum_for_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/define_enum_for_matcher_spec.rb
@@ -304,30 +304,361 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
     end
   end
 
+  if active_record_enum_supports_prefix_and_suffix?
+    context 'qualified with #with_prefix' do
+      context 'when the prefix is explicit' do
+        context 'if the attribute was not defined with a prefix' do
+          it 'rejects with an appropriate failure message' do
+            record = build_record_with_array_values(
+              model_name: 'Example',
+              attribute_name: :attr,
+              column_type: :integer,
+              values: [:active, :archived],
+            )
+
+            assertion = lambda do
+              expect(record).
+                to define_enum_for(:attr).
+                with_values([:active, :archived]).
+                with_prefix(:foo)
+            end
+
+            message = format_message(<<-MESSAGE)
+              Expected Example to define :attr as an enum, backed by an integer,
+              using a prefix of :foo, with possible values ‹[:active,
+              :archived]›. However, it was defined with either a different
+              prefix or none at all.
+            MESSAGE
+
+            expect(&assertion).to fail_with_message(message)
+          end
+        end
+
+        context 'if the attribute was defined with a different prefix' do
+          it 'rejects with an appropriate failure message' do
+            record = build_record_with_array_values(
+              model_name: 'Example',
+              attribute_name: :attr,
+              column_type: :integer,
+              values: [:active, :archived],
+              prefix: :foo,
+            )
+
+            assertion = lambda do
+              expect(record).
+                to define_enum_for(:attr).
+                with_values([:active, :archived]).
+                with_prefix(:bar)
+            end
+
+            message = format_message(<<-MESSAGE)
+              Expected Example to define :attr as an enum, backed by an integer,
+              using a prefix of :bar, with possible values ‹[:active,
+              :archived]›. However, it was defined with either a different
+              prefix or none at all.
+            MESSAGE
+
+            expect(&assertion).to fail_with_message(message)
+          end
+        end
+
+        context 'if the attribute was defined with the same prefix' do
+          it 'accepts' do
+            record = build_record_with_array_values(
+              model_name: 'Example',
+              attribute_name: :attr,
+              values: [:active, :archived],
+              prefix: :foo,
+            )
+
+            expect(record).
+              to define_enum_for(:attr).
+              with_values([:active, :archived]).
+              with_prefix(:foo)
+          end
+        end
+      end
+
+      context 'when the prefix is implicit' do
+        context 'if the attribute was not defined with a prefix' do
+          it 'rejects with an appropriate failure message' do
+            record = build_record_with_array_values(
+              model_name: 'Example',
+              attribute_name: :attr,
+              column_type: :integer,
+              values: [:active, :archived],
+            )
+
+            assertion = lambda do
+              expect(record).
+                to define_enum_for(:attr).
+                with_values([:active, :archived]).
+                with_prefix
+            end
+
+            message = format_message(<<-MESSAGE)
+              Expected Example to define :attr as an enum, backed by an integer,
+              using a prefix of :attr, with possible values ‹[:active,
+              :archived]›. However, it was defined with either a different
+              prefix or none at all.
+            MESSAGE
+
+            expect(&assertion).to fail_with_message(message)
+          end
+        end
+
+        context 'if the attribute was defined with a prefix' do
+          it 'accepts' do
+            record = build_record_with_array_values(
+              model_name: 'Example',
+              attribute_name: :attr,
+              values: [:active, :archived],
+              prefix: true,
+            )
+
+            expect(record).
+              to define_enum_for(:attr).
+              with_values([:active, :archived]).
+              with_prefix
+          end
+        end
+      end
+    end
+
+    context 'qualified with #with_suffix' do
+      context 'when the suffix is explicit' do
+        context 'if the attribute was not defined with a suffix' do
+          it 'rejects with an appropriate failure message' do
+            record = build_record_with_array_values(
+              model_name: 'Example',
+              attribute_name: :attr,
+              column_type: :integer,
+              values: [:active, :archived],
+            )
+
+            assertion = lambda do
+              expect(record).
+                to define_enum_for(:attr).
+                with_values([:active, :archived]).
+                with_suffix(:foo)
+            end
+
+            message = format_message(<<-MESSAGE)
+              Expected Example to define :attr as an enum, backed by an integer,
+              using a suffix of :foo, with possible values ‹[:active,
+              :archived]›. However, it was defined with either a different
+              suffix or none at all.
+            MESSAGE
+
+            expect(&assertion).to fail_with_message(message)
+          end
+        end
+
+        context 'if the attribute was defined with a different suffix' do
+          it 'rejects with an appropriate failure message' do
+            record = build_record_with_array_values(
+              model_name: 'Example',
+              attribute_name: :attr,
+              column_type: :integer,
+              values: [:active, :archived],
+              suffix: :foo,
+            )
+
+            assertion = lambda do
+              expect(record).
+                to define_enum_for(:attr).
+                with_values([:active, :archived]).
+                with_suffix(:bar)
+            end
+
+            message = format_message(<<-MESSAGE)
+              Expected Example to define :attr as an enum, backed by an integer,
+              using a suffix of :bar, with possible values ‹[:active,
+              :archived]›. However, it was defined with either a different
+              suffix or none at all.
+            MESSAGE
+
+            expect(&assertion).to fail_with_message(message)
+          end
+        end
+
+        context 'if the attribute was defined with the same suffix' do
+          it 'accepts' do
+            record = build_record_with_array_values(
+              model_name: 'Example',
+              attribute_name: :attr,
+              values: [:active, :archived],
+              suffix: :foo,
+            )
+
+            expect(record).
+              to define_enum_for(:attr).
+              with_values([:active, :archived]).
+              with_suffix(:foo)
+          end
+        end
+      end
+
+      context 'when the suffix is implicit' do
+        context 'if the attribute was not defined with a suffix' do
+          it 'rejects with an appropriate failure message' do
+            record = build_record_with_array_values(
+              model_name: 'Example',
+              attribute_name: :attr,
+              column_type: :integer,
+              values: [:active, :archived],
+            )
+
+            assertion = lambda do
+              expect(record).
+                to define_enum_for(:attr).
+                with_values([:active, :archived]).
+                with_suffix
+            end
+
+            message = format_message(<<-MESSAGE)
+              Expected Example to define :attr as an enum, backed by an integer,
+              using a suffix of :attr, with possible values ‹[:active,
+              :archived]›. However, it was defined with either a different
+              suffix or none at all.
+            MESSAGE
+
+            expect(&assertion).to fail_with_message(message)
+          end
+        end
+
+        context 'if the attribute was defined with a suffix' do
+          it 'accepts' do
+            record = build_record_with_array_values(
+              model_name: 'Example',
+              attribute_name: :attr,
+              values: [:active, :archived],
+              suffix: true,
+            )
+
+            expect(record).
+              to define_enum_for(:attr).
+              with_values([:active, :archived]).
+              with_suffix
+          end
+        end
+      end
+    end
+
+    context 'qualified with both #with_prefix and #with_suffix' do
+      context 'if the attribute was not defined with a different prefix' do
+        it 'rejects with an appropriate failure message' do
+          record = build_record_with_array_values(
+            model_name: 'Example',
+            attribute_name: :attr,
+            column_type: :integer,
+            values: [:active, :archived],
+            prefix: :foo,
+            suffix: :bar,
+          )
+
+          assertion = lambda do
+            expect(record).
+              to define_enum_for(:attr).
+              with_values([:active, :archived]).
+              with_prefix(:whatever).
+              with_suffix(:bar)
+          end
+
+          message = format_message(<<-MESSAGE)
+            Expected Example to define :attr as an enum, backed by an integer,
+            using a prefix of :whatever and a suffix of :bar, with possible
+            values ‹[:active, :archived]›. However, it was defined with either
+            a different prefix, a different suffix, or neither one at all.
+          MESSAGE
+
+          expect(&assertion).to fail_with_message(message)
+        end
+
+        context 'if the attribute was defined with a different suffix' do
+          it 'rejects with an appropriate failure message' do
+            record = build_record_with_array_values(
+              model_name: 'Example',
+              attribute_name: :attr,
+              column_type: :integer,
+              values: [:active, :archived],
+              prefix: :foo,
+              suffix: :bar,
+            )
+
+            assertion = lambda do
+              expect(record).
+                to define_enum_for(:attr).
+                with_values([:active, :archived]).
+                with_prefix(:foo).
+                with_suffix(:whatever)
+            end
+
+            message = format_message(<<-MESSAGE)
+              Expected Example to define :attr as an enum, backed by an integer,
+              using a prefix of :foo and a suffix of :whatever, with possible
+              values ‹[:active, :archived]›. However, it was defined with
+              either a different prefix, a different suffix, or neither one at
+              all.
+            MESSAGE
+
+            expect(&assertion).to fail_with_message(message)
+          end
+        end
+
+        context 'if the attribute was defined with the same prefix and suffix' do
+          it 'accepts' do
+            record = build_record_with_array_values(
+              model_name: 'Example',
+              attribute_name: :attr,
+              values: [:active, :archived],
+              prefix: :foo,
+              suffix: :bar,
+            )
+
+            expect(record).
+              to define_enum_for(:attr).
+              with_values([:active, :archived]).
+              with_prefix(:foo).
+              with_suffix(:bar)
+          end
+        end
+      end
+    end
+  end
+
   def build_record_with_array_values(
     model_name: 'Example',
     attribute_name: :attr,
     column_type: :integer,
-    values: ['published', 'unpublished', 'draft']
+    values: ['published', 'unpublished', 'draft'],
+    prefix: false,
+    suffix: false
   )
     build_record_with_enum_attribute(
       model_name: model_name,
       attribute_name: attribute_name,
       column_type: column_type,
       values: values,
+      prefix: prefix,
+      suffix: suffix,
     )
   end
 
   def build_record_with_hash_values(
     model_name: 'Example',
     attribute_name: :attr,
-    values: { active: 0, archived: 1 }
+    values: { active: 0, archived: 1 },
+    prefix: false,
+    suffix: false
   )
     build_record_with_enum_attribute(
       model_name: model_name,
       attribute_name: attribute_name,
       column_type: :integer,
       values: values,
+      prefix: prefix,
+      suffix: suffix,
     )
   end
 
@@ -335,13 +666,21 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
     model_name:,
     attribute_name:,
     column_type:,
-    values:
+    values:,
+    prefix: false,
+    suffix: false
   )
     model = define_model(
       model_name,
-      attribute_name => column_type,
+      attribute_name => { type: column_type },
     )
-    model.enum(attribute_name => values)
+
+    if active_record_enum_supports_prefix_and_suffix?
+      model.enum(attribute_name => values, _prefix: prefix, _suffix: suffix)
+    else
+      model.enum(attribute_name => values)
+    end
+
     model.new
   end
 

--- a/spec/unit/shoulda/matchers/active_record/define_enum_for_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/define_enum_for_matcher_spec.rb
@@ -8,9 +8,9 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
         attribute_name: :attr,
         column_type: :integer,
       )
-      message = as_one_line(<<~MESSAGE)
-        Expected Example to define :attrs as an enum and store the value in a
-        column of type integer
+      message = format_message(<<-MESSAGE)
+        Expected Example to define :attrs as an enum, backed by an integer.
+        However, no such enum exists in Example.
       MESSAGE
 
       assertion = lambda do
@@ -27,13 +27,13 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
         def self.statuses; end
       end
 
-      message = as_one_line(<<~MESSAGE)
-        Expected Example to define :statuses as an enum and store the value in a
-        column of type integer
+      message = format_message(<<-MESSAGE)
+        Expected Example to define :attr as an enum, backed by an integer.
+        However, no such enum exists in Example.
       MESSAGE
 
       assertion = lambda do
-        expect(model.new).to define_enum_for(:statuses)
+        expect(model.new).to define_enum_for(:attr)
       end
 
       expect(&assertion).to fail_with_message(message)
@@ -47,9 +47,9 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
           model_name: 'Example',
           attribute_name: :attr,
         )
-        message = as_one_line(<<~MESSAGE)
-          Expected Example to define :attr as an enum and store the value in a
-          column of type integer
+        message = format_message(<<-MESSAGE)
+          Expected Example to define :attr as an enum, backed by an integer.
+          However, no such enum exists in Example.
         MESSAGE
 
         assertion = lambda do
@@ -67,9 +67,9 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
           attribute_name: :attr,
           column_type: :string,
         )
-        message = as_one_line(<<~MESSAGE)
-          Expected Example to define :attr as an enum and store the value in a
-          column of type integer
+        message = format_message(<<-MESSAGE)
+          Expected Example to define :attr as an enum, backed by an integer.
+          However, :attr is a string column.
         MESSAGE
 
         assertion = lambda do
@@ -94,9 +94,9 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
             attribute_name: :attr,
             column_type: :integer,
           )
-          message = as_one_line(<<~MESSAGE)
-            Did not expect Example to define :attr as an enum and store the
-            value in a column of type integer
+          message = format_message(<<-MESSAGE)
+            Expected Example not to define :attr as an enum, backed by an integer,
+            but it did.
           MESSAGE
 
           assertion = lambda do
@@ -117,20 +117,23 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
             model_name: 'Example',
             attribute_name: :attr,
           )
-          message = as_one_line(<<~MESSAGE)
-            Expected Example to define :attr as an enum with ["open", "close"]
-            and store the value in a column of type integer
+          message = format_message(<<-MESSAGE)
+            Expected Example to define :attr as an enum, backed by an integer,
+            with possible values ‹["open", "close"]›. However, no such enum
+            exists in Example.
           MESSAGE
 
           assertion = lambda do
-            expect(record).to define_enum_for(:attr).with_values(['open', 'close'])
+            expect(record).
+              to define_enum_for(:attr).
+              with_values(['open', 'close'])
           end
 
           expect(&assertion).to fail_with_message(message)
         end
       end
 
-      context 'if the attribute is defined as an enum and the enum values match' do
+      context 'if the attribute is defined as an enum' do
         context 'but the enum values do not match' do
           it 'rejects with an appropriate failure message' do
             record = build_record_with_array_values(
@@ -138,13 +141,16 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
               attribute_name: :attr,
               values: ['published', 'unpublished', 'draft'],
             )
-            message = as_one_line(<<~MESSAGE)
-              Expected Example to define :attr as an enum with ["open", "close"]
-              and store the value in a column of type integer
+            message = format_message(<<-MESSAGE)
+              Expected Example to define :attr as an enum, backed by an integer,
+              with possible values ‹["open", "close"]›. However, the actual
+              enum values for :attr are ‹["published", "unpublished", "draft"]›.
             MESSAGE
 
             assertion = lambda do
-              expect(record).to define_enum_for(:attr).with_values(['open', 'close'])
+              expect(record).
+                to define_enum_for(:attr).
+                with_values(['open', 'close'])
             end
 
             expect(&assertion).to fail_with_message(message)
@@ -172,9 +178,10 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
             model_name: 'Example',
             attribute_name: :attr,
           )
-          message = as_one_line(<<~MESSAGE)
-            Expected Example to define :attr as an enum with {:active=>5,
-            :archived=>10} and store the value in a column of type integer
+          message = format_message(<<-MESSAGE)
+            Expected Example to define :attr as an enum, backed by an integer,
+            with possible values ‹{active: 5, archived: 10}›. However, no such
+            enum exists in Example.
           MESSAGE
 
           assertion = lambda do
@@ -195,9 +202,10 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
               attribute_name: :attr,
               values: { active: 0, archived: 1 },
             )
-            message = as_one_line(<<~MESSAGE)
-              Expected Example to define :attr as an enum with {:active=>5,
-              :archived=>10} and store the value in a column of type integer
+            message = format_message(<<-MESSAGE)
+              Expected Example to define :attr as an enum, backed by an integer,
+              with possible values ‹{active: 5, archived: 10}›. However, the
+              actual enum values for :attr are ‹{active: 0, archived: 1}›.
             MESSAGE
 
             assertion = lambda do
@@ -267,9 +275,9 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
           attribute_name: :attr,
           column_type: :integer,
         )
-        message = as_one_line(<<~MESSAGE)
-          Expected Example to define :attr as an enum and store the value in a
-          column of type string
+        message = format_message(<<-MESSAGE)
+          Expected Example to define :attr as an enum, backed by a string.
+          However, :attr is an integer column.
         MESSAGE
 
         assertion = lambda do
@@ -339,9 +347,5 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
 
   def build_record_with_non_enum_attribute(model_name:, attribute_name:)
     define_model(model_name, attribute_name => :integer).new
-  end
-
-  def as_one_line(message)
-    message.tr("\n", ' ').strip
   end
 end

--- a/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
@@ -721,60 +721,58 @@ Example did not properly validate that :attr is case-sensitively unique.
       include_context 'it supports scoped attributes of a certain type',
         column_type: :integer
 
-      if active_record_supports_enum?
-        context 'when one of the scoped attributes is an enum' do
-          it 'accepts' do
+      context 'when one of the scoped attributes is an enum' do
+        it 'accepts' do
+          record = build_record_validating_scoped_uniqueness_with_enum(
+            enum_scope: :scope
+          )
+          expect(record).to validate_uniqueness.scoped_to(:scope)
+        end
+
+        context 'when too narrow of a scope is specified' do
+          it 'rejects with an appropriate failure message' do
             record = build_record_validating_scoped_uniqueness_with_enum(
-              enum_scope: :scope
+              enum_scope: :scope1,
+              additional_scopes: [:scope2],
+              additional_attributes: [:other]
             )
-            expect(record).to validate_uniqueness.scoped_to(:scope)
-          end
 
-          context 'when too narrow of a scope is specified' do
-            it 'rejects with an appropriate failure message' do
-              record = build_record_validating_scoped_uniqueness_with_enum(
-                enum_scope: :scope1,
-                additional_scopes: [:scope2],
-                additional_attributes: [:other]
-              )
+            assertion = lambda do
+              expect(record).
+                to validate_uniqueness.
+                scoped_to(:scope1, :scope2, :other)
+            end
 
-              assertion = lambda do
-                expect(record).
-                  to validate_uniqueness.
-                  scoped_to(:scope1, :scope2, :other)
-              end
-
-              message = <<-MESSAGE
+            message = <<-MESSAGE
 Example did not properly validate that :attr is case-sensitively unique
 within the scope of :scope1, :scope2, and :other.
   Expected the validation to be scoped to :scope1, :scope2, and :other,
   but it was scoped to :scope1 and :scope2 instead.
-              MESSAGE
+            MESSAGE
 
-              expect(&assertion).to fail_with_message(message)
-            end
+            expect(&assertion).to fail_with_message(message)
           end
+        end
 
-          context 'when too broad of a scope is specified' do
-            it 'rejects with an appropriate failure message' do
-              record = build_record_validating_scoped_uniqueness_with_enum(
-                enum_scope: :scope1,
-                additional_scopes: [:scope2]
-              )
+        context 'when too broad of a scope is specified' do
+          it 'rejects with an appropriate failure message' do
+            record = build_record_validating_scoped_uniqueness_with_enum(
+              enum_scope: :scope1,
+              additional_scopes: [:scope2]
+            )
 
-              assertion = lambda do
-                expect(record).to validate_uniqueness.scoped_to(:scope1)
-              end
+            assertion = lambda do
+              expect(record).to validate_uniqueness.scoped_to(:scope1)
+            end
 
-              message = <<-MESSAGE
+            message = <<-MESSAGE
 Example did not properly validate that :attr is case-sensitively unique
 within the scope of :scope1.
   Expected the validation to be scoped to :scope1, but it was scoped to
   :scope1 and :scope2 instead.
-              MESSAGE
+            MESSAGE
 
-              expect(&assertion).to fail_with_message(message)
-            end
+            expect(&assertion).to fail_with_message(message)
           end
         end
       end

--- a/spec/unit_spec_helper.rb
+++ b/spec/unit_spec_helper.rb
@@ -24,6 +24,7 @@ RSpec.configure do |config|
   UnitTests::DatabaseHelpers.configure_example_group(config)
   UnitTests::ColumnTypeHelpers.configure_example_group(config)
   UnitTests::ValidationMatcherScenarioHelpers.configure_example_group(config)
+  UnitTests::MessageHelpers.configure_example_group(config)
 
   if UnitTests::RailsVersions.rails_lte_4?
     UnitTests::ActiveResourceBuilder.configure_example_group(config)


### PR DESCRIPTION
In Rails 5, the `enum` macro received two new options: `_prefix` and
`_suffix`. These options change the names of the methods that are
generated from the given enum values. This commit adds qualifiers to the
`define_enum_for` matcher so that they can be tested.

---

Closes #961.