### PR TITLE
Add support for custom indices

### DIFF
--- a/lib/shoulda/matchers/active_record/have_db_index_matcher.rb
+++ b/lib/shoulda/matchers/active_record/have_db_index_matcher.rb
@@ -72,8 +72,9 @@ module Shoulda
       # @private
       class HaveDbIndexMatcher
         def initialize(columns)
-          @columns = normalize_columns_to_array(columns)
-          @options = {}
+          @columns        = normalize_columns_to_array(columns)
+          @joined_columns = normalize_columns_to_string(columns)
+          @options        = {}
         end
 
         def unique(unique = true)
@@ -124,7 +125,10 @@ module Shoulda
         end
 
         def matched_index
-          indexes.detect { |each| each.columns == @columns }
+          indexes.detect do |each|
+            each.columns == @columns ||
+              normalize_columns_to_string(each.columns) == @joined_columns
+          end
         end
 
         def model_class
@@ -153,6 +157,10 @@ module Shoulda
 
         def normalize_columns_to_array(columns)
           Array.wrap(columns).map(&:to_s)
+        end
+
+        def normalize_columns_to_string(columns)
+          Array.wrap(columns).compact.map(&:to_s).join(', ')
         end
       end
     end


### PR DESCRIPTION
I am working on an issue with trying to validate custom created indices on postgres. I have worked out a patch for this issue, but am unable to create the same conditions in the unit specs on sqlite.

My project schema contains the following index, which was created through an execute statement:
```sql
t.index "user_id, ((timezone('America/New_York'::text, timezone('UTC'::text, happened_at)))::date)", name: "index_table_on_user_per_day", unique: true, using: :btree
````
When you look at the index the column is seen as the entire index.
```sql
[6] #<ActiveRecord::ConnectionAdapters::IndexDefinition:0x7ffc8e3a3f58
        columns = "user_id, ((timezone('America/New_York'::text, timezone('UTC'::text, happened_at)))::date)",
        comment = nil,
        lengths = [],
        name = "index_table_on_user_per_day",
        orders = nil,
        table = :table,
        type = nil,
        unique = true,
        using = :btree,
        where = nil
    >,
```

There are two inputs that I think should work in this case, the latter requires a better understanding of what is happening under the hood.
```ruby
# Intuitive 
  it { should have_db_index([:user_id, "((timezone('America/New_York'::text, timezone('UTC'::text, happened_at)))::date)"]).unique }

# Not Intuitive
  it { should have_db_index(["user_id, ((timezone('America/New_York'::text, timezone('UTC'::text, happened_at)))::date)"]).unique }
```

One solution would be to do all the compares in `#matched_index` after joining the columns to a string, but I expect this would break a lot of people's specs since that would be the compare order dependent of the array. The other solution is to do a 2nd check for this case, using a joined version of the columns. While it would be order dependent in this one case, I don't think building out the possible permutations is reasonable, and trying to split definition would be error-prone(Unless you split both?).

The issue I ran into while working on this is that the unit tests run on sqlite and as such have a different reaction to trying to deserialize these indices.
```ruby
db_connection.execute "CREATE INDEX index_geocodings_on_geocodable_id_per_abs ON geocodings(geocodable_id, abs(geocodable_value));"
=> [#<struct ActiveRecord::ConnectionAdapters::IndexDefinition
  table=:geocodings,
  name="index_geocodings_on_geocodable_id_per_abs",
  unique=false,
  columns=["geocodable_id", nil],
  lengths=nil,
  orders=nil,
  where=nil,
  type=nil,
  using=nil,
  comment=nil>]
```

So while my solution would work on postgres, I am not sure the correct way to move forward creating a PR based on sqlite.
```ruby
def matched_index
  raw_sql_columns = @columns.join(', ')

  indexes.detect { |each| [@columns, raw_sql_columns].include?(each.columns) }
end
```