### PR TITLE
Fix validates_uniqueness_matcher for integer attributes

### DIFF
--- a/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
+++ b/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
@@ -521,7 +521,8 @@ module Shoulda
           non_blank_value = dummy_value_for(@attribute)
           limit = column_limit_for(@attribute)
 
-          if limit && limit < non_blank_value.length
+          is_string_value = non_blank_value.is_a?(String)
+          if is_string_value && limit && limit < non_blank_value.length
             'x' * limit
           else
             non_blank_value

--- a/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
@@ -356,6 +356,17 @@ Example did not properly validate that :attr is case-sensitively unique.
       end
     end
 
+    context 'when the attribute is of integer type' do
+      it 'accepts' do
+        record = build_record_validating_uniqueness(
+          attribute_type: :integer,
+          attribute_options: { limit: 4 },
+        )
+
+        expect(record).to validate_uniqueness
+      end
+    end
+
     context 'when the existing record was created beforehand' do
       context 'when the subject is a new record' do
         it 'accepts' do


### PR DESCRIPTION
This fixes #1081. As discussed, I first added a failing test that confirms the issue is present, then added the fix and checked that the test passed.