### PR TITLE
Add index_errors association matcher

### DIFF
--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -1283,18 +1283,16 @@ module Shoulda
         end
 
         def index_errors_correct?
-          if options.key?(:index_errors)
-            if option_verifier.correct_for_boolean?(
-              :index_errors, options[:index_errors]
-            )
-              true
-            else
-              @missing = "#{name} should have index_errors set to "\
-                         "#{options[:index_errors]}"
-              false
-            end
-          else
+          return true unless options.key?(:index_errors)
+
+          if option_verifier.correct_for_boolean?(
+            :index_errors, options[:index_errors]
+          )
             true
+          else
+            @missing = "#{name} should have index_errors set to "\
+                       "#{options[:index_errors]}"
+            false
           end
         end
 

--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -524,6 +524,24 @@ module Shoulda
       #       should have_many(:games).autosave(true)
       #     end
       #
+      # ##### index_errors
+      #
+      # Use `index_errors` to assert that the `:index_errors` option was specified.
+      #
+      #     class Player < ActiveRecord::Base
+      #       has_many :games, index_errors: true
+      #     end
+      #
+      #     # RSpec
+      #     RSpec.describe Player, type: :model do
+      #       it { should have_many(:games).index_errors(true) }
+      #     end
+      #
+      #     # Minitest (Shoulda)
+      #     class PlayerTest < ActiveSupport::TestCase
+      #       should have_many(:games).index_errors(true)
+      #     end
+      #
       # ##### inverse_of
       #
       # Use `inverse_of` to assert that the `:inverse_of` option was specified.
@@ -1022,6 +1040,11 @@ module Shoulda
           self
         end
 
+        def index_errors(index_errors)
+          @options[:index_errors] = index_errors
+          self
+        end
+
         def class_name(class_name)
           @options[:class_name] = class_name
           self
@@ -1096,6 +1119,7 @@ module Shoulda
             class_name_correct? &&
             join_table_correct? &&
             autosave_correct? &&
+            index_errors_correct? &&
             conditions_correct? &&
             validate_correct? &&
             touch_correct? &&
@@ -1250,6 +1274,19 @@ module Shoulda
               true
             else
               @missing = "#{name} should have autosave set to #{options[:autosave]}"
+              false
+            end
+          else
+            true
+          end
+        end
+
+        def index_errors_correct?
+          if options.key?(:index_errors)
+            if option_verifier.correct_for_boolean?(:index_errors, options[:index_errors])
+              true
+            else
+              @missing = "#{name} should have index_errors set to #{options[:index_errors]}"
               false
             end
           else

--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -526,7 +526,8 @@ module Shoulda
       #
       # ##### index_errors
       #
-      # Use `index_errors` to assert that the `:index_errors` option was specified.
+      # Use `index_errors` to assert that the `:index_errors` option was
+      # specified.
       #
       #     class Player < ActiveRecord::Base
       #       has_many :games, index_errors: true
@@ -1283,10 +1284,12 @@ module Shoulda
 
         def index_errors_correct?
           if options.key?(:index_errors)
-            if option_verifier.correct_for_boolean?(:index_errors, options[:index_errors])
+            if option_verifier.correct_for_boolean?(:index_errors,
+                                                    options[:index_errors])
               true
             else
-              @missing = "#{name} should have index_errors set to #{options[:index_errors]}"
+              @missing = "#{name} should have index_errors set to "\
+                         "#{options[:index_errors]}"
               false
             end
           else

--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -1284,8 +1284,9 @@ module Shoulda
 
         def index_errors_correct?
           if options.key?(:index_errors)
-            if option_verifier.correct_for_boolean?(:index_errors,
-                                                    options[:index_errors])
+            if option_verifier.correct_for_boolean?(
+              :index_errors, options[:index_errors]
+            )
               true
             else
               @missing = "#{name} should have index_errors set to "\

--- a/spec/support/unit/helpers/rails_versions.rb
+++ b/spec/support/unit/helpers/rails_versions.rb
@@ -34,5 +34,9 @@ module UnitTests
     def rails_lt_5?
       rails_version < 5
     end
+
+    def rails_5_x?
+      rails_version =~ '~> 5.0'
+    end
   end
 end

--- a/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -810,16 +810,18 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
         expect(Parent.new).to have_many(:children).index_errors(true)
       end
 
-      it 'rejects an association with a non-matching :index_errors option and returns the correct message' do
+      it 'rejects an association with a non-matching :index_errors option and '\
+         'returns the correct message' do
         define_model :child, parent_id: :integer
         define_model :parent do
           has_many :children, autosave: false
         end
 
-        message = 'Expected Parent to have a has_many association called children (children should have index_errors set to true)'
-        expect {
+        message = 'Expected Parent to have a has_many association called '\
+                  'children (children should have index_errors set to true)'
+        expect do
           expect(Parent.new).to have_many(:children).index_errors(true)
-        }.to fail_with_message(message)
+        end.to fail_with_message(message)
       end
     end
 

--- a/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -801,6 +801,28 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
       }.to fail_with_message(message)
     end
 
+    context 'index_errors' do
+      it 'accepts an association with a matching :index_errors option' do
+        define_model :child, parent_id: :integer
+        define_model :parent do
+          has_many :children, index_errors: true
+        end
+        expect(Parent.new).to have_many(:children).index_errors(true)
+      end
+
+      it 'rejects an association with a non-matching :index_errors option and returns the correct message' do
+        define_model :child, parent_id: :integer
+        define_model :parent do
+          has_many :children, autosave: false
+        end
+
+        message = 'Expected Parent to have a has_many association called children (children should have index_errors set to true)'
+        expect {
+          expect(Parent.new).to have_many(:children).index_errors(true)
+        }.to fail_with_message(message)
+      end
+    end
+
     context 'validate' do
       it 'accepts when the :validate option matches' do
         expect(having_many_children(validate: false)).to have_many(:children).validate(false)

--- a/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -801,27 +801,29 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
       }.to fail_with_message(message)
     end
 
-    context 'index_errors' do
-      it 'accepts an association with a matching :index_errors option' do
-        define_model :child, parent_id: :integer
-        define_model :parent do
-          has_many :children, index_errors: true
-        end
-        expect(Parent.new).to have_many(:children).index_errors(true)
-      end
-
-      it 'rejects an association with a non-matching :index_errors option and '\
-         'returns the correct message' do
-        define_model :child, parent_id: :integer
-        define_model :parent do
-          has_many :children, autosave: false
-        end
-
-        message = 'Expected Parent to have a has_many association called '\
-                  'children (children should have index_errors set to true)'
-        expect do
+    if rails_5_x?
+      context 'index_errors' do
+        it 'accepts an association with a matching :index_errors option' do
+          define_model :child, parent_id: :integer
+          define_model :parent do
+            has_many :children, index_errors: true
+          end
           expect(Parent.new).to have_many(:children).index_errors(true)
-        end.to fail_with_message(message)
+        end
+
+        it 'rejects an association with a non-matching :index_errors option '\
+           'and returns the correct message' do
+          define_model :child, parent_id: :integer
+          define_model :parent do
+            has_many :children, autosave: false
+          end
+
+          message = 'Expected Parent to have a has_many association called '\
+                    'children (children should have index_errors set to true)'
+          expect do
+            expect(Parent.new).to have_many(:children).index_errors(true)
+          end.to fail_with_message(message)
+        end
       end
     end
 


### PR DESCRIPTION
Hello! Our team was adding `index_errors` to a couple `has_many` associations and we noticed that there's no matcher for that yet. It looked pretty similar to `autosave` since it's just a boolean, so I pretty much copied that 😄 
