### PR TITLE
Accepts association with :inverse_of set to false and non standard foreign key

### DIFF
--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -1366,7 +1366,7 @@ module Shoulda
         end
 
         def foreign_key_reflection
-          if [:has_one, :has_many].include?(macro) && reflection.options.include?(:inverse_of)
+          if [:has_one, :has_many].include?(macro) && reflection.options.include?(:inverse_of) && reflection.options[:inverse_of] != false
             associated_class.reflect_on_association(reflection.options[:inverse_of])
           else
             reflection

--- a/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -870,6 +870,17 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
       expect(Parent.new).not_to have_many(:children)
     end
 
+    it 'accepts an association with a nonstandard foreign key, with reverse association turned off' do
+      define_model :child, ancestor_id: :integer do
+      end
+
+      define_model :parent do
+        has_many :children, foreign_key: :ancestor_id, inverse_of: false
+      end
+
+      expect(Parent.new).to have_many(:children)
+    end
+
     def having_many_children(options = {})
       define_model :child, parent_id: :integer
       define_model(:parent).tap do |model|


### PR DESCRIPTION
Shoulda-matchers failed to validate such association:

```
has_many :children, foreign_key: :ancestor_id, inverse_of: false
```


