### PR TITLE
Handle uuid columns in validate_absence_of

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_absence_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_absence_of_matcher.rb
@@ -109,6 +109,7 @@ module Shoulda
             when :datetime, :time, :timestamp then Time.now
             when :date then Date.new
             when :binary then '0'
+            when :uuid then SecureRandom.uuid
             else 'an arbitrary value'
             end
           end

--- a/spec/unit/shoulda/matchers/active_model/validate_absence_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_absence_of_matcher_spec.rb
@@ -13,7 +13,8 @@ describe Shoulda::Matchers::ActiveModel::ValidateAbsenceOfMatcher, type: :model 
         :timestamp,
         :time,
         :date,
-        :binary
+        :binary,
+        :uuid
       ]
     end
 


### PR DESCRIPTION
There is not an explicit value set for uuid columns in the
validate_absence_of matcher.  The default string value is used which
will get set to nil instead when the type cast happens.  This causes the
matcher to fail when testing that the model does indeed validate for
absence of that attribute.