### PR TITLE
Fix has_secure_password checks for Rails 6

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
@@ -139,7 +139,7 @@ module Shoulda
 
             @attribute == :password
           else
-            auth_attr = @subject.instance_methods.find {|meth| meth.to_s =~ /authenticate_[\w_]+/ }
+            auth_attr = @subject.class.instance_methods.find {|meth| meth.to_s =~ /authenticate_[\w_]+/ }
 
             return false unless auth_attr
 

--- a/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
@@ -134,10 +134,17 @@ module Shoulda
         private
 
         def secure_password_being_validated?
-          return false unless defined?(::ActiveModel::SecurePassword::InstanceMethodsOnActivation)
-          return false unless @subject.class.ancestors.include?(::ActiveModel::SecurePassword::InstanceMethodsOnActivation)
+          if defined?(::ActiveModel::SecurePassword::InstanceMethodsOnActivation)
+            return false unless @subject.class.ancestors.include?(::ActiveModel::SecurePassword::InstanceMethodsOnActivation)
 
-          @attribute == :password
+            @attribute == :password
+          else
+            auth_attr = @subject.instance_methods.find {|meth| meth.to_s =~ /authenticate_[\w_]+/ }
+
+            return false unless auth_attr
+
+            @attribute = auth_attr.delete('authenticate_')
+          end
         end
 
         def disallows_and_double_checks_value_of!(value, message)

--- a/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
@@ -134,9 +134,10 @@ module Shoulda
         private
 
         def secure_password_being_validated?
-          defined?(::ActiveModel::SecurePassword) &&
-            @subject.class.ancestors.include?(::ActiveModel::SecurePassword::InstanceMethodsOnActivation) &&
-            @attribute == :password
+          return false unless defined?(::ActiveModel::SecurePassword::InstanceMethodsOnActivation)
+          return false unless @subject.class.ancestors.include?(::ActiveModel::SecurePassword::InstanceMethodsOnActivation)
+
+          @attribute == :password
         end
 
         def disallows_and_double_checks_value_of!(value, message)

--- a/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
+++ b/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
@@ -537,7 +537,7 @@ module Shoulda
 
             @secure_attribute = :password
           else
-            auth_attr = model.instance_methods.find {|meth| meth.to_s =~ /authenticate_[\w_]+/ }
+            auth_attr = model.class.instance_methods.find {|meth| meth.to_s =~ /authenticate_[\w_]+/ }
 
             return false unless auth_attr
 

--- a/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
+++ b/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
@@ -530,8 +530,10 @@ module Shoulda
         end
 
         def has_secure_password?
-          model.ancestors.map(&:to_s).include?(
-            'ActiveModel::SecurePassword::InstanceMethodsOnActivation'
+          return false unless defined?(::ActiveModel::SecurePassword::InstanceMethodsOnActivation)
+
+          model.ancestors.include?(
+            ::ActiveModel::SecurePassword::InstanceMethodsOnActivation
           )
         end
 


### PR DESCRIPTION
If you're trying out Rails 6 and using shoulda-matchers, then this PR in particular will cause problems: https://github.com/rails/rails/commit/08dde0f355e0450bc2cb7e0b4b95a0ec18d1a870#diff-a6f9af64a6d420eb1103e16c0a0a8f04

`ActiveModel::SecurePassword:: InstanceMethodsOnActivation` is no longer included.

This PR simply makes the test for that class more specific, so it still works for stable versions of Rails.