### PR TITLE
Keep consistency on allow_blank and allow_nil qualifiers

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
@@ -310,8 +310,8 @@ EOT
           self
         end
 
-        def allow_blank(allow_blank = true)
-          @options[:allow_blank] = allow_blank
+        def allow_blank
+          @options[:allow_blank] = true
           self
         end
 
@@ -319,9 +319,8 @@ EOT
           @options[:allow_blank]
         end
 
-        def allow_nil(allow_nil = true)
-          @options[:allow_nil] = allow_nil
-          self
+        def allow_nil
+          @options[:allow_nil] = true
         end
 
         def expects_to_allow_nil?


### PR DESCRIPTION
Resolves #747  merge conflicts .

---

After some discussion[1] was decided that these qualifiers do not accept
any parameter.

https://github.com/thoughtbot/shoulda-matchers/pull/722