### PR TITLE
4.0.0.rc1 release and documentation

### DIFF
--- a/MIT-LICENSE
+++ b/MIT-LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2006-2016, Tammer Saleh and thoughtbot, inc.
+Copyright (c) 2006-2018, Tammer Saleh and thoughtbot, inc.
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/lib/shoulda/matchers/version.rb
+++ b/lib/shoulda/matchers/version.rb
@@ -1,6 +1,6 @@
 module Shoulda
   module Matchers
     # @private
-    VERSION = '3.1.2'.freeze
+    VERSION = '4.0.0.rc1'.freeze
   end
 end


### PR DESCRIPTION
- [x] Add shoulda-matchers logo
- [x]  Use `https` for all external links
- [x] Add Table of Contents
- [x] Update licenses year
- [x] Ruby and Rails compatilibity notes
- [x] Update gem version to 4.0.0
- [ ] [README.md](https://github.com/thoughtbot/shoulda-matchers/pull/1125/files#diff-04c6e90faac2675aa89e2176d2eec7d8) proofreading 
