### PR TITLE
Fix .hound/ruby.yml syntax

### DIFF
--- a/.hound/ruby.yml
+++ b/.hound/ruby.yml
@@ -302,9 +302,9 @@ Style/SymbolProc:
   Enabled: true
   IgnoredMethods:
   - respond_to
-Style/TrailingCommaInArrayLiteral
+Style/TrailingCommaInArrayLiteral:
   Enabled: true
-Style/TrailingCommaInHashLiteral
+Style/TrailingCommaInHashLiteral:
   Enabled: true
 Style/TrailingCommaInArguments:
   Description: Checks for trailing comma in parameter lists and literals.


### PR DESCRIPTION
Fix `.hound/ruby.yml` syntax causing issues for hound and rubocop.