### PR TITLE
Enable chain after allow_nil in validates_inclusion_of matcher

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
@@ -321,6 +321,7 @@ EOT
 
         def allow_nil
           @options[:allow_nil] = true
+          self
         end
 
         def expects_to_allow_nil?


### PR DESCRIPTION
78a482f995db719e8fad6d9a5dae4a3fcc727c18 make `allow_nil` disable to chain because it forgot `return self`