### PR TITLE
Fix absence matcher tests so that they run

### DIFF
--- a/spec/support/unit/helpers/active_model_versions.rb
+++ b/spec/support/unit/helpers/active_model_versions.rb
@@ -21,6 +21,10 @@ module UnitTests
       ::ActiveModel::VERSION::MAJOR == 4
     end
 
+    def active_model_supports_absence_validation?
+      active_model_version >= 4
+    end
+
     def active_model_supports_strict?
       active_model_version >= 3.2
     end

--- a/spec/support/unit/model_creators/basic.rb
+++ b/spec/support/unit/model_creators/basic.rb
@@ -79,7 +79,12 @@ module UnitTests
                 overrides[:changing_values_with]
               )
 
-              if respond_to?(:write_attribute)
+              if (
+                respond_to?(:write_attribute) && (
+                  !self.class.respond_to?(:reflect_on_association) ||
+                  !self.class.reflect_on_association(attribute_name)
+                )
+              )
                 write_attribute(attribute_name, new_value)
               else
                 super(new_value)

--- a/spec/unit/shoulda/matchers/active_model/validate_absence_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_absence_of_matcher_spec.rb
@@ -1,7 +1,7 @@
 require 'unit_spec_helper'
 
 describe Shoulda::Matchers::ActiveModel::ValidateAbsenceOfMatcher, type: :model do
-  if active_model_4_0?
+  if active_model_supports_absence_validation?
     def self.available_column_types
       [
         :string,


### PR DESCRIPTION
Apparently they were supposed to be enabled for ActiveModel >= 4 but
ended up being enabled for ActiveModel 4 itself.