### PR TITLE
Don't require bootsnap in gen'ed Rails 5.2+ apps

### DIFF
--- a/spec/support/unit/rails_application.rb
+++ b/spec/support/unit/rails_application.rb
@@ -75,6 +75,7 @@ module UnitTests
     def generate
       rails_new
       fix_available_locales_warning
+      remove_bootsnap
       write_database_configuration
 
       if bundle.version_of("rails") >= 5
@@ -96,6 +97,16 @@ if I18n.respond_to?(:enforce_available_locales=)
 end
         EOT
       end
+    end
+
+    def remove_bootsnap
+      # Rails 5.2 introduced bootsnap, which is helpful when you're developing
+      # or deploying an app, but we don't really need it (and it messes with
+      # Zeus anyhow)
+      fs.comment_lines_matching(
+        'config/boot.rb',
+        %r{\Arequire 'bootsnap/setup'},
+      )
     end
 
     def write_database_configuration


### PR DESCRIPTION
[Bootsnap][1] is a new gem that speeds up load times for Rails apps and
is included by default in Rails 5.2+ apps. However, this somehow messes
with Zeus, which we use often to run tests locally. We don't need it in
the Rails apps that the tests generate, so make sure it's not required
in those apps.

[1]: https://github.com/Shopify/bootsnap