### PR TITLE
Fix Zeus so that it runs again on Ruby >= 2.5.x

### DIFF
--- a/zeus.json
+++ b/zeus.json
@@ -1,5 +1,5 @@
 {
-  "command": "ruby -rubygems -r./custom_plan -eZeus.go",
+  "command": "ruby -r rubygems -r ./custom_plan -e Zeus.go",
 
   "plan": {
     "boot": {


### PR DESCRIPTION
Ruby 2.5.0 removed support for the `-ubygems` option ([source][1]). This
was introduced many many years ago so you could say `ruby -rubygems`,
which was just a shortcut for `ruby -r rubygems`. Now that's no longer
there, so we have to update how Zeus starts a Ruby process.

[1]: https://github.com/ruby/ruby/commit/9de6c712b66aad77df40661c1fc6d37e9a5c251a