### PR TITLE
Fix negative versions of validation matchers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -70,6 +70,11 @@ is now:
   * *PR: [#1073]*
   * *Original issue: [#949]*
 
+* Fix `validate_inclusion_of` so that if it fails, it will no longer blow up
+  with the error "undefined method \`attribute_setter' for nil:NilClass".
+
+  * *Original issue: [#904]*
+
 ### Features
 
 * Add `required` and `optional` qualifiers to `belong_to` and `have_one`
@@ -143,6 +148,7 @@ is now:
 [#961]: https://github.com/thoughtbot/shoulda-matchers/issues/961
 [795ca68]: https://github.com/thoughtbot/shoulda-matchers/commit/795ca688bff08590dbd2ab6f2b51ea415e0c7473
 [#1089]: https://github.com/thoughtbot/shoulda-matchers/pulls/1089
+[#904]: https://github.com/thoughtbot/shoulda-matchers/issues/904
 
 ### Improvements
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -75,6 +75,12 @@ is now:
 
   * *Original issue: [#904]*
 
+* Add negative versions of all validation matchers (i.e. implement
+  `does_not_match?` for them) to prevent them from blowing up with
+  "undefined method \`attribute_setter' for nil:NilClass".
+
+  * *Original issue: [#904]*
+
 ### Features
 
 * Add `required` and `optional` qualifiers to `belong_to` and `have_one`

--- a/lib/shoulda/matchers/active_model/validate_absence_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_absence_of_matcher.rb
@@ -88,6 +88,11 @@ module Shoulda
           disallows_value_of(value, @expected_message)
         end
 
+        def does_not_match?(subject)
+          super(subject)
+          allows_value_of(value, @expected_message)
+        end
+
         def simple_description
           "validate that :#{@attribute} is empty/falsy"
         end

--- a/lib/shoulda/matchers/active_model/validate_acceptance_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_acceptance_of_matcher.rb
@@ -91,6 +91,11 @@ module Shoulda
           disallows_value_of(false, @expected_message)
         end
 
+        def does_not_match?(subject)
+          super(subject)
+          allows_value_of(false, @expected_message)
+        end
+
         def simple_description
           %(validate that :#{@attribute} has been set to "1")
         end

--- a/lib/shoulda/matchers/active_model/validate_confirmation_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_confirmation_of_matcher.rb
@@ -100,7 +100,21 @@ module Shoulda
             allows_missing_confirmation
         end
 
+        def does_not_match?(subject)
+          super(subject)
+
+          allows_different_value ||
+            disallows_same_value ||
+            disallows_missing_confirmation
+        end
+
         private
+
+        def allows_different_value
+          allows_value_of('different value') do |matcher|
+            qualify_matcher(matcher, 'some value')
+          end
+        end
 
         def disallows_different_value
           disallows_value_of('different value') do |matcher|
@@ -114,8 +128,20 @@ module Shoulda
           end
         end
 
+        def disallows_same_value
+          disallows_value_of('same value') do |matcher|
+            qualify_matcher(matcher, 'same value')
+          end
+        end
+
         def allows_missing_confirmation
           allows_value_of('any value') do |matcher|
+            qualify_matcher(matcher, nil)
+          end
+        end
+
+        def disallows_missing_confirmation
+          disallows_value_of('any value') do |matcher|
             qualify_matcher(matcher, nil)
           end
         end
@@ -128,17 +154,6 @@ module Shoulda
             @expected_message,
             against: confirmation_attribute,
             values: { attribute: attribute }
-          )
-        end
-
-        def set_confirmation(value)
-          @last_value_set_on_confirmation_attribute = value
-
-          AttributeSetter.set(
-            matcher_name: 'confirmation',
-            object: @subject,
-            attribute_name: confirmation_attribute,
-            value: value
           )
         end
       end

--- a/lib/shoulda/matchers/active_model/validate_exclusion_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_exclusion_of_matcher.rb
@@ -162,14 +162,33 @@ module Shoulda
           if @range
             allows_lower_value &&
               disallows_minimum_value &&
-              allows_higher_value &&
-              disallows_maximum_value
+              disallows_maximum_value &&
+              allows_higher_value
           elsif @array
             disallows_all_values_in_array?
           end
         end
 
+        def does_not_match?(subject)
+          super(subject)
+
+          if @range
+            disallows_lower_value ||
+              allows_minimum_value ||
+              allows_maximum_value ||
+              disallows_higher_value
+          elsif @array
+            allows_any_values_in_array?
+          end
+        end
+
         private
+
+        def allows_any_values_in_array?
+          @array.any? do |value|
+            allows_value_of(value, @expected_message)
+          end
+        end
 
         def disallows_all_values_in_array?
           @array.all? do |value|
@@ -181,16 +200,32 @@ module Shoulda
           @minimum == 0 || allows_value_of(@minimum - 1, @expected_message)
         end
 
-        def allows_higher_value
-          allows_value_of(@maximum + 1, @expected_message)
+        def disallows_lower_value
+          @minimum != 0 && disallows_value_of(@minimum - 1, @expected_message)
+        end
+
+        def allows_minimum_value
+          allows_value_of(@minimum, @expected_message)
         end
 
         def disallows_minimum_value
           disallows_value_of(@minimum, @expected_message)
         end
 
+        def allows_maximum_value
+          allows_value_of(@maximum, @expected_message)
+        end
+
         def disallows_maximum_value
           disallows_value_of(@maximum, @expected_message)
+        end
+
+        def allows_higher_value
+          allows_value_of(@maximum + 1, @expected_message)
+        end
+
+        def disallows_higher_value
+          disallows_value_of(@maximum + 1, @expected_message)
         end
 
         def inspect_message

--- a/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
@@ -496,7 +496,7 @@ EOT
             end
           end
 
-          values_outside_of_array.any? do |value|
+          values_outside_of_array.all? do |value|
             allows_value_of(value, @low_message)
           end
         end
@@ -517,8 +517,8 @@ EOT
             end
           end
 
-          values_outside_of_array.all? do |value|
-            disallows_value_of(value, @low_message)
+          values_outside_of_array.none? do |value|
+            allows_value_of(value, @low_message)
           end
         end
 

--- a/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
@@ -465,8 +465,8 @@ EOT
             end
           end
 
-          !values_outside_of_array.any? do |value|
-            allows_value_of(value, @low_message)
+          values_outside_of_array.all? do |value|
+            disallows_value_of(value, @low_message)
           end
         end
 

--- a/lib/shoulda/matchers/active_model/validate_numericality_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_numericality_of_matcher.rb
@@ -411,13 +411,13 @@ module Shoulda
         end
 
         def matches?(subject)
-          @subject = subject
-          @number_of_submatchers = @submatchers.size
+          matches_or_does_not_match?(subject)
+          first_submatcher_that_fails_to_match.nil?
+        end
 
-          add_disallow_value_matcher
-          qualify_submatchers
-
-          first_failing_submatcher.nil?
+        def does_not_match?(subject)
+          matches_or_does_not_match?(subject)
+          first_submatcher_that_fails_to_not_match.nil?
         end
 
         def simple_description
@@ -440,20 +440,14 @@ module Shoulda
         def failure_message
           overall_failure_message.dup.tap do |message|
             message << "\n"
-            message << failure_message_for_first_failing_submatcher
+            message << failure_message_for_first_submatcher_that_fails_to_match
           end
         end
 
         def failure_message_when_negated
           overall_failure_message_when_negated.dup.tap do |message|
-            if submatcher_failure_message_when_negated.present?
-              raise "hmm, this needs to be implemented."
-              message << "\n"
-              message << Shoulda::Matchers.word_wrap(
-                submatcher_failure_message_when_negated,
-                indent: 2
-              )
-            end
+            message << "\n"
+            message << failure_message_for_first_submatcher_that_fails_to_not_match
           end
         end
 
@@ -464,19 +458,25 @@ module Shoulda
 
         private
 
-        def model
-          @subject.class
+        def matches_or_does_not_match?(subject)
+          @subject = subject
+          @number_of_submatchers = @submatchers.size
+
+          add_disallow_value_matcher
+          qualify_submatchers
         end
 
         def overall_failure_message
           Shoulda::Matchers.word_wrap(
-            "#{model.name} did not properly #{description}."
+            "Expected #{model.name} to #{description}, but this could not " +
+            'be proved.'
           )
         end
 
         def overall_failure_message_when_negated
           Shoulda::Matchers.word_wrap(
-            "Expected #{model.name} not to #{description}, but it did."
+            "Expected #{model.name} not to #{description}, but this could not " +
+            'be proved.'
           )
         end
 
@@ -566,35 +566,49 @@ module Shoulda
           end
         end
 
-        def first_failing_submatcher
+        def first_submatcher_that_fails_to_match
           @_failing_submatchers ||= @submatchers.detect do |submatcher|
             !submatcher.matches?(@subject)
           end
         end
 
-        def submatcher_failure_message
-          first_failing_submatcher.failure_message
-        end
-
-        def submatcher_failure_message_when_negated
-          first_failing_submatcher.failure_message_when_negated
-        end
-
-        def failure_message_for_first_failing_submatcher
-          submatcher = first_failing_submatcher
-
-          if number_of_submatchers_for_failure_message > 1
-            submatcher_description = submatcher.simple_description.
-              sub(/\bvalidate that\b/, 'validates').
-              sub(/\bdisallow\b/, 'disallows').
-              sub(/\ballow\b/, 'allows')
-            submatcher_message =
-              "In checking that #{model.name} #{submatcher_description}, " +
-              submatcher.failure_message[0].downcase +
-              submatcher.failure_message[1..-1]
-          else
-            submatcher_message = submatcher.failure_message
+        def first_submatcher_that_fails_to_not_match
+          @_failing_submatchers ||= @submatchers.detect do |submatcher|
+            !submatcher.does_not_match?(@subject)
           end
+        end
+
+        def failure_message_for_first_submatcher_that_fails_to_match
+          build_submatcher_failure_message_for(
+            first_submatcher_that_fails_to_match,
+            :failure_message
+          )
+        end
+
+        def failure_message_for_first_submatcher_that_fails_to_not_match
+          build_submatcher_failure_message_for(
+            first_submatcher_that_fails_to_not_match,
+            :failure_message_when_negated
+          )
+        end
+
+        def build_submatcher_failure_message_for(
+          submatcher,
+          failure_message_method
+        )
+          failure_message = submatcher.public_send(failure_message_method)
+          submatcher_description = submatcher.simple_description.
+            sub(/\bvalidate that\b/, 'validates').
+            sub(/\bdisallow\b/, 'disallows').
+            sub(/\ballow\b/, 'allows')
+          submatcher_message =
+            if number_of_submatchers_for_failure_message > 1
+              "In checking that #{model.name} #{submatcher_description}, " +
+                failure_message[0].downcase +
+                failure_message[1..-1]
+            else
+              failure_message
+            end
 
           Shoulda::Matchers.word_wrap(submatcher_message, indent: 2)
         end
@@ -615,6 +629,10 @@ module Shoulda
             end
             arr
           end
+        end
+
+        def model
+          @subject.class
         end
       end
     end

--- a/lib/shoulda/matchers/active_model/validation_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validation_matcher.rb
@@ -51,6 +51,11 @@ module Shoulda
           false
         end
 
+        def does_not_match?(subject)
+          @subject = subject
+          true
+        end
+
         def failure_message
           overall_failure_message.dup.tap do |message|
             if failure_reason.present?
@@ -65,10 +70,10 @@ module Shoulda
 
         def failure_message_when_negated
           overall_failure_message_when_negated.dup.tap do |message|
-            if failure_reason_when_negated.present?
+            if failure_reason.present?
               message << "\n"
               message << Shoulda::Matchers.word_wrap(
-                failure_reason_when_negated,
+                failure_reason,
                 indent: 2
               )
             end
@@ -115,13 +120,15 @@ module Shoulda
 
         def overall_failure_message
           Shoulda::Matchers.word_wrap(
-            "#{model.name} did not properly #{description}."
+            "Expected #{model.name} to #{description}, but this could not be " +
+            'proved.'
           )
         end
 
         def overall_failure_message_when_negated
           Shoulda::Matchers.word_wrap(
-            "Expected #{model.name} not to #{description}, but it did."
+            "Expected #{model.name} not to #{description}, but this could " +
+            'not be proved.'
           )
         end
 

--- a/lib/shoulda/matchers/active_model/validation_matcher/build_description.rb
+++ b/lib/shoulda/matchers/active_model/validation_matcher/build_description.rb
@@ -16,10 +16,11 @@ module Shoulda
           def call
             if description_clauses_for_qualifiers.any?
               main_description +
+                clause_for_allow_blank_or_nil +
                 ', ' +
                 description_clauses_for_qualifiers.to_sentence
             else
-              main_description
+              main_description + clause_for_allow_blank_or_nil
             end
           end
 
@@ -29,14 +30,18 @@ module Shoulda
 
           private
 
+          def clause_for_allow_blank_or_nil
+            if matcher.try(:expects_to_allow_blank?)
+              ' as long as it is not blank'
+            elsif matcher.try(:expects_to_allow_nil?)
+              ' as long as it is not nil'
+            else
+              ''
+            end
+          end
+
           def description_clauses_for_qualifiers
             description_clauses = []
-
-            if matcher.try(:expects_to_allow_blank?)
-              description_clauses << 'but only if it is not blank'
-            elsif matcher.try(:expects_to_allow_nil?)
-              description_clauses << 'but only if it is not nil'
-            end
 
             if matcher.try(:expects_strict?)
               description_clauses << 'raising a validation exception'

--- a/spec/support/unit/rails_application.rb
+++ b/spec/support/unit/rails_application.rb
@@ -75,6 +75,7 @@ module UnitTests
     def generate
       rails_new
       fix_available_locales_warning
+      remove_bootsnap
       write_database_configuration
 
       if bundle.version_of("rails") >= 5
@@ -96,6 +97,16 @@ if I18n.respond_to?(:enforce_available_locales=)
 end
         EOT
       end
+    end
+
+    def remove_bootsnap
+      # Rails 5.2 introduced bootsnap, which is helpful when you're developing
+      # or deploying an app, but we don't really need it (and it messes with
+      # Zeus anyhow)
+      fs.comment_lines_matching(
+        'config/boot.rb',
+        %r{\Arequire 'bootsnap/setup'},
+      )
     end
 
     def write_database_configuration

--- a/spec/support/unit/record_validating_confirmation_builder.rb
+++ b/spec/support/unit/record_validating_confirmation_builder.rb
@@ -13,7 +13,7 @@ module UnitTests
     end
 
     def model_name
-      'Example'
+      options.fetch(:model_name, 'Example')
     end
 
     def record
@@ -29,7 +29,10 @@ module UnitTests
     end
 
     def confirmation_attribute
-      :"#{attribute_to_confirm}_confirmation"
+      options.fetch(
+        :confirmation_attribute,
+        :"#{attribute_to_confirm}_confirmation"
+      )
     end
 
     def attribute_that_receives_error

--- a/spec/unit/shoulda/matchers/active_model/validate_absence_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_absence_of_matcher_spec.rb
@@ -48,6 +48,27 @@ describe Shoulda::Matchers::ActiveModel::ValidateAbsenceOfMatcher, type: :model 
         end
       end
 
+      context 'when used in the negative' do
+        it 'fails' do
+          assertion = lambda do
+            expect(validating_absence_of(:attr)).
+              not_to validate_absence_of(:attr)
+          end
+
+          message = <<-MESSAGE
+Expected Example not to validate that :attr is empty/falsy, but this
+could not be proved.
+  After setting :attr to ‹"an arbitrary value"›, the matcher expected
+  the Example to be valid, but it was invalid instead, producing these
+  validation errors:
+
+  * attr: ["must be blank"]
+          MESSAGE
+
+          expect(&assertion).to fail_with_message(message)
+        end
+      end
+
       def validation_matcher_scenario_args
         super.deep_merge(model_creator: :active_record)
       end
@@ -58,7 +79,8 @@ describe Shoulda::Matchers::ActiveModel::ValidateAbsenceOfMatcher, type: :model 
         record = define_model(:example, attr: :string).new
 
         message = <<-MESSAGE
-Example did not properly validate that :attr is empty/falsy.
+Expected Example to validate that :attr is empty/falsy, but this could
+not be proved.
   After setting :attr to ‹"an arbitrary value"›, the matcher expected
   the Example to be invalid, but it was valid instead.
         MESSAGE
@@ -97,7 +119,8 @@ Example did not properly validate that :attr is empty/falsy.
     context 'an ActiveModel class without an absence validation' do
       it 'rejects with the correct failure message' do
         message = <<-MESSAGE
-Example did not properly validate that :attr is empty/falsy.
+Expected Example to validate that :attr is empty/falsy, but this could
+not be proved.
   After setting :attr to ‹"an arbitrary value"›, the matcher expected
   the Example to be invalid, but it was valid instead.
         MESSAGE
@@ -161,7 +184,8 @@ Example did not properly validate that :attr is empty/falsy.
         model = having_and_belonging_to_many(:children, absence: false)
 
         message = <<-MESSAGE
-Parent did not properly validate that :children is empty/falsy.
+Expected Parent to validate that :children is empty/falsy, but this
+could not be proved.
   After setting :children to ‹[#<Child id: nil>]›, the matcher expected
   the Parent to be invalid, but it was valid instead.
         MESSAGE

--- a/spec/unit/shoulda/matchers/active_model/validate_acceptance_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_acceptance_of_matcher_spec.rb
@@ -21,7 +21,8 @@ describe Shoulda::Matchers::ActiveModel::ValidateAcceptanceOfMatcher, type: :mod
           attribute_name: :attr,
           changing_values_with: :always_nil,
           expected_message: <<-MESSAGE.strip
-Example did not properly validate that :attr has been set to "1".
+Expected Example to validate that :attr has been set to "1", but this
+could not be proved.
   After setting :attr to ‹false› -- which was read back as ‹nil› -- the
   matcher expected the Example to be invalid, but it was valid instead.
 
@@ -35,6 +36,23 @@ Example did not properly validate that :attr has been set to "1".
       },
       model_creator: :active_model
     )
+
+    it 'fails when used in the negative' do
+      assertion = lambda do
+        expect(record_validating_acceptance).not_to matcher
+      end
+
+      message = <<-MESSAGE
+Expected Example not to validate that :attr has been set to "1", but
+this could not be proved.
+  After setting :attr to ‹false›, the matcher expected the Example to be
+  valid, but it was invalid instead, producing these validation errors:
+
+  * attr: ["must be accepted"]
+      MESSAGE
+
+      expect(&assertion).to fail_with_message(message)
+    end
   end
 
   context 'a model without an acceptance validation' do

--- a/spec/unit/shoulda/matchers/active_model/validate_confirmation_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_confirmation_of_matcher_spec.rb
@@ -36,8 +36,8 @@ describe Shoulda::Matchers::ActiveModel::ValidateConfirmationOfMatcher, type: :m
           attribute_name: :password,
           changing_values_with: :next_value,
           expected_message: <<-MESSAGE.strip
-Example did not properly validate that :password_confirmation matches
-:password.
+Expected Example to validate that :password_confirmation matches
+:password, but this could not be proved.
   After setting :password_confirmation to ‹"same value"›, then setting
   :password to ‹"same value"› -- which was read back as ‹"same valuf"›
   -- the matcher expected the Example to be valid, but it was invalid
@@ -55,6 +55,29 @@ Example did not properly validate that :password_confirmation matches
       },
       model_creator: :active_model
     )
+
+    it 'fails when used in the negative' do
+      builder = builder_for_record_validating_confirmation(
+        model_name: 'Example',
+        attribute: :password,
+        confirmation_attribute: :password_confirmation
+      )
+
+      assertion = lambda do
+        expect(builder.record).
+          not_to validate_confirmation_of(builder.attribute_to_confirm)
+      end
+
+      message = <<-MESSAGE
+Expected Example not to validate that :password_confirmation matches
+:password, but this could not be proved.
+  After setting :password_confirmation to ‹nil›, then setting :password
+  to ‹"any value"›, the matcher expected the Example to be invalid, but
+  it was valid instead.
+      MESSAGE
+
+      expect(&assertion).to fail_with_message(message)
+    end
   end
 
   context 'when the model does not have a confirmation attribute' do
@@ -108,8 +131,8 @@ The matcher attempted to set :attribute_to_confirm on the Example to
       end
 
       message = <<-MESSAGE
-Example did not properly validate that
-:attribute_to_confirm_confirmation matches :attribute_to_confirm.
+Expected Example to validate that :attribute_to_confirm_confirmation
+matches :attribute_to_confirm, but this could not be proved.
   After setting :attribute_to_confirm_confirmation to ‹"some value"›,
   then setting :attribute_to_confirm to ‹"different value"›, the matcher
   expected the Example to be invalid, but it was valid instead.

--- a/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb
@@ -448,9 +448,21 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
 
     define_method(:valid_values) { args.fetch(:possible_values) }
 
-    it 'does not match a record with no validations' do
-      builder = build_object
-      expect_not_to_match_on_values(builder, possible_values)
+    context 'when the record has no validations' do
+      it 'passes when used in the negative' do
+        builder = build_object
+        expect_not_to_match_on_values(builder, possible_values)
+      end
+
+      it 'fails when used in the positive with an appropriate failure message' do
+        builder = build_object
+
+        assertion = lambda do
+          expect_to_match_on_values(builder, possible_values)
+        end
+
+        expect(&assertion).to fail
+      end
     end
 
     it 'matches given the same array of valid values' do

--- a/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb
@@ -498,6 +498,16 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
       end
     end
 
+    it 'fails when used in the negative' do
+      builder = build_object_allowing(possible_values)
+
+      assertion = lambda do
+        expect_not_to_match_on_values(builder, possible_values)
+      end
+
+      expect(&assertion).to fail
+    end
+
     it_behaves_like 'it supports allow_nil', valid_values: possible_values
     it_behaves_like 'it supports allow_blank', valid_values: possible_values
     it_behaves_like 'it supports with_message', valid_values: possible_values

--- a/spec/unit/shoulda/matchers/active_model/validate_length_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_length_of_matcher_spec.rb
@@ -33,8 +33,8 @@ describe Shoulda::Matchers::ActiveModel::ValidateLengthOfMatcher, type: :model d
           attribute_name: :attr,
           changing_values_with: :add_character,
           expected_message: <<-MESSAGE.strip
-Example did not properly validate that the length of :attr is at least
-4.
+Expected Example to validate that the length of :attr is at least 4, but
+this could not be proved.
   After setting :attr to ‹"xxx"› -- which was read back as ‹"xxxa"› --
   the matcher expected the Example to be invalid, but it was valid
   instead.
@@ -55,6 +55,22 @@ Example did not properly validate that the length of :attr is at least
       def configure_validation_matcher(matcher)
         matcher.is_at_least(4)
       end
+    end
+
+    it 'fails when used in the negative' do
+      assertion = lambda do
+        expect(validating_length(minimum: 4)).
+          not_to validate_length_of(:attr).is_at_least(4)
+      end
+
+      message = <<-MESSAGE
+Expected Example not to validate that the length of :attr is at least 4,
+but this could not be proved.
+  After setting :attr to ‹"xxxx"›, the matcher expected the Example to
+  be invalid, but it was valid instead.
+      MESSAGE
+
+      expect(&assertion).to fail_with_message(message)
     end
   end
 
@@ -97,7 +113,8 @@ Example did not properly validate that the length of :attr is at least
           attribute_name: :attr,
           changing_values_with: :remove_character,
           expected_message: <<-MESSAGE.strip
-Example did not properly validate that the length of :attr is at most 4.
+Expected Example to validate that the length of :attr is at most 4, but
+this could not be proved.
   After setting :attr to ‹"xxxxx"› -- which was read back as ‹"xxxx"› --
   the matcher expected the Example to be invalid, but it was valid
   instead.
@@ -153,7 +170,8 @@ Example did not properly validate that the length of :attr is at most 4.
           attribute_name: :attr,
           changing_values_with: :add_character,
           expected_message: <<-MESSAGE.strip
-Example did not properly validate that the length of :attr is 4.
+Expected Example to validate that the length of :attr is 4, but this
+could not be proved.
   After setting :attr to ‹"xxx"› -- which was read back as ‹"xxxa"› --
   the matcher expected the Example to be invalid, but it was valid
   instead.
@@ -280,8 +298,8 @@ Example did not properly validate that the length of :attr is 4.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that the length of :attr is at least
-1.
+Expected Example to validate that the length of :attr is at least 1, but
+this could not be proved.
   After setting :attr to ‹nil›, the matcher expected the Example to be
   valid, but it was invalid instead, producing these validation errors:
 

--- a/spec/unit/shoulda/matchers/active_model/validate_numericality_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_numericality_of_matcher_spec.rb
@@ -138,7 +138,8 @@ describe Shoulda::Matchers::ActiveModel::ValidateNumericalityOfMatcher, type: :m
             attribute_name: :attr,
             changing_values_with: :numeric_value,
             expected_message: <<-MESSAGE.strip
-Example did not properly validate that :attr looks like a number.
+Expected Example to validate that :attr looks like a number, but this
+could not be proved.
   After setting :attr to ‹"abcd"› -- which was read back as ‹"1"› -- the
   matcher expected the Example to be invalid, but it was valid instead.
 
@@ -188,6 +189,27 @@ Example did not properly validate that :attr looks like a number.
           end
         end
       end
+
+      context 'when used in the negative' do
+        it 'fails' do
+          assertion = lambda do
+            record = build_record_validating_numericality
+            expect(record).not_to validate_numericality
+          end
+
+          message = <<-MESSAGE
+Expected Example not to validate that :attr looks like a number, but
+this could not be proved.
+  After setting :attr to ‹"abcd"›, the matcher expected the Example to
+  be valid, but it was invalid instead, producing these validation
+  errors:
+
+  * attr: ["is not a number"]
+          MESSAGE
+
+          expect(&assertion).to fail_with_message(message)
+        end
+      end
     end
 
     context 'and not validating anything' do
@@ -197,7 +219,8 @@ Example did not properly validate that :attr looks like a number.
         assertion = -> { expect(record).to validate_numericality }
 
         message = <<-MESSAGE
-Example did not properly validate that :attr looks like a number.
+Expected Example to validate that :attr looks like a number, but this
+could not be proved.
   After setting :attr to ‹"abcd"›, the matcher expected the Example to
   be invalid, but it was valid instead.
         MESSAGE
@@ -225,8 +248,8 @@ Example did not properly validate that :attr looks like a number.
             attribute_name: :attr,
             changing_values_with: :next_value_or_non_numeric_value,
             expected_message: <<-MESSAGE.strip
-Example did not properly validate that :attr looks like a number, but
-only if it is not nil.
+Expected Example to validate that :attr looks like a number as long as
+it is not nil, but this could not be proved.
   In checking that Example allows :attr to be ‹nil›, after setting :attr
   to ‹nil› -- which was read back as ‹"a"› -- the matcher expected the
   Example to be valid, but it was invalid instead, producing these
@@ -262,8 +285,8 @@ only if it is not nil.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr looks like a number, but
-only if it is not nil.
+Expected Example to validate that :attr looks like a number as long as
+it is not nil, but this could not be proved.
   In checking that Example allows :attr to be ‹nil›, after setting :attr
   to ‹nil›, the matcher expected the Example to be valid, but it was
   invalid instead, producing these validation errors:
@@ -294,7 +317,8 @@ only if it is not nil.
             attribute_name: :attr,
             changing_values_with: :numeric_value,
             expected_message: <<-MESSAGE.strip
-Example did not properly validate that :attr looks like an integer.
+Expected Example to validate that :attr looks like an integer, but this
+could not be proved.
   After setting :attr to ‹"0.1"› -- which was read back as ‹"1"› -- the
   matcher expected the Example to be invalid, but it was valid instead.
 
@@ -326,7 +350,8 @@ Example did not properly validate that :attr looks like an integer.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr looks like an integer.
+Expected Example to validate that :attr looks like an integer, but this
+could not be proved.
   After setting :attr to ‹"0.1"›, the matcher expected the Example to be
   invalid, but it was valid instead.
         MESSAGE
@@ -354,7 +379,8 @@ Example did not properly validate that :attr looks like an integer.
             attribute_name: :attr,
             changing_values_with: :next_value,
             expected_message: <<-MESSAGE.strip
-Example did not properly validate that :attr looks like an odd number.
+Expected Example to validate that :attr looks like an odd number, but
+this could not be proved.
   After setting :attr to ‹"2"› -- which was read back as ‹"3"› -- the
   matcher expected the Example to be invalid, but it was valid instead.
 
@@ -428,7 +454,8 @@ Example did not properly validate that :attr looks like an odd number.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr looks like an odd number.
+Expected Example to validate that :attr looks like an odd number, but
+this could not be proved.
   After setting :attr to ‹"2"›, the matcher expected the Example to be
   invalid, but it was valid instead.
         MESSAGE
@@ -456,7 +483,8 @@ Example did not properly validate that :attr looks like an odd number.
             attribute_name: :attr,
             changing_values_with: :next_value,
             expected_message: <<-MESSAGE.strip
-Example did not properly validate that :attr looks like an even number.
+Expected Example to validate that :attr looks like an even number, but
+this could not be proved.
   After setting :attr to ‹"1"› -- which was read back as ‹"2"› -- the
   matcher expected the Example to be invalid, but it was valid instead.
 
@@ -530,7 +558,8 @@ Example did not properly validate that :attr looks like an even number.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr looks like an even number.
+Expected Example to validate that :attr looks like an even number, but
+this could not be proved.
   After setting :attr to ‹"1"›, the matcher expected the Example to be
   invalid, but it was valid instead.
         MESSAGE
@@ -557,8 +586,8 @@ Example did not properly validate that :attr looks like an even number.
             attribute_name: :attr,
             changing_values_with: :next_value,
             expected_message: <<-MESSAGE.strip
-Example did not properly validate that :attr looks like a number less
-than or equal to 18.
+Expected Example to validate that :attr looks like a number less than or
+equal to 18, but this could not be proved.
   After setting :attr to ‹"18"› -- which was read back as ‹"19"› -- the
   matcher expected the Example to be valid, but it was invalid instead,
   producing these validation errors:
@@ -637,8 +666,8 @@ than or equal to 18.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr looks like a number less
-than or equal to 18.
+Expected Example to validate that :attr looks like a number less than or
+equal to 18, but this could not be proved.
   After setting :attr to ‹"19"›, the matcher expected the Example to be
   invalid, but it was valid instead.
         MESSAGE
@@ -665,8 +694,8 @@ than or equal to 18.
             attribute_name: :attr,
             changing_values_with: :next_value,
             expected_message: <<-MESSAGE.strip
-Example did not properly validate that :attr looks like a number less
-than 18.
+Expected Example to validate that :attr looks like a number less than
+18, but this could not be proved.
   After setting :attr to ‹"17"› -- which was read back as ‹"18"› -- the
   matcher expected the Example to be valid, but it was invalid instead,
   producing these validation errors:
@@ -743,8 +772,8 @@ than 18.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr looks like a number less
-than 18.
+Expected Example to validate that :attr looks like a number less than
+18, but this could not be proved.
   After setting :attr to ‹"19"›, the matcher expected the Example to be
   invalid, but it was valid instead.
         MESSAGE
@@ -769,8 +798,8 @@ than 18.
             attribute_name: :attr,
             changing_values_with: :next_value,
             expected_message: <<-MESSAGE.strip
-Example did not properly validate that :attr looks like a number equal
-to 18.
+Expected Example to validate that :attr looks like a number equal to 18,
+but this could not be proved.
   After setting :attr to ‹"18"› -- which was read back as ‹"19"› -- the
   matcher expected the Example to be valid, but it was invalid instead,
   producing these validation errors:
@@ -847,8 +876,8 @@ to 18.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr looks like a number equal
-to 18.
+Expected Example to validate that :attr looks like a number equal to 18,
+but this could not be proved.
   After setting :attr to ‹"19"›, the matcher expected the Example to be
   invalid, but it was valid instead.
         MESSAGE
@@ -877,8 +906,8 @@ to 18.
             attribute_name: :attr,
             changing_values_with: :next_value,
             expected_message: <<-MESSAGE.strip
-Example did not properly validate that :attr looks like a number greater
-than or equal to 18.
+Expected Example to validate that :attr looks like a number greater than
+or equal to 18, but this could not be proved.
   After setting :attr to ‹"17"› -- which was read back as ‹"18"› -- the
   matcher expected the Example to be invalid, but it was valid instead.
 
@@ -962,8 +991,8 @@ than or equal to 18.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr looks like a number greater
-than or equal to 18.
+Expected Example to validate that :attr looks like a number greater than
+or equal to 18, but this could not be proved.
   After setting :attr to ‹"17"›, the matcher expected the Example to be
   invalid, but it was valid instead.
         MESSAGE
@@ -990,8 +1019,8 @@ than or equal to 18.
             attribute_name: :attr,
             changing_values_with: :next_value,
             expected_message: <<-MESSAGE.strip
-Example did not properly validate that :attr looks like a number greater
-than 18.
+Expected Example to validate that :attr looks like a number greater than
+18, but this could not be proved.
   After setting :attr to ‹"18"› -- which was read back as ‹"19"› -- the
   matcher expected the Example to be invalid, but it was valid instead.
 
@@ -1071,8 +1100,8 @@ than 18.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr looks like a number greater
-than 18.
+Expected Example to validate that :attr looks like a number greater than
+18, but this could not be proved.
   After setting :attr to ‹"18"›, the matcher expected the Example to be
   invalid, but it was valid instead.
         MESSAGE
@@ -1099,8 +1128,8 @@ than 18.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr looks like a number,
-producing a custom validation error on failure.
+Expected Example to validate that :attr looks like a number, producing a
+custom validation error on failure, but this could not be proved.
   After setting :attr to ‹"abcd"›, the matcher expected the Example to
   be invalid and to produce a validation error matching ‹/wrong/› on
   :attr. The record was indeed invalid, but it produced these validation
@@ -1129,8 +1158,8 @@ producing a custom validation error on failure.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr looks like a number,
-producing a custom validation error on failure.
+Expected Example to validate that :attr looks like a number, producing a
+custom validation error on failure, but this could not be proved.
   After setting :attr to ‹"abcd"›, the matcher expected the Example to
   be invalid, but it was valid instead.
         MESSAGE
@@ -1157,8 +1186,8 @@ producing a custom validation error on failure.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr looks like a number,
-raising a validation exception on failure.
+Expected Example to validate that :attr looks like a number, raising a
+validation exception on failure, but this could not be proved.
   After setting :attr to ‹"abcd"›, the matcher expected the Example to
   be invalid and to raise a validation exception, but the record
   produced validation errors instead.
@@ -1192,7 +1221,8 @@ raising a validation exception on failure.
       end
 
       message = <<-MESSAGE
-Example did not properly validate that :attr looks like a number.
+Expected Example to validate that :attr looks like a number, but this
+could not be proved.
   After setting :attr to ‹"abcd"›, the matcher expected the Example to
   be invalid, but it was valid instead.
       MESSAGE
@@ -1229,8 +1259,8 @@ Example did not properly validate that :attr looks like a number.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr looks like an integer
-greater than 18.
+Expected Example to validate that :attr looks like an integer greater
+than 18, but this could not be proved.
   In checking that Example disallows :attr from being a decimal number,
   after setting :attr to ‹"0.1"›, the matcher expected the Example to be
   invalid and to produce the validation error "must be an integer" on
@@ -1254,8 +1284,8 @@ greater than 18.
         end
 
         message = <<-MESSAGE.strip_heredoc
-Example did not properly validate that :attr looks like an integer
-greater than 18.
+Expected Example to validate that :attr looks like an integer greater
+than 18, but this could not be proved.
   In checking that Example disallows :attr from being a decimal number,
   after setting :attr to ‹"0.1"›, the matcher expected the Example to be
   invalid and to produce the validation error "must be an integer" on
@@ -1282,8 +1312,8 @@ greater than 18.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr looks like an even number
-greater than 18.
+Expected Example to validate that :attr looks like an even number
+greater than 18, but this could not be proved.
   In checking that Example disallows :attr from being a number that is
   not greater than 18, after setting :attr to ‹"18"›, the matcher
   expected the Example to be invalid, but it was valid instead.
@@ -1306,8 +1336,8 @@ greater than 18.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr looks like an even number
-greater than 18.
+Expected Example to validate that :attr looks like an even number
+greater than 18, but this could not be proved.
   In checking that Example disallows :attr from being an odd number,
   after setting :attr to ‹"1"›, the matcher expected the Example to be
   invalid and to produce the validation error "must be even" on :attr.
@@ -1334,8 +1364,8 @@ greater than 18.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr looks like an odd number
-less than or equal to 99.
+Expected Example to validate that :attr looks like an odd number less
+than or equal to 99, but this could not be proved.
   In checking that Example disallows :attr from being a number that is
   not less than or equal to 99, after setting :attr to ‹"101"›, the
   matcher expected the Example to be invalid, but it was valid instead.
@@ -1360,8 +1390,8 @@ less than or equal to 99.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr looks like an integer
-greater than 18 and less than 99.
+Expected Example to validate that :attr looks like an integer greater
+than 18 and less than 99, but this could not be proved.
   In checking that Example disallows :attr from being a number that is
   not greater than 18, after setting :attr to ‹"18"›, the matcher
   expected the Example to be invalid, but it was valid instead.
@@ -1385,10 +1415,9 @@ greater than 18 and less than 99.
             is_greater_than(18)
         end
 
-        # why is value "19" here?
         message = <<-MESSAGE
-Example did not properly validate that :attr looks like an integer
-greater than 18.
+Expected Example to validate that :attr looks like an integer greater
+than 18, but this could not be proved.
   In checking that Example disallows :attr from being a number that is
   not greater than 18, after setting :attr to ‹"18"›, the matcher
   expected the Example to be invalid and to produce the validation error
@@ -1415,8 +1444,8 @@ greater than 18.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr looks like an integer
-greater than 18.
+Expected Example to validate that :attr looks like an integer greater
+than 18, but this could not be proved.
   In checking that Example disallows :attr from being a number that is
   not greater than 18, after setting :attr to ‹"18"›, the matcher
   expected the Example to be invalid, but it was valid instead.
@@ -1438,10 +1467,9 @@ greater than 18.
             is_greater_than(18)
         end
 
-         # why is value "20" here?
         message = <<-MESSAGE
-Example did not properly validate that :attr looks like an even number
-greater than 18.
+Expected Example to validate that :attr looks like an even number
+greater than 18, but this could not be proved.
   In checking that Example disallows :attr from being a number that is
   not greater than 18, after setting :attr to ‹"18"›, the matcher
   expected the Example to be invalid and to produce the validation error
@@ -1468,8 +1496,8 @@ greater than 18.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr looks like an even number
-greater than 18.
+Expected Example to validate that :attr looks like an even number
+greater than 18, but this could not be proved.
   In checking that Example disallows :attr from being a number that is
   not greater than 18, after setting :attr to ‹"18"›, the matcher
   expected the Example to be invalid, but it was valid instead.
@@ -1492,8 +1520,8 @@ greater than 18.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr looks like an odd number
-less than or equal to 99.
+Expected Example to validate that :attr looks like an odd number less
+than or equal to 99, but this could not be proved.
   In checking that Example disallows :attr from being a number that is
   not less than or equal to 99, after setting :attr to ‹"101"›, the
   matcher expected the Example to be invalid, but it was valid instead.
@@ -1516,8 +1544,8 @@ less than or equal to 99.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr looks like an odd number
-less than or equal to 99.
+Expected Example to validate that :attr looks like an odd number less
+than or equal to 99, but this could not be proved.
   In checking that Example disallows :attr from being a number that is
   not less than or equal to 99, after setting :attr to ‹"101"›, the
   matcher expected the Example to be invalid and to produce the
@@ -1546,10 +1574,9 @@ less than or equal to 99.
             is_less_than(99)
         end
 
-        # why is value "19" here?
         message = <<-MESSAGE
-Example did not properly validate that :attr looks like an integer
-greater than 18 and less than 99.
+Expected Example to validate that :attr looks like an integer greater
+than 18 and less than 99, but this could not be proved.
   In checking that Example disallows :attr from being a number that is
   not greater than 18, after setting :attr to ‹"18"›, the matcher
   expected the Example to be invalid and to produce the validation error
@@ -1578,8 +1605,8 @@ greater than 18 and less than 99.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr looks like an integer
-greater than 18 and less than 99.
+Expected Example to validate that :attr looks like an integer greater
+than 18 and less than 99, but this could not be proved.
   In checking that Example disallows :attr from being a number that is
   not less than 99, after setting :attr to ‹"100"›, the matcher expected
   the Example to be invalid and to produce the validation error "must be
@@ -1659,7 +1686,8 @@ greater than 18 and less than 99.
           attribute_name: :attr,
           changing_values_with: :numeric_value,
           expected_message: <<-MESSAGE.strip
-Example did not properly validate that :attr looks like a number.
+Expected Example to validate that :attr looks like a number, but this
+could not be proved.
   After setting :attr to ‹"abcd"› -- which was read back as ‹"1"› -- the
   matcher expected the Example to be invalid, but it was valid instead.
 

--- a/spec/unit/shoulda/matchers/active_model/validate_presence_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_presence_of_matcher_spec.rb
@@ -21,7 +21,8 @@ describe Shoulda::Matchers::ActiveModel::ValidatePresenceOfMatcher, type: :model
           attribute_name: :attr,
           changing_values_with: :never_falsy,
           expected_message: <<-MESSAGE
-Example did not properly validate that :attr cannot be empty/falsy.
+Expected Example to validate that :attr cannot be empty/falsy, but this
+could not be proved.
   After setting :attr to ‹nil› -- which was read back as ‹"dummy value"›
   -- the matcher expected the Example to be invalid, but it was valid
   instead.
@@ -35,6 +36,23 @@ Example did not properly validate that :attr cannot be empty/falsy.
         }
       }
     )
+
+    it 'fails when used in the negative' do
+      assertion = lambda do
+        expect(validating_presence).not_to matcher
+      end
+
+      message = <<-MESSAGE
+Expected Example not to validate that :attr cannot be empty/falsy, but
+this could not be proved.
+  After setting :attr to ‹nil›, the matcher expected the Example to be
+  valid, but it was invalid instead, producing these validation errors:
+
+  * attr: ["can't be blank"]
+      MESSAGE
+
+      expect(&assertion).to fail_with_message(message)
+    end
   end
 
   context 'a model without a presence validation' do
@@ -46,7 +64,8 @@ Example did not properly validate that :attr cannot be empty/falsy.
       end
 
       message = <<-MESSAGE
-Example did not properly validate that :attr cannot be empty/falsy.
+Expected Example to validate that :attr cannot be empty/falsy, but this
+could not be proved.
   After setting :attr to ‹nil›, the matcher expected the Example to be
   invalid, but it was valid instead.
       MESSAGE
@@ -75,7 +94,8 @@ Example did not properly validate that :attr cannot be empty/falsy.
           attribute_name: :attr,
           changing_values_with: :never_falsy,
           expected_message: <<-MESSAGE
-Example did not properly validate that :attr cannot be empty/falsy.
+Expected Example to validate that :attr cannot be empty/falsy, but this
+could not be proved.
   After setting :attr to ‹nil› -- which was read back as ‹"dummy value"›
   -- the matcher expected the Example to be invalid, but it was valid
   instead.
@@ -102,7 +122,8 @@ Example did not properly validate that :attr cannot be empty/falsy.
       end
 
       message = <<-MESSAGE
-Example did not properly validate that :attr cannot be empty/falsy.
+Expected Example to validate that :attr cannot be empty/falsy, but this
+could not be proved.
   After setting :attr to ‹nil›, the matcher expected the Example to be
   invalid, but it was valid instead.
       MESSAGE
@@ -127,7 +148,8 @@ Example did not properly validate that :attr cannot be empty/falsy.
           attribute_name: :attr,
           changing_values_with: :never_falsy,
           expected_message: <<-MESSAGE
-Example did not properly validate that :attr cannot be empty/falsy.
+Expected Example to validate that :attr cannot be empty/falsy, but this
+could not be proved.
   After setting :attr to ‹nil› -- which was read back as ‹"dummy value"›
   -- the matcher expected the Example to be invalid, but it was valid
   instead.
@@ -185,7 +207,8 @@ Example did not properly validate that :attr cannot be empty/falsy.
           attribute_name: :attr,
           changing_values_with: :never_falsy,
           expected_message: <<-MESSAGE
-Example did not properly validate that :attr cannot be empty/falsy.
+Expected Example to validate that :attr cannot be empty/falsy, but this
+could not be proved.
   After setting :attr to ‹nil› -- which was read back as ‹"dummy value"›
   -- the matcher expected the Example to be invalid, but it was valid
   instead.
@@ -223,7 +246,8 @@ Example did not properly validate that :attr cannot be empty/falsy.
       end
 
       message = <<-MESSAGE
-Parent did not properly validate that :children cannot be empty/falsy.
+Expected Parent to validate that :children cannot be empty/falsy, but
+this could not be proved.
   After setting :children to ‹[]›, the matcher expected the Parent to be
   invalid, but it was valid instead.
       MESSAGE
@@ -260,8 +284,8 @@ Parent did not properly validate that :children cannot be empty/falsy.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr cannot be empty/falsy,
-raising a validation exception on failure.
+Expected Example to validate that :attr cannot be empty/falsy, raising a
+validation exception on failure, but this could not be proved.
   After setting :attr to ‹nil›, the matcher expected the Example to be
   invalid and to raise a validation exception, but the record produced
   validation errors instead.

--- a/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
@@ -82,8 +82,9 @@ describe Shoulda::Matchers::ActiveRecord::ValidateUniquenessOfMatcher, type: :mo
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr is case-sensitively unique
-within the scope of :scope1, :scope2, and :other.
+Expected Example to validate that :attr is case-sensitively unique
+within the scope of :scope1, :scope2, and :other, but this could not be
+proved.
   Expected the validation to be scoped to :scope1, :scope2, and :other,
   but it was scoped to :scope1 and :scope2 instead.
         MESSAGE
@@ -108,8 +109,8 @@ within the scope of :scope1, :scope2, and :other.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr is case-sensitively unique
-within the scope of :scope1.
+Expected Example to validate that :attr is case-sensitively unique
+within the scope of :scope1, but this could not be proved.
   Expected the validation to be scoped to :scope1, but it was scoped to
   :scope1 and :scope2 instead.
         MESSAGE
@@ -131,8 +132,8 @@ within the scope of :scope1.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr is case-sensitively unique
-within the scope of :scope.
+Expected Example to validate that :attr is case-sensitively unique
+within the scope of :scope, but this could not be proved.
   Expected the validation to be scoped to :scope, but it was scoped to
   :other instead.
         MESSAGE
@@ -152,7 +153,8 @@ within the scope of :scope.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr is case-sensitively unique.
+Expected Example to validate that :attr is case-sensitively unique, but
+this could not be proved.
   Expected the validation not to be scoped to anything, but it was
   scoped to :scope instead.
         MESSAGE
@@ -171,7 +173,8 @@ Example did not properly validate that :attr is case-sensitively unique.
           end
 
           message = <<-MESSAGE
-Example did not properly validate that :attr is case-sensitively unique.
+Expected Example to validate that :attr is case-sensitively unique, but
+this could not be proved.
   Expected the validation not to be scoped to anything, but it was
   scoped to :scope instead.
           MESSAGE
@@ -193,8 +196,8 @@ Example did not properly validate that :attr is case-sensitively unique.
           end
 
           message = <<-MESSAGE.strip
-Example did not properly validate that :attr is case-sensitively unique
-within the scope of :non_existent.
+Expected Example to validate that :attr is case-sensitively unique
+within the scope of :non_existent, but this could not be proved.
   :non_existent does not seem to be an attribute on Example.
           MESSAGE
 
@@ -216,8 +219,9 @@ within the scope of :non_existent.
           end
 
           message = <<-MESSAGE.strip
-Example did not properly validate that :attr is case-sensitively unique
-within the scope of :non_existent1 and :non_existent2.
+Expected Example to validate that :attr is case-sensitively unique
+within the scope of :non_existent1 and :non_existent2, but this could
+not be proved.
   :non_existent1 and :non_existent2 do not seem to be attributes on
   Example.
           MESSAGE
@@ -334,7 +338,8 @@ within the scope of :non_existent1 and :non_existent2.
       end
 
       message = <<-MESSAGE
-Example did not properly validate that :attr is case-sensitively unique.
+Expected Example to validate that :attr is case-sensitively unique, but
+this could not be proved.
   Given an existing Example whose :attr is ‹"value"›, after making a new
   Example and setting its :attr to ‹"value"› as well, the matcher
   expected the new Example to be invalid, but it was valid instead.
@@ -529,8 +534,8 @@ Example did not properly validate that :attr is case-sensitively unique.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr is case-sensitively unique
-within the scope of :other.
+Expected Example to validate that :attr is case-sensitively unique
+within the scope of :other, but this could not be proved.
   Expected the validation to be scoped to :other, but it was not scoped
   to anything.
         MESSAGE
@@ -552,7 +557,8 @@ within the scope of :other.
           end
 
           message = <<-MESSAGE
-Example did not properly validate that :attr is case-sensitively unique.
+Expected Example to validate that :attr is case-sensitively unique, but
+this could not be proved.
   After taking the given Example, whose :attr is ‹"some value"›, and
   saving it as the existing record, then making a new Example and
   setting its :attr to ‹"some value"› as well, the matcher expected the
@@ -582,8 +588,9 @@ Example did not properly validate that :attr is case-sensitively unique.
             end
 
             message = <<-MESSAGE
-Example did not properly validate that :attr is case-sensitively unique,
-producing a custom validation error on failure.
+Expected Example to validate that :attr is case-sensitively unique,
+producing a custom validation error on failure, but this could not be
+proved.
   After taking the given Example, whose :attr is ‹"some value"›, and
   saving it as the existing record, then making a new Example and
   setting its :attr to ‹"some value"› as well, the matcher expected the
@@ -625,8 +632,9 @@ producing a custom validation error on failure.
             end
 
             message = <<-MESSAGE
-Example did not properly validate that :attr is case-sensitively unique,
-producing a custom validation error on failure.
+Expected Example to validate that :attr is case-sensitively unique,
+producing a custom validation error on failure, but this could not be
+proved.
   After taking the given Example, whose :attr is ‹"some value"›, and
   saving it as the existing record, then making a new Example and
   setting its :attr to ‹"some value"› as well, the matcher expected the
@@ -663,7 +671,8 @@ producing a custom validation error on failure.
           default_value: 'some value',
           changing_values_with: :next_value,
           expected_message: <<-MESSAGE.strip
-Example did not properly validate that :attr is case-sensitively unique.
+Expected Example to validate that :attr is case-sensitively unique, but
+this could not be proved.
   After taking the given Example, whose :attr is ‹"some valuf"›, and
   saving it as the existing record, then making a new Example and
   setting its :attr to ‹"some valuf"› (read back as ‹"some valug"›) as
@@ -683,6 +692,28 @@ Example did not properly validate that :attr is case-sensitively unique.
         }
       }
     )
+
+    it 'fails when used in the negative' do
+      assertion = lambda do
+        record = build_record_validating_uniqueness(
+          attribute_type: :string,
+          attribute_options: { limit: 1 }
+        )
+
+        expect(record).not_to validate_uniqueness
+      end
+
+      message = <<-MESSAGE
+Expected Example not to validate that :attr is case-sensitively unique,
+but this could not be proved.
+  After taking the given Example, setting its :attr to ‹"x"›, and saving
+  it as the existing record, then making a new Example and setting its
+  :attr to a different value, ‹"X"›, the matcher expected the new
+  Example to be invalid, but it was valid instead.
+      MESSAGE
+
+      expect(&assertion).to fail_with_message(message)
+    end
   end
 
   context 'when the model has a scoped uniqueness validation' do
@@ -755,8 +786,9 @@ Example did not properly validate that :attr is case-sensitively unique.
             end
 
             message = <<-MESSAGE
-Example did not properly validate that :attr is case-sensitively unique
-within the scope of :scope1, :scope2, and :other.
+Expected Example to validate that :attr is case-sensitively unique
+within the scope of :scope1, :scope2, and :other, but this could not be
+proved.
   Expected the validation to be scoped to :scope1, :scope2, and :other,
   but it was scoped to :scope1 and :scope2 instead.
             MESSAGE
@@ -777,8 +809,8 @@ within the scope of :scope1, :scope2, and :other.
             end
 
             message = <<-MESSAGE
-Example did not properly validate that :attr is case-sensitively unique
-within the scope of :scope1.
+Expected Example to validate that :attr is case-sensitively unique
+within the scope of :scope1, but this could not be proved.
   Expected the validation to be scoped to :scope1, but it was scoped to
   :scope1 and :scope2 instead.
             MESSAGE
@@ -911,8 +943,8 @@ within the scope of :scope1.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr is case-insensitively
-unique.
+Expected Example to validate that :attr is case-insensitively unique,
+but this could not be proved.
   After taking the given Example, whose :attr is ‹"some value"›, and
   saving it as the existing record, then making a new Example and
   setting its :attr to a different value, ‹"SOME VALUE"›, the matcher
@@ -937,7 +969,8 @@ unique.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr is case-sensitively unique.
+Expected Example to validate that :attr is case-sensitively unique, but
+this could not be proved.
   After taking the given Example, setting its :attr to ‹"dummy value"›,
   and saving it as the existing record, then making a new Example and
   setting its :attr to a different value, ‹"DUMMY VALUE"›, the matcher
@@ -970,8 +1003,8 @@ Example did not properly validate that :attr is case-sensitively unique.
             default_value: 'some value',
             changing_values_with: :next_value,
             expected_message: <<-MESSAGE.strip
-Example did not properly validate that :attr is case-insensitively
-unique.
+Expected Example to validate that :attr is case-insensitively unique,
+but this could not be proved.
   After taking the given Example, whose :attr is ‹"some valuf"›, and
   saving it as the existing record, then making a new Example and
   setting its :attr to ‹"some valuf"› (read back as ‹"some valug"›) as
@@ -1051,8 +1084,8 @@ unique.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr is case-sensitively unique,
-but only if it is not nil.
+Expected Example to validate that :attr is case-sensitively unique as
+long as it is not nil, but this could not be proved.
   After taking the given Example, setting its :attr to ‹nil›, and saving
   it as the existing record, then making a new Example and setting its
   :attr to ‹nil› as well, the matcher expected the new Example to be
@@ -1075,8 +1108,8 @@ but only if it is not nil.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr is case-sensitively unique,
-but only if it is not nil.
+Expected Example to validate that :attr is case-sensitively unique as
+long as it is not nil, but this could not be proved.
   Given an existing Example, after setting its :attr to ‹nil›, then
   making a new Example and setting its :attr to ‹nil› as well, the
   matcher expected the new Example to be valid, but it was invalid
@@ -1180,8 +1213,8 @@ but only if it is not nil.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr is case-sensitively unique,
-but only if it is not blank.
+Expected Example to validate that :attr is case-sensitively unique as
+long as it is not blank, but this could not be proved.
   After taking the given Example, setting its :attr to ‹""›, and saving
   it as the existing record, then making a new Example and setting its
   :attr to ‹""› as well, the matcher expected the new Example to be
@@ -1204,8 +1237,8 @@ but only if it is not blank.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr is case-sensitively unique,
-but only if it is not blank.
+Expected Example to validate that :attr is case-sensitively unique as
+long as it is not blank, but this could not be proved.
   Given an existing Example, after setting its :attr to ‹""›, then
   making a new Example and setting its :attr to ‹""› as well, the
   matcher expected the new Example to be valid, but it was invalid
@@ -1230,8 +1263,8 @@ but only if it is not blank.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr is case-sensitively unique,
-but only if it is not blank.
+Expected Example to validate that :attr is case-sensitively unique as
+long as it is not blank, but this could not be proved.
   After taking the given Example, setting its :attr to ‹""›, and saving
   it as the existing record, then making a new Example and setting its
   :attr to ‹""› as well, the matcher expected the new Example to be
@@ -1256,8 +1289,8 @@ but only if it is not blank.
         end
 
         message = <<-MESSAGE
-Example did not properly validate that :attr is case-sensitively unique,
-but only if it is not blank.
+Expected Example to validate that :attr is case-sensitively unique as
+long as it is not blank, but this could not be proved.
   Given an existing Example, after setting its :attr to ‹""›, then
   making a new Example and setting its :attr to ‹""› as well, the
   matcher expected the new Example to be valid, but it was invalid
@@ -1336,7 +1369,8 @@ but only if it is not blank.
       end
 
       message = <<-MESSAGE.strip
-Example did not properly validate that :attr is case-sensitively unique.
+Expected Example to validate that :attr is case-sensitively unique, but
+this could not be proved.
   :attr does not seem to be an attribute on Example.
       MESSAGE
 
@@ -1363,7 +1397,8 @@ Example did not properly validate that :attr is case-sensitively unique.
           end
 
           message = <<-MESSAGE.strip
-Example did not properly validate that :name is case-sensitively unique.
+Expected Example to validate that :name is case-sensitively unique, but
+this could not be proved.
   After taking the given Example, setting its :name to ‹"dummy value"›
   (read back as ‹"DUMMY VALUE"›), and saving it as the existing record,
   then making a new Example and setting its :name to ‹"dummy value"›

--- a/spec/unit_spec_helper.rb
+++ b/spec/unit_spec_helper.rb
@@ -1,6 +1,7 @@
 require_relative 'support/unit/load_environment'
 
 require 'rspec/rails'
+require 'rspec/matchers/fail_matchers'
 require 'shoulda-matchers'
 
 require 'spec_helper'
@@ -10,6 +11,8 @@ Dir[ File.join(File.expand_path('../support/unit/**/*.rb', __FILE__)) ].sort.eac
 end
 
 RSpec.configure do |config|
+  config.include RSpec::Matchers::FailMatchers
+
   UnitTests::ActionPackVersions.configure_example_group(config)
   UnitTests::ActiveModelHelpers.configure_example_group(config)
   UnitTests::ActiveModelVersions.configure_example_group(config)

--- a/zeus.json
+++ b/zeus.json
@@ -1,5 +1,5 @@
 {
-  "command": "ruby -rubygems -r./custom_plan -eZeus.go",
+  "command": "ruby -r rubygems -r ./custom_plan -e Zeus.go",
 
   "plan": {
     "boot": {


### PR DESCRIPTION
NOTE: This branch incorporates changes from #1133, #1134, and #1135 so that development is easier and all tests pass. When those PRs are merged I'll rebase the branch.

@guialbuk I know this diff is large. I don't expect you to read the whole thing, but I really just wanted to make sure you were aware of the fix here and whether my explanation made sense.

---

When using a validation matcher in the negative, i.e.:

    should_not validate_*(...)

as opposed to:

    should validate_*(...)

...it's common to receive the following error:

    undefined method `attribute_setter' for nil:NilClass

This happens particularly when using a matcher that makes use of
AllowValueMatcher or DisallowValueMatcher internally (which all of the
validation matchers do).

Whenever you make an assertion by using a matcher in the negative as
opposed to the positive, RSpec still calls the `matches?` method for
that matcher; however, the assertion will pass if that returns *false*
as opposed to true. In other words, it just inverts the result.

However, whenever we are using AllowValueMatcher or
DisallowValueMatcher, it doesn't really work to invert the result. like
this. This is because AllowValueMatcher and DisallowValueMatcher,
despite their name, aren't truly opposites of each other.

AllowValueMatcher performs these steps:

1. Set the attribute on the record to some value
2. Run validations on the record
3. Ask whether validations pass or fail
4. If validations fail, store the value that caused the failure along
   with the validation errors and return false
5. Otherwise, return true

However, DisallowValueMatcher performs these steps:

1. Set the attribute on the record to some value
2. Run validations on the record
3. Ask whether validations pass or fail
4. If validations *pass*, store the value that caused the failure along
   with some metadata and return false
5. Otherwise, return true

This difference in logic is achieved by having AllowValueMatcher
implement `does_not_match?` and then having DisallowValueMatcher use
this for its positive case and use `matches?` for its negative case.
It's easy to see because of this that `does_not_match?` is not the same
as `!matches?` and vice versa.

So a matcher that makes use of these submatchers internally needs to use
their opposite versions whenever that matcher is used in the negative
case. In other words, all of the matchers need a `does_not_match?` which
is like `matches?`, except that all of the logic is inverted, and in all
the cases in which AllowValueMatcher is used, DisallowValueMatcher needs
to be used.

Doing this ensures that when `failure_message` is called on
AllowValueMatcher or DisallowValueMatcher, step 4 in the list of steps
above stores a proper value that can then be referenced in the failure
message for the validation matcher itself.

---

References #904
Fixes #963
Fixes #931
Fixes #1075