### PR TITLE
Fix default behavior of belong_to under Rails 4.2

### DIFF
--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -968,12 +968,8 @@ module Shoulda
           @submatchers = []
           @missing = ''
 
-          if macro == :belongs_to
-            if RailsShim.active_record_gte_5? && belongs_to_required_by_default?
-              required
-            else
-              optional
-            end
+          if macro == :belongs_to && RailsShim.active_record_gte_5?
+            required(belongs_to_required_by_default?)
           end
         end
 

--- a/spec/support/unit/helpers/active_record_versions.rb
+++ b/spec/support/unit/helpers/active_record_versions.rb
@@ -37,7 +37,7 @@ module UnitTests
       active_record_version < 5
     end
 
-    def active_record_supports_required_for_associations?
+    def active_record_supports_optional_for_associations?
       active_record_version >= 5
     end
   end


### PR DESCRIPTION
Rails 5 introduced a change where `belongs_to` would default to adding a
presence validation along with the association. However, it also
introduced a configuration option, `belongs_to_required_by_default`, to
emulate the old behavior prior to Rails 5. For Rails 4.2 projects as
well as Rails 5 which were migrated from 4, this setting is false, so
that existing apps do not break.

To mimic this, a change was made to the `belong_to` matcher to check for
the presence of the presence validator if
`belongs_to_required_by_default` is true and check for the absence of
the presence validator if it is false. However, this last bit of the
logic actually causes problems. Take this case, for example:

    ActiveRecord::Base.belongs_to_required_by_default = false

    class Post < ActiveRecord::Base
      belongs_to :user
      validates :user, presence: true
    end

    RSpec.describe Post, type: :model do
      it { is_expected.to belong_to(:user) }
    end

In this example, the developer has chosen to place a presence validation
on the association manually. `belong_to` doesn't know this, however, and
will check to make sure that `user` can be nil, which of course it
can't. Therefore, this test will fail. In addition, the failure message
that `belong_to` generates is confusing:

    Expected Post to have a belongs_to association called user (the
    association should have been defined with `optional: true`, but was
    not)

The reason why the test fails is that when
`belongs_to_required_by_default` is false, belong_to` will place an implicit
`optional` qualifier on itself. In other words, these two tests are
equivalent:

    it { is_expected.to belong_to(:user) }
    it { is_expected.to belong_to(:user).optional }

However, this is not only wrong, but the `belongs_to` macro in Rails 4.2
doesn't have an `optional` option (it has `required` instead), so the
failure message that `belong_to` generates is confusing.

This commit fixes this by ~modifying `belong_to` so that it uses
`required(false)` implicitly instead of `optional` (they both have
slightly different semantics).~ modifying `belong_to` so that
under Rails 4.2, the matcher will have not have any qualifiers on
it by default.

---

Fixes #1108.