### PR TITLE
Fix UI issues with generated docs

### DIFF
--- a/doc_config/yard/templates/default/fulldoc/html/css/global.css
+++ b/doc_config/yard/templates/default/fulldoc/html/css/global.css
@@ -60,3 +60,7 @@ blockquote p {
   font-weight: inherit;
   line-height: inherit;
 }
+
+ul ul, ol ol, ul ol, ol ul {
+  margin-bottom: 1.25em;
+}

--- a/doc_config/yard/templates/default/fulldoc/html/full_list.erb
+++ b/doc_config/yard/templates/default/fulldoc/html/full_list.erb
@@ -15,12 +15,6 @@
     <base id="base_target" target="_parent" />
   </head>
   <body>
-    <script type="text/javascript" charset="utf-8">
-      if (window.top.frames.main) {
-        document.getElementById('base_target').target = 'main';
-        document.body.className = 'frames';
-      }
-    </script>
     <div id="content">
       <h1 id="full_list_header"><%= @list_title %></h1>
 

--- a/doc_config/yard/templates/default/fulldoc/html/js/app.js
+++ b/doc_config/yard/templates/default/fulldoc/html/js/app.js
@@ -119,22 +119,6 @@ function linkSummaries() {
   });
 }
 
-function framesInit() {
-  if (hasFrames) {
-    document.body.className = 'frames';
-    $('#menu .noframes a').attr('href', document.location);
-    try {
-      window.top.document.title = $('html head title').text();
-    } catch(error) {
-      // some browsers will not allow this when serving from file://
-      // but we don't want to stop the world.
-    }
-  }
-  else {
-    $('#menu .noframes a').text('frames').attr('href', framesUrl);
-  }
-}
-
 function keyboardShortcuts() {
   if (window.top.frames.main) return;
 
@@ -284,7 +268,6 @@ function updateStickyHeaders() {
 }
 
 $(makeHeadersSticky);
-$(framesInit);
 $(createSourceLinks);
 $(createDefineLinks);
 $(createFullTreeLinks);

--- a/doc_config/yard/templates/default/fulldoc/html/setup.rb
+++ b/doc_config/yard/templates/default/fulldoc/html/setup.rb
@@ -6,3 +6,30 @@ def javascripts
   javascripts = super
   javascripts.insert 1, 'js/jquery.stickyheaders.js'
 end
+
+def class_list(root = Registry.root, tree = TreeContext.new)
+  out = String.new("")
+  children = run_verifier(root.children)
+  if root == Registry.root
+    children += @items.select {|o| o.namespace.is_a?(CodeObjects::Proxy) }
+  end
+  children.compact.sort_by(&:path).each do |child|
+    next unless child.is_a?(CodeObjects::NamespaceObject)
+    name = child.namespace.is_a?(CodeObjects::Proxy) ? child.path : child.name
+    has_children = run_verifier(child.children).any? {|o| o.is_a?(CodeObjects::NamespaceObject) }
+    out << "<li id='object_#{child.path}' class='#{tree.classes.join(' ')}'>"
+    out << "<div class='item'>"
+    out << "<a class='toggle'></a> " if has_children
+    out << linkify(child, name)
+    out << " &lt; #{child.superclass.name}" if child.is_a?(CodeObjects::ClassObject) && child.superclass
+    out << "<small class='search_info'>"
+    out << child.namespace.title
+    out << "</small>"
+    out << "</div>"
+    tree.nest do
+      out << "<ul>#{class_list(child, tree)}</ul>" if has_children
+    end
+    out << "</li>"
+  end
+  out
+end


### PR DESCRIPTION
The current docsite isn't as usable as it should be: clicking on the nav
links should show a popover when in fact it goes to another page. This
is happening because some of the JavaScript is failing on the docsite
due to some old-school code (we're talking early 2000's DHTML stuff)
which was leftover from YARD's default layout which interacts with
frames. We don't use frames on the docsite so there is no need to have
this code.

Also this commit tweaks the CSS for the class list to remove extra
indentation from the bullet points.