### PR TITLE
Set messages to :inclusion only for range and not array

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
@@ -308,8 +308,6 @@ EOT
           @range = range
           @minimum = range.first
           @maximum = range.max
-          @low_message ||= :inclusion
-          @high_message ||= :inclusion
           self
         end
 

--- a/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
@@ -295,8 +295,8 @@ EOT
           @range = nil
           @minimum = nil
           @maximum = nil
-          @low_message = :inclusion
-          @high_message = :inclusion
+          @low_message = nil
+          @high_message = nil
         end
 
         def in_array(array)
@@ -308,6 +308,8 @@ EOT
           @range = range
           @minimum = range.first
           @maximum = range.max
+          @low_message ||= :inclusion
+          @high_message ||= :inclusion
           self
         end
 

--- a/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb
@@ -432,7 +432,10 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
 
     context 'given nil' do
       it 'is as if with_message had never been called' do
-        builder = build_object_allowing(valid_values)
+        builder = build_object_allowing(
+          valid_values,
+          validation_options: { message: 'this message should not matter' }
+        )
 
         expect_to_match_on_values(builder, valid_values) do |matcher|
           matcher.with_message(nil)


### PR DESCRIPTION
Fixes #1146 

The problem is, I suspect, that before 507dc57, `@low_message ||= :inclusion` and `@high_message ||= :inclusion` are set only for range and not for array. However, on 507dc57, both `@low_message` and `@high_message` are set to `:inclusion` regardless of whether it's array or range. This PR should restore the old behaviour.

Confirmed working by @matthewrudy