### PR TITLE
Introduce support for the Attributes API typing

### DIFF
--- a/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
+++ b/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
@@ -937,7 +937,9 @@ module Shoulda
         end
 
         def attribute_type_for(scope)
-          model.attribute_types[scope.to_s] if model.respond_to?(:attribute_types)
+          if model.respond_to?(:attribute_types)
+            model.attribute_types[scope.to_s]
+          end
         end
 
         def column_limit_for(attribute)

--- a/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
+++ b/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
@@ -839,7 +839,7 @@ module Shoulda
         def uuid?(scope)
           [
             column_for(scope),
-            attribute_type_for(scope)
+            attribute_type_for(scope),
           ].compact.map(&:type).include? :uuid
         end
 
@@ -937,7 +937,7 @@ module Shoulda
         end
 
         def attribute_type_for(scope)
-          return model.attribute_types[scope.to_s] if model.respond_to?(:attribute_types)
+          model.attribute_types[scope.to_s] if model.respond_to?(:attribute_types)
         end
 
         def column_limit_for(attribute)

--- a/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
+++ b/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
@@ -818,9 +818,7 @@ module Shoulda
         end
 
         def next_scalar_value_for(scope, previous_value)
-          column = column_for(scope)
-
-          if column.type == :uuid
+          if uuid?(scope)
             SecureRandom.uuid
           elsif defined_as_enum?(scope)
             available_values = available_enum_values_for(scope, previous_value)
@@ -836,6 +834,13 @@ module Shoulda
           else
             previous_value.to_s.next
           end
+        end
+
+        def uuid?(scope)
+          [
+            column_for(scope),
+            attribute_type_for(scope)
+          ].compact.map(&:type).include? :uuid
         end
 
         def all_scopes_are_booleans?
@@ -929,6 +934,10 @@ module Shoulda
 
         def column_for(scope)
           model.columns_hash[scope.to_s]
+        end
+
+        def attribute_type_for(scope)
+          return model.attribute_types[scope.to_s] if model.respond_to?(:attribute_types)
         end
 
         def column_limit_for(attribute)

--- a/spec/support/unit/helpers/active_model_versions.rb
+++ b/spec/support/unit/helpers/active_model_versions.rb
@@ -28,5 +28,9 @@ module UnitTests
     def active_model_supports_strict?
       active_model_version >= 3.2
     end
+
+    def active_model_supports_attributes_api?
+      ::ActiveModel::VERSION::MAJOR >= 5
+    end
   end
 end

--- a/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
@@ -1481,7 +1481,7 @@ this could not be proved.
         scopes = {
           scopes: [
             {
-              name:        :foo,
+              name:        :uuid,
               column_type: :string,
               value_type:  :string,
               options:     {
@@ -1502,18 +1502,15 @@ this could not be proved.
           end
         end
 
-        ActiveRecord::Type.register(:uuid, ActiveRecord::Type::Uuid, override: false)
+        ActiveRecord::Type.register(:uuid,
+                                    ActiveRecord::Type::Uuid,
+                                    override: false)
+        model.attribute(:uuid, :uuid)
 
-        model.attribute(:foo, :uuid)
+        expect(SecureRandom).to receive(:uuid).and_call_original
+        next_scalar_value_for(:uuid, "", model.new)
 
-        value1 = SecureRandom.uuid
-        create_record_from(model, foo: value1)
-        value2 = next_scalar_value_for(:foo, value1, model.new)
-        record = build_record_from(model, foo: value2)
-
-        expect(SecureRandom).to receive(:uuid)
-
-        expect(record).to validate_uniqueness.scoped_to(:foo)
+        expect(model.new).to validate_uniqueness.scoped_to(:uuid).ignoring_case_sensitivity
       end
     end
 

--- a/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
@@ -1492,19 +1492,17 @@ this could not be proved.
         }
         model = define_model_validating_uniqueness(scopes)
 
-        unless database_supports_uuid_columns?
-          module ActiveRecord
-            module Type
-              class Uuid < ActiveRecord::Type::String
-                def type
-                  :uuid
-                end
+        module ActiveRecord
+          module Type
+            class Uuid < ActiveRecord::Type::String
+              def type
+                :uuid
               end
             end
           end
-
-          ActiveRecord::Type.register(:uuid, ActiveRecord::Type::Uuid)
         end
+
+        ActiveRecord::Type.register(:uuid, ActiveRecord::Type::Uuid, override: false)
 
         model.attribute(:foo, :uuid)
 

--- a/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
@@ -10,17 +10,17 @@ describe Shoulda::Matchers::ActiveRecord::ValidateUniquenessOfMatcher, type: :mo
       context 'when the subject is a new record' do
         it 'accepts' do
           record = build_record_validating_uniqueness(
-              scopes: [
-                          build_attribute(name: :scope1),
-                          { name: :scope2 }
-                      ]
+            scopes: [
+              build_attribute(name: :scope1),
+              { name: :scope2 }
+            ]
           )
           expect(record).to validate_uniqueness.scoped_to(:scope1, :scope2)
         end
 
         it 'still accepts if the scope is unset beforehand' do
           record = build_record_validating_uniqueness(
-              scopes: [ build_attribute(name: :scope, value: nil) ]
+            scopes: [ build_attribute(name: :scope, value: nil) ]
           )
 
           expect(record).to validate_uniqueness.scoped_to(:scope)
@@ -31,9 +31,9 @@ describe Shoulda::Matchers::ActiveRecord::ValidateUniquenessOfMatcher, type: :mo
         it 'accepts' do
           record = create_record_validating_uniqueness(
               scopes: [
-                          build_attribute(name: :scope1),
-                          { name: :scope2 }
-                      ]
+                build_attribute(name: :scope1),
+                { name: :scope2 }
+              ]
           )
 
           expect(record).to validate_uniqueness.scoped_to(:scope1, :scope2)
@@ -41,7 +41,7 @@ describe Shoulda::Matchers::ActiveRecord::ValidateUniquenessOfMatcher, type: :mo
 
         it 'still accepts if the scope is unset beforehand' do
           record = create_record_validating_uniqueness(
-              scopes: [ build_attribute(name: :scope, value: nil) ]
+            scopes: [ build_attribute(name: :scope, value: nil) ]
           )
 
           expect(record).to validate_uniqueness.scoped_to(:scope)
@@ -1479,12 +1479,12 @@ this could not be proved.
     context 'Rails 5 attributes API' do
       it 'builds uuid for attributes API type :uuid' do
         model = define_model_validating_uniqueness(scopes: [
-                                                             { name:        :foo,
-                                                               column_type: :string,
-                                                               value_type:  :string,
-                                                               options:     { array: false }
-                                                             }
-                                                           ])
+          { name:        :foo,
+            column_type: :string,
+            value_type:  :string,
+            options:     { array: false }
+          }
+        ])
         module ActiveRecord
           module Type
             class Uuid < ActiveRecord::Type::String

--- a/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
@@ -1507,10 +1507,10 @@ this could not be proved.
           override: false,)
         model.attribute(:uuid, :uuid)
 
+        record = model.new(uuid: next_scalar_value_for(:uuid, '', model.new))
         expect(SecureRandom).to receive(:uuid).and_call_original
-        next_scalar_value_for(:uuid, '', model.new)
 
-        expect(model.new).to validate_uniqueness.
+        expect(record).to validate_uniqueness.
           scoped_to(:uuid).
           ignoring_case_sensitivity
       end

--- a/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
@@ -1503,14 +1503,16 @@ this could not be proved.
         end
 
         ActiveRecord::Type.register(:uuid,
-                                    ActiveRecord::Type::Uuid,
-                                    override: false)
+          ActiveRecord::Type::Uuid,
+          override: false,)
         model.attribute(:uuid, :uuid)
 
         expect(SecureRandom).to receive(:uuid).and_call_original
-        next_scalar_value_for(:uuid, "", model.new)
+        next_scalar_value_for(:uuid, '', model.new)
 
-        expect(model.new).to validate_uniqueness.scoped_to(:uuid).ignoring_case_sensitivity
+        expect(model.new).to validate_uniqueness.
+          scoped_to(:uuid).
+          ignoring_case_sensitivity
       end
     end
 


### PR DESCRIPTION
The column type itself is only a uuid in certain database
implementations like PostgreSQL

MySQL uuids are supportable using the Rails 5 Attributes API and
registering a new :uuid type. The column type is not a :uuid, but the
registered attribute type is a :uuid

e.g.
```
module ActiveRecord
  module Type
    class Uuid < ActiveRecord::Type::Binary
      def type
        :uuid
      end

      ...
    end
  end
end

ActiveRecord::Type.register(:uuid, ActiveRecord::Type::Uuid, adapter: :mysql2)

class Model < ApplicationRecord
  attribute :id, :uuid
end

Model.attribute_types[:id].type # => :uuid
```

Example gem making using of the Attributes API for uuids in MySQL: https://github.com/mathieujobin/activerecord-mysql-uuid-column

This is related to a closed issue "Support UUID columns that end in 'f'": https://github.com/thoughtbot/shoulda-matchers/commit/81034eaf3d0f19f0863eccdc0d10856f6a4610c1 . This fix did not identify the Rails 5 attributes API types however.