### PR TITLE
Make have_db_index_matcher respect the connection of individual model

### DIFF
--- a/lib/shoulda/matchers/active_record/have_db_index_matcher.rb
+++ b/lib/shoulda/matchers/active_record/have_db_index_matcher.rb
@@ -136,7 +136,7 @@ module Shoulda
         end
 
         def indexes
-          ::ActiveRecord::Base.connection.indexes(table_name)
+          model_class.connection.indexes(table_name)
         end
 
         def expectation


### PR DESCRIPTION
Hi Sir, 

Problem
-
I established the connections of a group of models to another database.
However, I ran into problem when I try to use `have_db_index_matcher` on those models.

`ActiveRecord::StatementInvalid, Table doesn't exist`

Solution
-
The `have_db_index_matcher` should respect the connection of individual model instead of using the connection of `ActiveRecord::Base` directly.