### PR TITLE
ValidateInclusionOfMatcher#allow_nil should return `self`

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
@@ -322,6 +322,7 @@ EOT
 
         def allow_nil
           @options[:allow_nil] = true
+          self
         end
 
         def expects_to_allow_nil?


### PR DESCRIPTION
It seems that this method was returning `self` explicitly until [this change](https://github.com/thoughtbot/shoulda-matchers/commit/97e25692537777cf33ea35ad1d4bd18b7de9a777#diff-3706e19f08c07fb311fbf18e8fce5629), but overwriting the method seems to resolve the failure I've been getting.