### PR TITLE
Remove Ruby 2.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ rvm:
   - 2.5.1
   - 2.4.4
   - 2.3.7
-  - 2.2.8
 
 gemfile:
   - gemfiles/4.2.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: ruby
 sudo: false
 cache: bundler
 script: "bundle exec rake"
+# Source: <https://docs.travis-ci.com/user/languages/ruby/#bundler-20>
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
 install: "bundle install --jobs=3 --retry=3"
 
 env:

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,13 +4,13 @@ This release mainly brings the gem up to date with modern versions of Ruby and
 Rails and drops support for older, unsupported versions. The compatibility list
 is now:
 
-* **Ruby:** 2.5.1, 2.4.4, 2.3.7, 2.2.8
+* **Ruby:** 2.5.1, 2.4.4, 2.3.7
 * **Rails:** 5.2.1, 5.1.6, 5.0.6, 4.2.9
 
 ### Backward-incompatible changes
 
-* Drop support for Rails 4.0 and 4.1 as well as Ruby 2.0 and 2.1, since they've
-  been end-of-lifed. The gem now supports Ruby 2.2+ and Rails 4.2+.
+* Drop support for Rails 4.0 and 4.1 as well as Ruby 2.0, 2.1, and 2.2, since
+  they've been end-of-lifed. The gem now supports Ruby 2.3+ and Rails 4.2+.
 
 * `use_before_filter`, `use_after_filter`, and `use_around_filter` are no longer
   usable when using shoulda-matchers under Rails 5.x, as the corresponding

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ complex, and error-prone.
 ## Compatibility
 
 Shoulda Matchers 4 is tested and supported against Rails 5.x, Rails 4.2, RSpec
-3.x, Minitest 5, Minitest 4, and Ruby 2.2+.
+3.x, Minitest 5, Minitest 4, and Ruby 2.3+.
 
-For Rails 4.0/4.1 and Ruby 2.0/2.1 compatibility, please use shoulda-matchers
+For Rails 4.0/4.1 and Ruby 2.0/2.1/2.2 compatibility, please use shoulda-matchers
 [3.1.2](https://github.com/thoughtbot/shoulda-matchers/releases/tag/v3.1.2).
 
 ## Getting started

--- a/bin/setup
+++ b/bin/setup
@@ -164,7 +164,7 @@ install-dependencies() {
   fi
 
   banner 'Installing Ruby dependencies'
-  gem install bundler --conservative
+  gem install bundler -v '~> 1.0' --conservative
   bundle check || bundle install
   bundle exec appraisal install
 


### PR DESCRIPTION
Official support for Ruby 2.2 ended in June 2018, so we are dropping support for it as well.

Ref: https://www.ruby-lang.org/en/news/2018/06/20/support-of-ruby-2-2-has-ended/