### PR TITLE
Fix for validate_presence_of for Rails6 secure_password problem

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
@@ -157,7 +157,7 @@ module Shoulda
           ) &&
             @subject.class.ancestors.include?(
               ::ActiveModel::SecurePassword::InstanceMethodsOnActivation
-          ) &&
+            ) &&
             @attribute == :password
         end
 

--- a/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
@@ -121,7 +121,7 @@ module Shoulda
 
           possibly_ignore_interference_by_writer
 
-          if secure_password_being_validated?
+          if should_double_check_attribute?
             disallows_and_double_checks_value_of!(blank_value, @expected_message)
           else
             disallows_original_or_typecast_value?(blank_value, @expected_message)
@@ -133,7 +133,7 @@ module Shoulda
 
           possibly_ignore_interference_by_writer
 
-          if secure_password_being_validated?
+          if should_double_check_attribute?
             allows_and_double_checks_value_of!(blank_value, @expected_message)
           else
             allows_original_or_typecast_value?(blank_value, @expected_message)
@@ -146,24 +146,24 @@ module Shoulda
 
         private
 
-        def secure_password_being_validated?
-          rails_lt_6_secure_password_being_validated? ||
-            rails_6_secure_password_being_validated?
+        def should_double_check_attribute?
+          attribute_is_secure_password? ||
+            attribute_has_digest?
         end
 
-        def rails_lt_6_secure_password_being_validated?
+        def attribute_is_secure_password?
           defined?(::ActiveModel::SecurePassword::InstanceMethodsOnActivation) &&
             @subject.class.ancestors.include?(::ActiveModel::SecurePassword::InstanceMethodsOnActivation) &&
             @attribute == :password
         end
 
-        def rails_6_secure_password_being_validated?
+        def attribute_has_digest?
           !defined?(::ActiveModel::SecurePassword) &&
             @subject.respond_to?("#{@attribute}_digest")
         end
 
         def possibly_ignore_interference_by_writer
-          if secure_password_being_validated?
+          if should_double_check_attribute?
             ignore_interference_by_writer.default_to(when: :blank?)
           end
         end

--- a/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
@@ -152,8 +152,12 @@ module Shoulda
         end
 
         def attribute_is_secure_password?
-          defined?(::ActiveModel::SecurePassword::InstanceMethodsOnActivation) &&
-            @subject.class.ancestors.include?(::ActiveModel::SecurePassword::InstanceMethodsOnActivation) &&
+          defined?(
+            ::ActiveModel::SecurePassword::InstanceMethodsOnActivation
+          ) &&
+            @subject.class.ancestors.include?(
+              ::ActiveModel::SecurePassword::InstanceMethodsOnActivation
+          ) &&
             @attribute == :password
         end
 

--- a/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
@@ -147,9 +147,19 @@ module Shoulda
         private
 
         def secure_password_being_validated?
-          defined?(::ActiveModel::SecurePassword) &&
+          rails_lt_6_secure_password_being_validated? ||
+            rails_6_secure_password_being_validated?
+        end
+
+        def rails_lt_6_secure_password_being_validated?
+          defined?(::ActiveModel::SecurePassword::InstanceMethodsOnActivation) &&
             @subject.class.ancestors.include?(::ActiveModel::SecurePassword::InstanceMethodsOnActivation) &&
             @attribute == :password
+        end
+
+        def rails_6_secure_password_being_validated?
+          !defined?(::ActiveModel::SecurePassword) &&
+            @subject.respond_to?("#{@attribute}_digest")
         end
 
         def possibly_ignore_interference_by_writer

--- a/spec/support/unit/helpers/rails_versions.rb
+++ b/spec/support/unit/helpers/rails_versions.rb
@@ -38,13 +38,5 @@ module UnitTests
     def rails_5_x?
       rails_version =~ '~> 5.0'
     end
-
-    def rails_lt_6?
-      rails_version < 6
-    end
-
-    def rails_6_x?
-      rails_version =~ '~> 6.0'
-    end
   end
 end

--- a/spec/support/unit/helpers/rails_versions.rb
+++ b/spec/support/unit/helpers/rails_versions.rb
@@ -38,5 +38,13 @@ module UnitTests
     def rails_5_x?
       rails_version =~ '~> 5.0'
     end
+
+    def rails_lt_6?
+      rails_version < 6
+    end
+
+    def rails_6_x?
+      rails_version =~ '~> 6.0'
+    end
   end
 end

--- a/spec/unit/shoulda/matchers/active_model/validate_presence_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_presence_of_matcher_spec.rb
@@ -327,7 +327,7 @@ validation exception on failure, but this could not be proved.
     end
   end
 
-  if rails_4_x?
+  if rails_4_x? || rails_5_x?
     context 'against a pre-set password in a model that has_secure_password' do
       it 'raises a CouldNotSetPasswordError' do
         user_class = define_model :user, password_digest: :string do


### PR DESCRIPTION
Addresses #1167 

Logic is that Rails 6 secure password attributes require an additional attribute called [attribute]_digest

So if we're in Rails 6 and the attribute has a matching [attribute]_digest attribute, it's a secure password