### PR TITLE
Address recent issues with `required` qualifier

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -91,6 +91,11 @@ is now:
   * *Original PR: [#956]*
   * *Original issues: [#870], [#861]*
 
+* Add `without_presence_validation` qualifier to `belong_to` to get around the
+  fact that `required` is assumed, above.
+
+  * *Original issues: [#1153], [#1154]*
+
 * Add `allow_nil` qualifier to `delegate_method`.
 
   * *Commit: [d49cfca]*
@@ -147,6 +152,8 @@ is now:
 [#956]: https://github.com/thoughtbot/shoulda-matchers/pulls/956
 [#870]: https://github.com/thoughtbot/shoulda-matchers/issues/870
 [#861]: https://github.com/thoughtbot/shoulda-matchers/issues/861
+[#1153]: https://github.com/thoughtbot/shoulda-matchers/issues/1153
+[#1154]: https://github.com/thoughtbot/shoulda-matchers/issues/1154
 [#954]: https://github.com/thoughtbot/shoulda-matchers/issues/954
 [#1074]: https://github.com/thoughtbot/shoulda-matchers/pulls/1074
 [#1075]: https://github.com/thoughtbot/shoulda-matchers/pulls/1075

--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -272,6 +272,35 @@ module Shoulda
       #       should belong_to(:organization).required
       #     end
       #
+      # #### without_presence_validation
+      #
+      # Use `without_presence_validation` with `belong_to` to prevent the
+      # matcher from checking whether the association disallows nil (Rails 5+
+      # only). This can be helpful if you have a custom hook that always sets
+      # the association to a meaningful value:
+      #
+      #     class Person < ActiveRecord::Base
+      #       belongs_to :organization
+      #
+      #       before_validation :autoassign_organization
+      #
+      #       private
+      #
+      #       def autoassign_organization
+      #         self.organization = Organization.create!
+      #       end
+      #     end
+      #
+      #     # RSpec
+      #     describe Person
+      #       it { should belong_to(:organization).without_presence_validation }
+      #     end
+      #
+      #     # Minitest (Shoulda)
+      #     class PersonTest < ActiveSupport::TestCase
+      #       should belong_to(:organization).without_presence_validation
+      #     end
+      #
       # ##### optional
       #
       # Use `optional` to assert that the association is allowed to be nil.
@@ -1089,6 +1118,11 @@ module Shoulda
 
         def join_table(join_table_name)
           @options[:join_table_name] = join_table_name
+          self
+        end
+
+        def without_validating_presence
+          remove_submatcher(AssociationMatchers::RequiredMatcher)
           self
         end
 

--- a/lib/shoulda/matchers/active_record/association_matchers/optional_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matchers/optional_matcher.rb
@@ -7,6 +7,7 @@ module Shoulda
           attr_reader :missing_option
 
           def initialize(attribute_name, optional)
+            @attribute_name = attribute_name
             @optional = optional
             @submatcher = ActiveModel::AllowValueMatcher.new(nil).
               for(attribute_name)
@@ -21,16 +22,38 @@ module Shoulda
             if submatcher_passes?(subject)
               true
             else
-              @missing_option =
-                'the association should have been defined ' +
-                "with `optional: #{optional}`, but was not"
+              @missing_option = 'and for the record '
+
+              missing_option <<
+                if optional
+                  'not to '
+                else
+                  'to '
+                end
+
+              missing_option << (
+                'fail validation if ' +
+                ":#{attribute_name} is unset; i.e., either the association " +
+                'should have been defined with `optional: ' +
+                "#{optional.inspect}`, or there "
+              )
+
+              missing_option <<
+                if optional
+                  'should not '
+                else
+                  'should '
+                end
+
+              missing_option << "be a presence validation on :#{attribute_name}"
+
               false
             end
           end
 
           private
 
-          attr_reader :optional, :submatcher
+          attr_reader :attribute_name, :optional, :submatcher
 
           def submatcher_passes?(subject)
             if optional

--- a/lib/shoulda/matchers/active_record/association_matchers/required_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matchers/required_matcher.rb
@@ -7,6 +7,7 @@ module Shoulda
           attr_reader :missing_option
 
           def initialize(attribute_name, required)
+            @attribute_name = attribute_name
             @required = required
             @submatcher = ActiveModel::DisallowValueMatcher.new(nil).
               for(attribute_name).
@@ -22,16 +23,38 @@ module Shoulda
             if submatcher_passes?(subject)
               true
             else
-              @missing_option =
-                'the association should have been defined ' +
-                "with `required: #{required}`, but was not"
+              @missing_option = 'and for the record '
+
+              missing_option <<
+                if required
+                  'to '
+                else
+                  'not to '
+                end
+
+              missing_option << (
+                'fail validation if ' +
+                ":#{attribute_name} is unset; i.e., either the association " +
+                'should have been defined with `required: ' +
+                "#{required.inspect}`, or there "
+              )
+
+              missing_option <<
+                if required
+                  'should '
+                else
+                  'should not '
+                end
+
+              missing_option << "be a presence validation on :#{attribute_name}"
+
               false
             end
           end
 
           private
 
-          attr_reader :required, :submatcher
+          attr_reader :attribute_name, :required, :submatcher
 
           def submatcher_passes?(subject)
             if required

--- a/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -300,8 +300,10 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
 
                 message = format_message(<<-MESSAGE, one_line: true)
                   Expected Child to have a belongs_to association called parent
-                  (the association should have been defined with `required:
-                  true`, but was not)
+                  (and for the record to fail validation if :parent is unset;
+                  i.e., either the association should have been defined with
+                  `required: true`, or there should be a presence validation on
+                  :parent)
                 MESSAGE
 
                 expect(&assertion).to fail_with_message(message)
@@ -317,8 +319,9 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
 
             message = format_message(<<-MESSAGE, one_line: true)
               Expected Child to have a belongs_to association called parent
-              (the association should have been defined with `required:
-              true`, but was not)
+              (and for the record to fail validation if :parent is unset; i.e.,
+              either the association should have been defined with `required:
+              true`, or there should be a presence validation on :parent)
             MESSAGE
 
             expect(&assertion).to fail_with_message(message)
@@ -338,8 +341,10 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
 
                 message = format_message(<<-MESSAGE, one_line: true)
                   Expected Child to have a belongs_to association called parent
-                  (the association should have been defined with `required:
-                  false`, but was not)
+                  (and for the record not to fail validation if :parent is
+                  unset; i.e., either the association should have been defined
+                  with `required: false`, or there should not be a presence
+                  validation on :parent)
                 MESSAGE
 
                 expect(&assertion).to fail_with_message(message)
@@ -372,9 +377,11 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
                 end
 
                 message = format_message(<<-MESSAGE, one_line: true)
-                  Expected Child to have a belongs_to association called parent (the
-                  association should have been defined with `optional: true`, but
-                  was not)
+                  Expected Child to have a belongs_to association called parent
+                  (and for the record not to fail validation if :parent is
+                  unset; i.e., either the association should have been defined
+                  with `optional: true`, or there should not be a presence
+                  validation on :parent)
                 MESSAGE
 
                 expect(&assertion).to fail_with_message(message)
@@ -519,9 +526,10 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
           end
 
           message = format_message(<<-MESSAGE, one_line: true)
-            Expected Child to have a belongs_to association called parent (the
-            association should have been defined with `required: false`, but
-            was not)
+            Expected Child to have a belongs_to association called parent (and
+            for the record not to fail validation if :parent is unset; i.e.,
+            either the association should have been defined with `required:
+            false`, or there should not be a presence validation on :parent)
           MESSAGE
 
           expect(&assertion).to fail_with_message(message)
@@ -536,9 +544,11 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
           end
 
           message = format_message(<<-MESSAGE, one_line: true)
-            Expected Child to have a belongs_to association called parent (the
-            association should have been defined with `optional: true`, but
-            was not)
+            Expected Child to have a belongs_to association called parent
+            (and for the record not to fail validation if :parent is unset;
+            i.e., either the association should have been defined with
+            `optional: true`, or there should not be a presence validation on
+            :parent)
           MESSAGE
 
           expect(&assertion).to fail_with_message(message)
@@ -562,9 +572,10 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
             end
 
             message = format_message(<<-MESSAGE, one_line: true)
-              Expected Child to have a belongs_to association called parent (the
-              association should have been defined with `required: true`, but
-              was not)
+              Expected Child to have a belongs_to association called parent
+              (and for the record to fail validation if :parent is unset; i.e.,
+              either the association should have been defined with `required:
+              true`, or there should be a presence validation on :parent)
             MESSAGE
 
             expect(&assertion).to fail_with_message(message)
@@ -593,9 +604,10 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
             end
 
             message = format_message(<<-MESSAGE, one_line: true)
-              Expected Child to have a belongs_to association called parent (the
-              association should have been defined with `required: true`, but
-              was not)
+              Expected Child to have a belongs_to association called parent
+              (and for the record to fail validation if :parent is unset; i.e.,
+              either the association should have been defined with `required:
+              true`, or there should be a presence validation on :parent)
             MESSAGE
 
             expect(&assertion).to fail_with_message(message)
@@ -1231,10 +1243,12 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
             to have_one(:detail).required
         end
 
-        message =
-          'Expected Person to have a has_one association called detail ' +
-          '(the association should have been defined with `required: true`, ' +
-          'but was not)'
+        message = format_message(<<-MESSAGE, one_line: true)
+          Expected Person to have a has_one association called detail (and for
+          the record to fail validation if :detail is unset; i.e., either the
+          association should have been defined with `required: true`, or there
+          should be a presence validation on :detail)
+        MESSAGE
 
         expect(&assertion).to fail_with_message(message)
       end

--- a/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -616,6 +616,105 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
       end
     end
 
+    if active_record_supports_optional_for_associations?
+      context 'when the model ensures the association is set' do
+        context 'and the matcher is not qualified with anything' do
+          context 'and the matcher is not qualified with without_validating_presence' do
+            it 'fails with an appropriate message' do
+              model = create_child_model_belonging_to_parent do
+                before_validation :ensure_parent_is_set
+
+                def ensure_parent_is_set
+                  self.parent = Parent.create
+                end
+              end
+
+              assertion = lambda do
+                configuring_default_belongs_to_requiredness(true) do
+                  expect(model.new).to belong_to(:parent)
+                end
+              end
+
+              message = format_message(<<-MESSAGE, one_line: true)
+                Expected Child to have a belongs_to association called parent (and
+                for the record to fail validation if :parent is unset; i.e.,
+                either the association should have been defined with `required:
+                true`, or there should be a presence validation on :parent)
+              MESSAGE
+
+              expect(&assertion).to fail_with_message(message)
+            end
+          end
+
+          context 'and the matcher is qualified with without_validating_presence' do
+            it 'passes' do
+              model = create_child_model_belonging_to_parent do
+                before_validation :ensure_parent_is_set
+
+                def ensure_parent_is_set
+                  self.parent = Parent.create
+                end
+              end
+
+              configuring_default_belongs_to_requiredness(true) do
+                expect(model.new).
+                  to belong_to(:parent).
+                  without_validating_presence
+              end
+            end
+          end
+        end
+
+        context 'and the matcher is qualified with required' do
+          context 'and the matcher is not qualified with without_validating_presence' do
+            it 'fails with an appropriate message' do
+              model = create_child_model_belonging_to_parent do
+                before_validation :ensure_parent_is_set
+
+                def ensure_parent_is_set
+                  self.parent = Parent.create
+                end
+              end
+
+              assertion = lambda do
+                configuring_default_belongs_to_requiredness(true) do
+                  expect(model.new).to belong_to(:parent).required
+                end
+              end
+
+              message = format_message(<<-MESSAGE, one_line: true)
+                Expected Child to have a belongs_to association called parent
+                (and for the record to fail validation if :parent is unset; i.e.,
+                either the association should have been defined with `required:
+                true`, or there should be a presence validation on :parent)
+              MESSAGE
+
+              expect(&assertion).to fail_with_message(message)
+            end
+          end
+
+          context 'and the matcher is also qualified with without_validating_presence' do
+            it 'passes' do
+              model = create_child_model_belonging_to_parent do
+                before_validation :ensure_parent_is_set
+
+                def ensure_parent_is_set
+                  self.parent = Parent.create
+                end
+              end
+
+              configuring_default_belongs_to_requiredness(true) do
+                expect(model.new).
+                  to belong_to(:parent).
+                  required.
+                  without_validating_presence
+              end
+            end
+          end
+        end
+      end
+    end
+
     def belonging_to_parent(options = {}, parent_options = {}, &block)
       child_model = create_child_model_belonging_to_parent(
         options,


### PR DESCRIPTION
This set of commits makes a couple of improvements to address the issues that people have been reporting with `belong_to` as it relates to its automatic application of `required` (#1153, #1154):

* There is now a new qualifier `without_presence_validation` which allows one to instruct `belong_to` to skip checking whether the presence validation is present or absent.
* The failure message that `belong_to` generates if the `required` or `optional` checks fail is a little more helpful now as it provides suggestions on how to prevent the failure.