### PR TITLE
Improve README on how to integrate with RSpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ to use model matchers in certain example groups, you'll need to manually include
 them. Here's a good way of doing that:
 
 ```ruby
+require 'shoulda-matchers'
+
 RSpec.configure do |config|
   config.include(Shoulda::Matchers::ActiveModel, type: :model)
   config.include(Shoulda::Matchers::ActiveRecord, type: :model)


### PR DESCRIPTION
Improve the documentation on how to integrate the should matchers with RSpec in non Rails projects.

Currently the docs don't specify that `shoulda-matcher` needs to be required before RSpec configuration block.

That leads to a failure when trying to `bundle exec rspec`
```
Failure/Error: config.include(Shoulda::Matchers::ActiveModel, type: :model)

NameError:
  uninitialized constant Shoulda
```

Putting `require 'shoulda-matchers'` fixed the issue in my case.