### PR TITLE
Fixes uniqueness validator syntax in documentation

### DIFF
--- a/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
+++ b/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
@@ -144,7 +144,7 @@ module Shoulda
       # unique, but the scoped attributes are not unique either.
       #
       #     class Post < ActiveRecord::Base
-      #       validates :slug, uniqueness: true, scope: :journal_id
+      #       validates :slug, uniqueness: { scope: :journal_id }
       #     end
       #
       #     # RSpec


### PR DESCRIPTION
The documentation shows a wrong example of uniqueness validation:
```ruby
validates :slug, uniqueness: true, scope: :journal_id
```
The correct syntax is:
```ruby
validates :slug, uniqueness: { scope: :journal_id }
```