### PR TITLE
Transforms string arguments to symbols for scoped arguments on Unique…

### DIFF
--- a/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
+++ b/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
@@ -276,7 +276,7 @@ module Shoulda
         end
 
         def scoped_to(*scopes)
-          @options[:scopes] = [*scopes].flatten
+          @options[:scopes] = [*scopes].flatten.map(&:to_sym)
           self
         end
 
@@ -477,7 +477,7 @@ module Shoulda
 
         def actual_sets_of_scopes
           validations.map do |validation|
-            Array.wrap(validation.options[:scope])
+            Array.wrap(validation.options[:scope]).map(&:to_sym)
           end.reject(&:empty?)
         end
 

--- a/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
@@ -1461,6 +1461,30 @@ this could not be proved.
         end
       end
     end
+
+    context 'when the scope argument is defined as a string on the model' do
+      it 'transforms the scope argument to a symbol' do
+        model = define_model_validating_uniqueness(
+          attribute_name: :name,
+          scopes: ['account_id'],
+        )
+
+        expect(model.new).to validate_uniqueness_of(:name).
+          scoped_to(:account_id)
+      end
+    end
+
+    context 'when the scoped_to argument is passed as a string' do
+      it 'transforms the scoped_to argument to a symbol' do
+        model = define_model_validating_uniqueness(
+          attribute_name: :name,
+          scopes: [:account_id],
+        )
+
+        expect(model.new).to validate_uniqueness_of(:name).
+          scoped_to('account_id')
+      end
+    end
   end
 
   context 'when the column is a boolean column' do


### PR DESCRIPTION
…ness Matcher

* ActiveRecord allows attributes to be use string or symbol arguments interchangeably.
The ValidateUniquenessOfMatcher operates under the assumption that all scope arguments
will be defined as symbols. We should transform the scoped arguments to symbol
so that exceptions do not get raised.

* See https://github.com/thoughtbot/shoulda-matchers/issues/1175