### PR TITLE
Fix `without_validating_presence` documentation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -91,7 +91,7 @@ is now:
   * *Original PR: [#956]*
   * *Original issues: [#870], [#861]*
 
-* Add `without_presence_validation` qualifier to `belong_to` to get around the
+* Add `without_validating_presence` qualifier to `belong_to` to get around the
   fact that `required` is assumed, above.
 
   * *Original issues: [#1153], [#1154]*

--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -272,9 +272,9 @@ module Shoulda
       #       should belong_to(:organization).required
       #     end
       #
-      # #### without_presence_validation
+      # #### without_validating_presence
       #
-      # Use `without_presence_validation` with `belong_to` to prevent the
+      # Use `without_validating_presence` with `belong_to` to prevent the
       # matcher from checking whether the association disallows nil (Rails 5+
       # only). This can be helpful if you have a custom hook that always sets
       # the association to a meaningful value:
@@ -293,12 +293,12 @@ module Shoulda
       #
       #     # RSpec
       #     describe Person
-      #       it { should belong_to(:organization).without_presence_validation }
+      #       it { should belong_to(:organization).without_validating_presence }
       #     end
       #
       #     # Minitest (Shoulda)
       #     class PersonTest < ActiveSupport::TestCase
-      #       should belong_to(:organization).without_presence_validation
+      #       should belong_to(:organization).without_validating_presence
       #     end
       #
       # ##### optional


### PR DESCRIPTION
`balongs_to.without_validating_presence` was introduced in #1170 and both the documentation and the changelog state that the method is called `without_presence_validation`.  Imho the implemented method name is better, so here is the documentation update, to avoid future confusion
