### PR TITLE
Bug fix: uniqueness validation fails with scoped attributes of data type time

### DIFF
--- a/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
+++ b/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
@@ -820,7 +820,7 @@ module Shoulda
           elsif previous_value.respond_to?(:next)
             previous_value.next
           elsif previous_value.respond_to?(:to_datetime)
-            previous_value.to_datetime.next
+            previous_value.to_datetime.in(60).next
           elsif boolean_value?(previous_value)
             !previous_value
           else

--- a/lib/shoulda/matchers/util.rb
+++ b/lib/shoulda/matchers/util.rb
@@ -92,7 +92,7 @@ module Shoulda
           when :datetime, :timestamp
             DateTime.new(2100, 1, 1)
           when :time
-            Time.new(2100, 1, 1)
+            Time.new(2000, 1, 1)
           when :uuid
             SecureRandom.uuid
           when :boolean

--- a/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
@@ -829,6 +829,11 @@ within the scope of :scope1, but this could not be proved.
         column_type: :datetime
     end
 
+    context 'when one of the scoped attributes is a time column (using Time)' do
+      include_context 'it supports scoped attributes of a certain type',
+        column_type: :time
+    end
+
     context 'when one of the scoped attributes is a datetime column (using Time)' do
       include_context 'it supports scoped attributes of a certain type',
         column_type: :datetime,
@@ -1538,32 +1543,7 @@ this could not be proved.
   end
 
   def dummy_value_for(attribute_type, array: false)
-    if array
-      [ dummy_scalar_value_for(attribute_type) ]
-    else
-      dummy_scalar_value_for(attribute_type)
-    end
-  end
-
-  def dummy_scalar_value_for(attribute_type)
-    case attribute_type
-    when :string, :text
-      'dummy value'
-    when :integer
-      1
-    when :date
-      Date.today
-    when :datetime
-      Date.today.to_datetime
-    when :time
-      Time.now
-    when :uuid
-      SecureRandom.uuid
-    when :boolean
-      true
-    else
-      raise ArgumentError, "Unknown type '#{attribute_type}'"
-    end
+    Shoulda::Matchers::Util.dummy_value_for(attribute_type, array: array)
   end
 
   def next_version_of(value, value_type)


### PR DESCRIPTION
**PR to fix issue #1114**  

### The bug

The validation fails but it should pass when the scope has data type `time`. 

Example: model `Schedule` with the following attributes and their data types:
`day_of_week`: `integer`
`start_time`: `time`

```ruby
class Schedule
    validates :day_of_week, uniqueness: { scope: :start_time }
end
```

Spec:
```ruby
it { should validate_uniqueness_of(:day_of_week).scoped_to(:start_time) }

Failures:

  1) Schedule should require case sensitive unique value for day_of_week scoped to start_time
     Failure/Error: it { should validate_uniqueness_of(:day_of_week).scoped_to(:start_time) }
     
       Did not expect errors to include "has already been taken" when day_of_week is set to 0,
       got errors:
       * "has already been taken" (attribute: day_of_week, value: 0) (with different value of start_time)
```

This bug is caused by the method that calculates the next value to test for the uniqueness of the scope:
[`lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb`](https://github.com/thoughtbot/shoulda-matchers/blob/master/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb#L833)
```ruby
module Shoulda
  module Matchers
    module ActiveRecord
    ...
    def next_scalar_value_for(scope, previous_value)
        ...
        elsif previous_value.respond_to?(:to_datetime)
            previous_value.to_datetime.next
    ...
```

When `previous_value` is of type `time`:

`previous_value` -> `2018-07-02 11:20:14`
` previous_value.to_datetime.next` -> `2018-07-03 11:20:14`

The date is incremented by 1, however the time remains the same. As a result when the next value is set on the new record the uniqueness validation fails since the 2 records have the same time value.

### The fix

This PR fixes the bug by adding `in(60)` to increment the timestamp by 60 second before incrementing the date with `next`:
`previous_value.to_datetime.in(60).next`