### PR TITLE
Use model class DB connection in have_db_index matcher

### DIFF
--- a/lib/shoulda/matchers/active_record/have_db_index_matcher.rb
+++ b/lib/shoulda/matchers/active_record/have_db_index_matcher.rb
@@ -136,7 +136,7 @@ module Shoulda
         end
 
         def indexes
-          ::ActiveRecord::Base.connection.indexes(table_name)
+          model_class.connection.indexes(table_name)
         end
 
         def expectation

--- a/spec/support/tests/database_configuration.rb
+++ b/spec/support/tests/database_configuration.rb
@@ -20,14 +20,11 @@ module Tests
 
     def to_hash
       ENVIRONMENTS.each_with_object({}) do |env, config_as_hash|
-        config_as_hash[env] = inner_config_as_hash
+        config_as_hash[env] = {
+          'adapter' => adapter.to_s,
+          'database' => "#{database}_#{env}",
+        }
       end
-    end
-
-    private
-
-    def inner_config_as_hash
-      { 'adapter' => adapter.to_s, 'database' => database.to_s }
     end
   end
 end

--- a/spec/support/unit/rails_application.rb
+++ b/spec/support/unit/rails_application.rb
@@ -77,6 +77,8 @@ module UnitTests
       fix_available_locales_warning
       remove_bootsnap
       write_database_configuration
+      write_activerecord_model_with_default_connection
+      write_activerecord_model_with_different_connection
 
       if bundle.version_of("rails") >= 5
         add_initializer_for_time_zone_aware_types
@@ -113,6 +115,36 @@ end
       YAML.dump(database.config.to_hash, fs.open('config/database.yml', 'w'))
     end
 
+    def write_activerecord_model_with_different_connection
+      # To simulate multi-db connections, we create a new "base model" which
+      # connects to a different database (in this case -
+      # shoulda-matchers-test_production).
+      # Any models which inherit from this class, or uses this model's
+      # connection will be routed to this database.
+      path = 'app/models/production_record.rb'
+      fs.write(path, <<-TEXT)
+class ProductionRecord < ActiveRecord::Base
+  self.abstract_class = true
+  establish_connection :production
+end
+      TEXT
+    end
+
+    def write_activerecord_model_with_default_connection
+      # Alongside ProductionRecord created above, we also create a dummy
+      # DevelopmentRecord which connects to the default database (in this case -
+      # shoulda-matchers-test_development, for symmetry's sake. This allows us
+      # to be a little more explicit when writing tests, for example:
+      #   expect(with_index_on(:age1, parent_class: DevelopmentRecord)).to have_db_index(:age1)
+      #   expect(with_index_on(:age2, parent_class: ProductionRecord)).to have_db_index(:age2)
+      path = 'app/models/development_record.rb'
+      fs.write(path, <<-TEXT)
+class DevelopmentRecord < ActiveRecord::Base
+  self.abstract_class = true
+end
+      TEXT
+    end
+
     def add_initializer_for_time_zone_aware_types
       path = 'config/initializers/configure_time_zone_aware_types.rb'
       fs.write(path, <<-TEXT)
@@ -128,7 +160,7 @@ end
 
     def run_migrations
       fs.within_project do
-        run_command! 'bundle exec rake db:drop db:create db:migrate'
+        run_command! 'bundle exec rake db:drop:all db:create:all db:migrate'
       end
     end
 

--- a/spec/unit/shoulda/matchers/active_record/have_db_index_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/have_db_index_matcher_spec.rb
@@ -3,7 +3,20 @@ require 'unit_spec_helper'
 describe Shoulda::Matchers::ActiveRecord::HaveDbIndexMatcher, type: :model do
   context 'have_db_index' do
     it 'accepts an existing index' do
-      expect(with_index_on(:age)).to have_db_index(:age)
+      model_connected_to_development = with_index_on(
+        :age1,
+        model_name: 'DevelopmentEmployee',
+        table_name: 'development_employees',
+        parent_class: DevelopmentRecord,
+      )
+      model_connected_to_production = with_index_on(
+        :age2,
+        model_name: 'ProductionEmployee',
+        table_name: 'production_employees',
+        parent_class: ProductionRecord,
+      )
+      expect(model_connected_to_development).to have_db_index(:age1)
+      expect(model_connected_to_production).to have_db_index(:age2)
     end
 
     it 'rejects a nonexistent index' do
@@ -77,9 +90,13 @@ describe Shoulda::Matchers::ActiveRecord::HaveDbIndexMatcher, type: :model do
   end
 
   def with_index_on(column_name, index_options = {})
-    create_table 'employees' do |table|
+    model_name   = index_options.delete(:model_name) || 'Employee'
+    table_name   = index_options.delete(:table_name) || 'employees'
+    parent_class = index_options.delete(:parent_class) || DevelopmentRecord
+
+    create_table(table_name, connection: parent_class.connection) do |table|
       table.integer column_name
-    end.add_index(:employees, column_name, index_options)
-    define_model_class('Employee').new
+    end.add_index(table_name.to_sym, column_name, index_options)
+    define_model_class(model_name, parent_class: parent_class).new
   end
 end


### PR DESCRIPTION
Fix #1051. This PR is WIP. 

Hey @mcmire, lemme know what you think.

I'm thinking to rename `ProductionRecord` to something else, as this naming might cause confusion.