### PR TITLE
Detect correct digestible attributes

### DIFF
--- a/lib/shoulda/matchers/rails_shim.rb
+++ b/lib/shoulda/matchers/rails_shim.rb
@@ -137,16 +137,15 @@ module Shoulda
         end
 
         def digestible_attributes_in(record)
-          record.methods.inject([]) do |array, method_name|
-            match = method_name.to_s.match(
-              /\A(\w+)_(?:confirmation|digest)=\Z/,
-            )
+          writer_methods = record.public_methods.grep(/\A\w+.*=\Z/)
 
-            if match
-              array.concat([match[1].to_sym])
-            else
-              array
-            end
+          reader_methods = writer_methods.map do |method_name|
+            method_name.to_s.remove(/=\Z/).to_sym
+          end
+
+          reader_methods.select do |reader_method_name|
+            record.respond_to?("#{reader_method_name}_digest") &&
+              record.respond_to?("#{reader_method_name}_confirmation=")
           end
         end
 


### PR DESCRIPTION
`RailsShim.digestible_attributes_in` should return only digestible attributes when AR class has `_confirmation` writer method.

Example: 

```ruby
class UserSession < ApplicationRecord
  has_one :xxx_confirmation
end

record = UserSession.new
RailsShim.digestible_attributes_in(record) #=> [:xxx]  ooops :(
```

```ruby
# spec
it { is_expected.to validate_uniqueness_of(:bar) }

# result
Failure/Error: fit { is_expected.to validate_uniqueness_of(:bar) }

NoMethodError:
 undefined method `xxx=' for #<UserSession:0x00007feb23b822a0>
```

This bug introduced in #1193.

