### PR TITLE
CI: Update Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-sudo: false
 addons:
   postgresql: "10"
   apt:
@@ -13,9 +12,9 @@ env:
     - DATABASE_ADAPTER=sqlite3
     - DATABASE_ADAPTER=postgresql
 rvm:
-  - 2.4.4
-  - 2.5.4
-  - 2.6.2
+  - 2.4.6
+  - 2.5.5
+  - 2.6.3
 gemfile:
   - gemfiles/rails_4_2.gemfile
   - gemfiles/rails_5_0.gemfile
@@ -24,11 +23,9 @@ gemfile:
   - gemfiles/rails_6_0.gemfile
 matrix:
   exclude:
-    - rvm: 2.3.7
+    - rvm: 2.4.6
       gemfile: gemfiles/rails_6_0.gemfile
-    - rvm: 2.4.4
-      gemfile: gemfiles/rails_6_0.gemfile
-    - rvm: 2.6.2
+    - rvm: 2.6.3
       gemfile: gemfiles/rails_4_2.gemfile
 cache: bundler
 # Source: <https://docs.travis-ci.com/user/languages/ruby/#bundler-20>


### PR DESCRIPTION
This PR updates the CI matrix versions.

  - drop unused Travis setting sudo: false - see https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration