### PR TITLE
Teach have_db_index about expression indexes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -101,6 +101,7 @@ Style/CharacterLiteral:
 Style/ClassAndModuleChildren:
   Enabled: false
 Style/CollectionMethods:
+  Enabled: true
   PreferredMethods:
     find: detect
     reduce: inject

--- a/Appraisals
+++ b/Appraisals
@@ -111,24 +111,26 @@ appraise 'rails_5_2' do
   gem 'pg', '~> 1.1', platform: :ruby
 end
 
-appraise 'rails_6_0' do
-  instance_eval(&shared_dependencies)
+if Gem::Requirement.new('>= 2.5.0').satisfied_by?(Gem::Version.new(RUBY_VERSION))
+  appraise 'rails_6_0' do
+    instance_eval(&shared_dependencies)
 
-  gem 'rails', '~> 6.0.0.beta3'
-  gem 'puma', '~> 3.11'
-  gem 'bootsnap', '>= 1.4.1', require: false
-  gem 'sass-rails', '~> 5.0'
-  gem 'webpacker', '>= 4.0.0.rc3'
-  gem 'turbolinks', '~> 5'
-  gem 'jbuilder', '~> 2.5'
-  gem 'bcrypt', '~> 3.1.7'
-  gem 'capybara', '>= 2.15'
-  gem 'listen', '>= 3.0.5', '< 3.2'
-  gem 'spring-watcher-listen', '~> 2.0.0'
-  gem 'selenium-webdriver'
-  gem 'chromedriver-helper'
+    gem 'rails', '~> 6.0.0.beta3'
+    gem 'puma', '~> 3.11'
+    gem 'bootsnap', '>= 1.4.1', require: false
+    gem 'sass-rails', '~> 5.0'
+    gem 'webpacker', '>= 4.0.0.rc3'
+    gem 'turbolinks', '~> 5'
+    gem 'jbuilder', '~> 2.5'
+    gem 'bcrypt', '~> 3.1.7'
+    gem 'capybara', '>= 2.15'
+    gem 'listen', '>= 3.0.5', '< 3.2'
+    gem 'spring-watcher-listen', '~> 2.0.0'
+    gem 'selenium-webdriver'
+    gem 'chromedriver-helper'
 
-  # Other dependencies
-  gem 'rails-controller-testing', '>= 1.0.1'
-  gem 'pg', '~> 1.1', platform: :ruby
+    # Other dependencies
+    gem 'rails-controller-testing', '>= 1.0.1'
+    gem 'pg', '~> 1.1', platform: :ruby
+  end
 end

--- a/bin/setup
+++ b/bin/setup
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 RUBY_VERSION=$(script/supported_ruby_versions | xargs -n 1 echo | sort -V | tail -n 1)
+required_ruby_version=$(cat .ruby-version)
 
 cd "$(dirname "$(dirname "$0")")"
 
@@ -30,12 +31,24 @@ error() {
   echo -e "\033[31m$@\033[0m"
 }
 
+echo-wrapped() {
+  echo "$@" | fmt -w 80 | cat
+}
+
 has-executable() {
   type "$1" &>/dev/null
 }
 
 is-running() {
   pgrep "$1" >/dev/null
+}
+
+start() {
+  if has-executable brew; then
+    brew services start "$1"
+  else
+    sudo service "${2:-$1}" start
+  fi
 }
 
 install() {
@@ -90,9 +103,10 @@ check-for-build-tools() {
   if [[ $platform == "linux" ]]; then
     if ! has-executable apt-get; then
       error "You don't seem to have a package manager installed."
-      echo "The setup script assumes you're using Debian or a Debian-derived flavor of Linux"
-      echo "(i.e. something with Apt). If this is not the case, then we would gladly take a"
-      echo "PR fixing this!"
+      echo-wrapped "\
+The setup script assumes you're using Debian or a Debian-derived flavor of
+Linux (i.e. something with Apt). If this is not the case, then we would
+gladly take a PR fixing this!"
       exit 1
     fi
 
@@ -100,10 +114,12 @@ check-for-build-tools() {
   else
     if ! has-executable brew; then
       error "You don't seem to have Homebrew installed."
-      echo
-      echo "Follow the instructions here to do this:"
-      echo
-      echo "http://brew.sh"
+      echo-wrapped "\
+Follow the instructions here to do this:
+
+    http://brew.sh
+
+Then re-run this script."
       exit 1
     fi
 
@@ -145,21 +161,22 @@ install-dependencies() {
       rbenv install --skip-existing "$RUBY_VERSION"
     fi
   elif has-executable rvm; then
-    if ! (rvm ls | grep $RUBY_VERSION'\>' &>/dev/null); then
-      banner "Installing Ruby $RUBY_VERSION with rvm"
-      error "You don't seem to have Ruby $RUBY_VERSION installed."
-      echo
-      echo "Use RVM to do so, and then re-run this command."
-      echo
+    if ! (rvm list | grep $required_ruby_version'\>' &>/dev/null); then
+      banner "Installing Ruby $required_ruby_version with rvm"
+      rvm install $required_ruby_version
+      rvm use $required_ruby_version
     fi
   else
     error "You don't seem to have a Ruby manager installed."
-    echo
-    echo 'We recommend using rbenv. You can find installation instructions here:'
-    echo
-    echo 'http://github.com/rbenv/rbenv'
-    echo
-    echo "When you're done, simply re-run this script!"
+    echo-wrapped "\
+We recommend using rbenv. You can find instructions to install it here:
+
+    https://github.com/rbenv/rbenv#installation
+
+Make sure to follow the instructions to configure your shell so that rbenv is
+automatically loaded.
+
+When you're done, open up a new terminal tab and re-run this script."
     exit 1
   fi
 
@@ -167,22 +184,6 @@ install-dependencies() {
   gem install bundler -v '~> 1.0' --conservative
   bundle check || bundle install
   bundle exec appraisal install
-
-  if ! has-executable node; then
-    banner 'Installing Node'
-
-    if [[ $platform == 'linux' ]]; then
-      curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
-
-      install nodejs
-
-      if ! has-executable npm; then
-        install npm
-      fi
-    else
-      install nodejs
-    fi
-  fi
 }
 
 check-for-build-tools

--- a/spec/support/unit/helpers/active_record_versions.rb
+++ b/spec/support/unit/helpers/active_record_versions.rb
@@ -40,5 +40,9 @@ module UnitTests
     def active_record_supports_optional_for_associations?
       active_record_version >= 5
     end
+
+    def active_record_supports_expression_indexes?
+      active_record_version >= 5
+    end
   end
 end

--- a/spec/support/unit/helpers/database_helpers.rb
+++ b/spec/support/unit/helpers/database_helpers.rb
@@ -16,5 +16,6 @@ module UnitTests
     alias_method :database_supports_array_columns?, :postgresql?
     alias_method :database_supports_uuid_columns?, :postgresql?
     alias_method :database_supports_money_columns?, :postgresql?
+    alias_method :database_supports_expression_indexes?, :postgresql?
   end
 end


### PR DESCRIPTION
In Rails 5, the schema layer was updated so that indexes could be
created on expressions rather that simply columns. Update
`have_db_index` so that you can test for this.

More reading: <https://github.com/rails/rails/commit/edc2b7718725016e988089b5fb6d6fb9d6e16882>

---

Fixes #945.
Fixes #1207.