### PR TITLE
Clear up confusion w/ presence around belongs_to associations

### DIFF
--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -272,7 +272,7 @@ module Shoulda
       #       should belong_to(:organization).required
       #     end
       #
-      # #### without_validating_presence
+      # ##### without_validating_presence
       #
       # Use `without_validating_presence` with `belong_to` to prevent the
       # matcher from checking whether the association disallows nil (Rails 5+

--- a/lib/shoulda/matchers/util/word_wrap.rb
+++ b/lib/shoulda/matchers/util/word_wrap.rb
@@ -2,6 +2,8 @@ module Shoulda
   module Matchers
     # @private
     module WordWrap
+      TERMINAL_WIDTH = 72
+
       def word_wrap(document, options = {})
         Document.new(document, options).wrap
       end
@@ -112,7 +114,6 @@ module Shoulda
 
     # @private
     class Line
-      TERMINAL_WIDTH = 72
       OFFSETS = { left: -1, right: +1 }
 
       def initialize(line, indent: 0)
@@ -171,7 +172,7 @@ module Shoulda
       def wrap_line(line, direction: :left)
         index = nil
 
-        if line.length > TERMINAL_WIDTH
+        if line.length > Shoulda::Matchers::WordWrap::TERMINAL_WIDTH
           index = determine_where_to_break_line(line, direction: :left)
 
           if index == -1
@@ -192,7 +193,7 @@ module Shoulda
 
       def determine_where_to_break_line(line, args)
         direction = args.fetch(:direction)
-        index = TERMINAL_WIDTH
+        index = Shoulda::Matchers::WordWrap::TERMINAL_WIDTH
         offset = OFFSETS.fetch(direction)
 
         while line[index] !~ /\s/ && (0...line.length).cover?(index)

--- a/spec/support/unit/helpers/application_configuration_helpers.rb
+++ b/spec/support/unit/helpers/application_configuration_helpers.rb
@@ -1,0 +1,31 @@
+module UnitTests
+  module ApplicationConfigurationHelpers
+    def with_belongs_to_as_required_by_default(&block)
+      configuring_application(
+        ::ActiveRecord::Base,
+        :belongs_to_required_by_default,
+        true,
+        &block
+      )
+    end
+
+    def with_belongs_to_as_optional_by_default(&block)
+      configuring_application(
+        ::ActiveRecord::Base,
+        :belongs_to_required_by_default,
+        false,
+        &block
+      )
+    end
+
+    private
+
+    def configuring_application(config, name, value)
+      previous_value = config.send(name)
+      config.send("#{name}=", value)
+      yield
+    ensure
+      config.send("#{name}=", previous_value)
+    end
+  end
+end

--- a/spec/support/unit/matchers/match_against.rb
+++ b/spec/support/unit/matchers/match_against.rb
@@ -1,0 +1,151 @@
+module UnitTests
+  module Matchers
+    def match_against(object)
+      MatchAgainstMatcher.new(object)
+    end
+
+    class MatchAgainstMatcher
+      DIVIDER = ('-' * Shoulda::Matchers::WordWrap::TERMINAL_WIDTH).freeze
+
+      attr_reader :failure_message, :failure_message_when_negated
+
+      def initialize(object)
+        @object = object
+        @failure_message = nil
+        @failure_message_when_negated = nil
+      end
+
+      def and_fail_with(message)
+        @message = message.strip
+        self
+      end
+      alias_method :or_fail_with, :and_fail_with
+
+      def matches?(generate_matcher)
+        @positive_matcher = generate_matcher.call
+        @negative_matcher = generate_matcher.call
+
+        if positive_matcher.matches?(object)
+          !message || matcher_fails_in_negative?
+        else
+          @failure_message = <<-MESSAGE
+Expected the matcher to match in the positive, but it failed with this message:
+
+#{DIVIDER}
+#{positive_matcher.failure_message}
+#{DIVIDER}
+          MESSAGE
+          false
+        end
+      end
+
+      def does_not_match?(generate_matcher)
+        @positive_matcher = generate_matcher.call
+        @negative_matcher = generate_matcher.call
+
+        if negative_matcher.does_not_match?(object)
+          !message || matcher_fails_in_positive?
+        else
+          @failure_message_when_negated = <<-MESSAGE
+Expected the matcher to match in the negative, but it failed with this message:
+
+#{DIVIDER}
+#{negative_matcher.failure_message_when_negated}
+#{DIVIDER}
+          MESSAGE
+          false
+        end
+      end
+
+      def supports_block_expectations?
+        true
+      end
+
+      private
+
+      attr_reader :object, :message, :positive_matcher, :negative_matcher
+
+      def matcher_fails_in_negative?
+        if !negative_matcher.does_not_match?(object)
+          if message == negative_matcher.failure_message_when_negated.strip
+            true
+          else
+            diff_result = diff(
+              message,
+              negative_matcher.failure_message_when_negated.strip,
+            )
+            @failure_message = <<-MESSAGE
+Expected the negative version of the matcher not to match and for the failure
+message to be:
+
+#{DIVIDER}
+#{message.chomp}
+#{DIVIDER}
+
+However, it was:
+
+#{DIVIDER}
+#{negative_matcher.failure_message_when_negated}
+#{DIVIDER}
+
+Diff:
+
+#{Shoulda::Matchers::Util.indent(diff_result, 2)}
+            MESSAGE
+            false
+          end
+        else
+          @failure_message =
+            'Expected the negative version of the matcher not to match, ' +
+            'but it did.'
+          false
+        end
+      end
+
+      def matcher_fails_in_positive?
+        if !positive_matcher.matches?(object)
+          if message == positive_matcher.failure_message.strip
+            true
+          else
+            diff_result = diff(
+              message,
+              positive_matcher.failure_message.strip,
+            )
+            @failure_message_when_negated = <<-MESSAGE
+Expected the positive version of the matcher not to match and for the failure
+message to be:
+
+#{DIVIDER}
+#{message.chomp}
+#{DIVIDER}
+
+However, it was:
+
+#{DIVIDER}
+#{positive_matcher.failure_message}
+#{DIVIDER}
+
+Diff:
+
+#{Shoulda::Matchers::Util.indent(diff_result, 2)}
+            MESSAGE
+            false
+          end
+        else
+          @failure_message_when_negated =
+            'Expected the positive version of the matcher not to match, ' +
+            'but it did.'
+          false
+        end
+      end
+
+      def diff(expected, actual)
+        differ.diff(expected, actual)[1..-1]
+      end
+
+      def differ
+        @_differ ||= RSpec::Support::Differ.new
+      end
+    end
+  end
+end

--- a/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -1,6 +1,8 @@
 require 'unit_spec_helper'
 
 describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
+  include UnitTests::ApplicationConfigurationHelpers
+
   context 'belong_to' do
     it 'accepts a good association with the default foreign key' do
       expect(belonging_to_parent).to belong_to(:parent)
@@ -284,7 +286,7 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
         if active_record_supports_optional_for_associations?
           context 'when belongs_to is configured to be required by default' do
             it 'passes' do
-              configuring_default_belongs_to_requiredness(true) do
+              with_belongs_to_as_required_by_default do
                 expect(belonging_to_parent).to belong_to(:parent).required(true)
               end
             end
@@ -292,7 +294,7 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
 
           context 'when belongs_to is not configured to be required by default' do
             it 'fails with an appropriate message' do
-              configuring_default_belongs_to_requiredness(false) do
+              with_belongs_to_as_optional_by_default do
                 assertion = lambda do
                   expect(belonging_to_parent).
                     to belong_to(:parent).required(true)
@@ -333,7 +335,7 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
         if active_record_supports_optional_for_associations?
           context 'when belongs_to is configured to be required by default' do
             it 'fails with an appropriate message' do
-              configuring_default_belongs_to_requiredness(true) do
+              with_belongs_to_as_required_by_default do
                 assertion = lambda do
                   expect(belonging_to_parent).
                     to belong_to(:parent).required(false)
@@ -354,7 +356,7 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
 
           context 'when belongs_to is not configured to be required by default' do
             it 'passes' do
-              configuring_default_belongs_to_requiredness(false) do
+              with_belongs_to_as_optional_by_default do
                 expect(belonging_to_parent).to belong_to(:parent).required(false)
               end
             end
@@ -370,7 +372,7 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
         if active_record_supports_optional_for_associations?
           context 'when belongs_to is configured to be required by default' do
             it 'fails with an appropriate message' do
-              configuring_default_belongs_to_requiredness(true) do
+              with_belongs_to_as_required_by_default do
                 assertion = lambda do
                   expect(belonging_to_parent).
                     to belong_to(:parent).optional
@@ -391,7 +393,7 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
 
           context 'when belongs_to is not configured to be required by default' do
             it 'passes' do
-              configuring_default_belongs_to_requiredness(false) do
+              with_belongs_to_as_optional_by_default do
                 expect(belonging_to_parent).to belong_to(:parent).optional
               end
             end
@@ -407,7 +409,7 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
         if active_record_supports_optional_for_associations?
           context 'when belongs_to is configured to be required by default' do
             it 'passes' do
-              configuring_default_belongs_to_requiredness(true) do
+              with_belongs_to_as_required_by_default do
                 expect(belonging_to_parent).to belong_to(:parent)
               end
             end
@@ -415,14 +417,14 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
 
           context 'when belongs_to is not configured to be required by default' do
             it 'passes' do
-              configuring_default_belongs_to_requiredness(false) do
+              with_belongs_to_as_optional_by_default do
                 expect(belonging_to_parent).to belong_to(:parent)
               end
             end
 
             context 'and a presence validation is on the attribute instead of using required: true' do
               it 'passes' do
-                configuring_default_belongs_to_requiredness(false) do
+                with_belongs_to_as_optional_by_default do
                   record = belonging_to_parent do
                     validates_presence_of :parent
                   end
@@ -435,7 +437,7 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
             context 'and a presence validation is on the attribute with a condition' do
               context 'and the condition is true' do
                 it 'passes' do
-                  configuring_default_belongs_to_requiredness(false) do
+                  with_belongs_to_as_optional_by_default do
                     child_model = create_child_model_belonging_to_parent do
                       attr_accessor :condition
                       validates_presence_of :parent, if: :condition
@@ -450,7 +452,7 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
 
               context 'and the condition is false' do
                 it 'passes' do
-                  configuring_default_belongs_to_requiredness(false) do
+                  with_belongs_to_as_optional_by_default do
                     child_model = create_child_model_belonging_to_parent do
                       attr_accessor :condition
                       validates_presence_of :parent, if: :condition
@@ -630,7 +632,7 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
               end
 
               assertion = lambda do
-                configuring_default_belongs_to_requiredness(true) do
+                with_belongs_to_as_required_by_default do
                   expect(model.new).to belong_to(:parent)
                 end
               end
@@ -656,7 +658,7 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
                 end
               end
 
-              configuring_default_belongs_to_requiredness(true) do
+              with_belongs_to_as_required_by_default do
                 expect(model.new).
                   to belong_to(:parent).
                   without_validating_presence
@@ -677,7 +679,7 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
               end
 
               assertion = lambda do
-                configuring_default_belongs_to_requiredness(true) do
+                with_belongs_to_as_required_by_default do
                   expect(model.new).to belong_to(:parent).required
                 end
               end
@@ -703,7 +705,7 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
                 end
               end
 
-              configuring_default_belongs_to_requiredness(true) do
+              with_belongs_to_as_required_by_default do
                 expect(model.new).
                   to belong_to(:parent).
                   required.
@@ -1764,22 +1766,5 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
     else
       [:destroy, :delete, :nullify, :restrict]
     end
-  end
-
-  def configuring_default_belongs_to_requiredness(value, &block)
-    configuring_application(
-      ActiveRecord::Base,
-      :belongs_to_required_by_default,
-      value,
-      &block
-    )
-  end
-
-  def configuring_application(config, name, value)
-    previous_value = config.send(name)
-    config.send("#{name}=", value)
-    yield
-  ensure
-    config.send("#{name}=", previous_value)
   end
 end


### PR DESCRIPTION
Now that `belongs_to` associations add a presence validation
automatically, if you have a test such as the following:

    class StudentBook < ApplicationRecord
      belongs_to :student
    end

    RSpec.describe StudentBook do
      it { is_expected.not_to be_valid }
      it { is_expected.to validate_presence_of(:student) }
    end

then the test for presence of :student will fail, because the validation
message on the automatic presence validation is different than the usual
message. The solution here, of course, is to just use `belong_to`, but
that is not very obvious. So this commit updates the presence matcher to
remind users about using `belong_to` in a case such as this.

---

Fixes #1095. 