### PR TITLE
 Improve failure message for enum matcher

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,8 @@
 require: rubocop-rails
 AllCops:
   TargetRubyVersion: 2.4
+Layout/AlignArguments:
+  EnforcedStyle: with_fixed_indentation
 Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 Layout/CommentIndentation:
@@ -74,6 +76,8 @@ Naming/BinaryOperatorParameterName:
 Naming/MemoizedInstanceVariableName:
   EnforcedStyleForLeadingUnderscores: required
 Naming/PredicateName:
+  Enabled: false
+Style/BlockDelimiters:
   Enabled: false
 Style/ClassVars:
   Enabled: false


### PR DESCRIPTION
When the enum matcher fails, the message it generates is not as clear as
it could be, particularly around showing the expected enum values versus
the actual ones. This commit expands the failure message to be more
helpful (and ensures that the description of the matcher is kept
compact).

---

Fixes #1178.