### PR TITLE
validate_presence_of(:active_storage_field) throws exception

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
@@ -236,6 +236,8 @@ validation for you? Instead of using `validate_presence_of`, try
         def disallowed_values
           if collection?
             [Array.new]
+          elsif attachment?
+            [nil]
           else
             values = []
 
@@ -341,12 +343,22 @@ validation for you? Instead of using `validate_presence_of`, try
             model.reflect_on_association(@attribute)
         end
 
+        def attachment?
+          model.respond_to?(:reflect_on_association) &&
+            model_reflect_on_associations?(["#{@attribute}_attachment", "#{@attribute}_attachments"])
+        end
+
         def attribute_type
           if model.respond_to?(:attribute_types)
             model.attribute_types[@attribute.to_s]
           else
             LegacyAttributeType.new(model, @attribute)
           end
+        end
+
+        def model_reflect_on_associations?(associations)
+          reflections = associations.map { |association| model.reflect_on_association(association) }
+          !reflections.compact.empty?
         end
 
         def presence_validation_exists_on_attribute?

--- a/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
@@ -345,7 +345,7 @@ validation for you? Instead of using `validate_presence_of`, try
 
         def attachment?
           model.respond_to?(:reflect_on_association) &&
-            model_reflect_on_associations?(["#{@attribute}_attachment", "#{@attribute}_attachments"])
+            model_has_associations?(["#{@attribute}_attachment", "#{@attribute}_attachments"])
         end
 
         def attribute_type
@@ -356,9 +356,8 @@ validation for you? Instead of using `validate_presence_of`, try
           end
         end
 
-        def model_reflect_on_associations?(associations)
-          reflections = associations.map { |association| model.reflect_on_association(association) }
-          !reflections.compact.empty?
+        def model_has_associations?(associations)
+          associations.any? { |association| !!model.reflect_on_association(association) }
         end
 
         def presence_validation_exists_on_attribute?

--- a/spec/support/unit/helpers/active_record_versions.rb
+++ b/spec/support/unit/helpers/active_record_versions.rb
@@ -44,5 +44,9 @@ module UnitTests
     def active_record_supports_expression_indexes?
       active_record_version >= 5
     end
+
+    def active_record_supports_validate_presence_on_active_storage?
+      active_record_version >= '6.0.0.beta1'
+    end
   end
 end

--- a/spec/support/unit/helpers/rails_versions.rb
+++ b/spec/support/unit/helpers/rails_versions.rb
@@ -38,9 +38,5 @@ module UnitTests
     def rails_5_x?
       rails_version =~ '~> 5.0'
     end
-
-    def rails_gte_6_0?
-      rails_version >= '6.0.0.beta1'
-    end
   end
 end

--- a/spec/support/unit/helpers/rails_versions.rb
+++ b/spec/support/unit/helpers/rails_versions.rb
@@ -38,5 +38,9 @@ module UnitTests
     def rails_5_x?
       rails_version =~ '~> 5.0'
     end
+
+    def rails_gte_6_0?
+      rails_version >= '6.0.0.beta1'
+    end
   end
 end

--- a/spec/unit/shoulda/matchers/active_model/validate_presence_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_presence_of_matcher_spec.rb
@@ -204,8 +204,7 @@ could not be proved.
     end
   end
 
-  # validate_presence_of an attachment only works on rails >= 6
-  if rails_gte_6_0?
+  if active_record_supports_validate_presence_on_active_storage?
     context 'a has_one_attached association with a presence validation' do
       it 'requires the attribute to be set' do
         expect(has_one_attached_child(presence: true)).to validate_presence_of(:child)


### PR DESCRIPTION
When trying to test validation of presence against a active storage relation, shoulda tries to set the attribute as empty string. This makes the association fail to be set and breaks the test.

I've introduced a block that checks if the field is an active storage relation and only allows `nil` to be set to the object.

Fixes #1223