### PR TITLE
Support for folks using chruby

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -160,6 +160,16 @@ install-dependencies() {
       banner "Installing Ruby $RUBY_VERSION with rbenv"
       rbenv install --skip-existing "$RUBY_VERSION"
     fi
+  elif has-executable chruby-exec; then
+    PREFIX='' source /usr/local/share/chruby/chruby.sh
+    if ! (chruby '' | grep $RUBY_VERSION'\>' &>/dev/null); then
+      if has-executable install-ruby; then
+      banner "Installing Ruby $RUBY_VERSION with install-ruby"
+        install-ruby "$RUBY_VERSION"
+      else
+        error "Please install Ruby $RUBY_VERSION"
+      fi
+    fi
   elif has-executable rvm; then
     if ! (rvm list | grep $required_ruby_version'\>' &>/dev/null); then
       banner "Installing Ruby $required_ruby_version with rvm"


### PR DESCRIPTION
This is a bit tricky to support, since `chruby` is actually a function, not a command. And the script doesn't interact so well with `set -u`. (Thus the `PREFIX=''` and the `chruby ''`.)

Also, chruby doesn't come with its own Ruby installer. Most people will use `ruby-install` though.