### PR TITLE
Fix presence matcher against an AM record

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,6 +43,8 @@ Lint/ParenthesesAsGroupedExpression:
   Enabled: false
 Lint/RequireParentheses:
   Enabled: false
+Lint/SafeNavigationChain:
+  Enabled: false
 Lint/UnderscorePrefixedVariableName:
   Enabled: false
 Lint/Void:
@@ -123,6 +125,8 @@ Style/Documentation:
 Style/DoubleNegation:
   Enabled: false
 Style/EachWithObject:
+  Enabled: false
+Style/EmptyElse:
   Enabled: false
 Style/EmptyLiteral:
   Enabled: false

--- a/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
@@ -170,7 +170,7 @@ module Shoulda
               allows_and_double_checks_value_of!(value)
             end
           else
-            (expects_to_allow_nil? && !allows_value_of(nil)) ||
+            (expects_to_allow_nil? && disallows_value_of(nil)) ||
               disallowed_values.any? do |value|
                 allows_original_or_typecast_value?(value)
               end

--- a/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
@@ -312,11 +312,13 @@ validation for you? Instead of using `validate_presence_of`, try
         end
 
         def attribute_accepts_string_values?
-          !association? && (
-            !attribute_type.respond_to?(:coder) ||
-            !attribute_type.coder ||
-            attribute_type.coder.object_class == String
-          )
+          if association? || attachment?
+            false
+          elsif attribute_serializer
+            attribute_serializer.object_class == String
+          else
+            attribute_type.try(:type) == :string
+          end
         end
 
         def association?
@@ -350,6 +352,14 @@ validation for you? Instead of using `validate_presence_of`, try
         def model_has_associations?(associations)
           associations.any? do |association|
             !!model.try(:reflect_on_association, association)
+          end
+        end
+
+        def attribute_serializer
+          if attribute_type.respond_to?(:coder)
+            attribute_type.coder
+          else
+            nil
           end
         end
 

--- a/lib/shoulda/matchers/rails_shim.rb
+++ b/lib/shoulda/matchers/rails_shim.rb
@@ -156,6 +156,14 @@ module Shoulda
           nil
         end
 
+        def attribute_type_for(model, attribute_name)
+          if model.respond_to?(:attribute_types)
+            model.attribute_types[attribute_name.to_s]
+          else
+            LegacyAttributeType.new(model, attribute_name)
+          end
+        end
+
         private
 
         def simply_generate_validation_message(
@@ -178,6 +186,25 @@ module Shoulda
           translate_options =
             { default: default_translation_keys }.merge(options)
           I18n.translate(primary_translation_key, translate_options)
+        end
+
+        class LegacyAttributeType
+          def initialize(model, attribute_name)
+            @model = model
+            @attribute_name = attribute_name
+          end
+
+          def coder
+            if model.respond_to?(:serialized_attributes)
+              ActiveSupport::Deprecation.silence do
+                model.serialized_attributes[attribute_name.to_s]
+              end
+            end
+          end
+
+          private
+
+          attr_reader :model, :attribute_name
         end
       end
     end

--- a/lib/shoulda/matchers/rails_shim.rb
+++ b/lib/shoulda/matchers/rails_shim.rb
@@ -157,7 +157,7 @@ module Shoulda
         end
 
         def attribute_type_for(model, attribute_name)
-          if model.respond_to?(:attribute_types)
+          if supports_full_attributes_api?(model)
             model.attribute_types[attribute_name.to_s]
           else
             LegacyAttributeType.new(model, attribute_name)
@@ -186,6 +186,11 @@ module Shoulda
           translate_options =
             { default: default_translation_keys }.merge(options)
           I18n.translate(primary_translation_key, translate_options)
+        end
+
+        def supports_full_attributes_api?(model)
+          defined?(::ActiveModel::Attributes) &&
+            model.respond_to?(:attribute_types)
         end
 
         class LegacyAttributeType


### PR DESCRIPTION
When using the presence matcher against an ActiveModel record, check to
ensure that the model is using the Attributes API and has explicitly
declared the attribute to be a string before attempting to set the
attribute to an empty string. Otherwise, the attribute may be getting
treated as an object in some point in the validation process, and
therefore setting it to an empty string would create problems.

---

Fixes #1218.
Fixes #1228.