### PR TITLE
Fix presence matcher w/ custom serializer

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
@@ -314,10 +314,11 @@ validation for you? Instead of using `validate_presence_of`, try
         def attribute_accepts_string_values?
           if association?
             false
-          elsif attribute_serializer
-            attribute_serializer.object_class == String
+          elsif attribute_serialization_coder.respond_to?(:object_class)
+            attribute_serialization_coder.object_class == String
           else
-            attribute_type.try(:type) == :string
+            RailsShim.supports_full_attributes_api?(model) &&
+              attribute_type.try(:type) == :string
           end
         end
 
@@ -355,12 +356,8 @@ validation for you? Instead of using `validate_presence_of`, try
           end
         end
 
-        def attribute_serializer
-          if attribute_type.respond_to?(:coder)
-            attribute_type.coder
-          else
-            nil
-          end
+        def attribute_serialization_coder
+          RailsShim.attribute_serialization_coder_for(model, @attribute)
         end
 
         def attribute_type

--- a/lib/shoulda/matchers/active_record/serialize_matcher.rb
+++ b/lib/shoulda/matchers/active_record/serialize_matcher.rb
@@ -183,15 +183,11 @@ module Shoulda
         end
 
         def attribute_is_serialized?
-          serialized_attributes.include?(@name)
+          !!serialization_coder
         end
 
         def serialization_coder
-          serialized_attributes[@name]
-        end
-
-        def serialized_attributes
-          Shoulda::Matchers::RailsShim.serialized_attributes_for(model)
+          RailsShim.attribute_serialization_coder_for(model, @name)
         end
 
         def model

--- a/spec/unit/shoulda/matchers/active_model/validate_presence_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_presence_of_matcher_spec.rb
@@ -57,23 +57,50 @@ this could not be proved.
     end
 
     context 'when the attribute is decorated with serialize' do
-      context 'and the type is a string' do
+      context 'and the serializer is a built-in Ruby type' do
+        context 'and the type is a string' do
+          it 'still works' do
+            record = record_validating_presence_of(:traits) do
+              serialize :traits, String
+            end
+
+            expect(record).to validate_presence_of(:traits)
+          end
+        end
+
+        context 'and the type is not a string' do
+          it 'still works' do
+            record = record_validating_presence_of(:traits) do
+              serialize :traits, Array
+            end
+
+            expect(record).to validate_presence_of(:traits)
+          end
+        end
+      end
+
+      context 'and the serializer is JSON' do
         it 'still works' do
           record = record_validating_presence_of(:traits) do
-            serialize :traits, String
+            serialize :traits, JSON
           end
 
           expect(record).to validate_presence_of(:traits)
         end
       end
 
-      context 'and the type is not a string' do
+      context 'and the serializer is something custom' do
         it 'still works' do
-          record = record_validating_presence_of(:traits) do
-            serialize :traits, Array
+          serializer = Class.new do
+            define_singleton_method(:dump) { |value| value }
+            define_singleton_method(:load) { |value| value }
           end
 
-          expect(record).to validate_presence_of(:traits)
+          record = record_validating_presence_of(:data) do
+            serialize :data, serializer
+          end
+
+          expect(record).to validate_presence_of(:data)
         end
       end
     end


### PR DESCRIPTION
When using the presence matcher on an attribute that is defined with
`serialize` and using a custom serializer instead of a Rails built-in,
the matcher failed spectacularly. This commit fixes that.