### PR TITLE
Add `optional(false)` support to `belong_to`

### DIFF
--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -1096,12 +1096,12 @@ module Shoulda
           self
         end
 
-        def optional
+        def optional(optional = true)
           remove_submatcher(AssociationMatchers::RequiredMatcher)
           add_submatcher(
             AssociationMatchers::OptionalMatcher,
             name,
-            true,
+            optional,
           )
           self
         end

--- a/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -436,8 +436,20 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
             end
           end
         else
-          it 'passes' do
-            expect(belonging_to_parent).to belong_to(:parent).optional(false)
+          it 'fails with an appropriate message' do
+            assertion = lambda do
+              expect(belonging_to_parent).
+                to belong_to(:parent).optional(false)
+            end
+
+            message = format_message(<<-MESSAGE, one_line: true)
+              Expected Child to have a belongs_to association called parent
+              (and for the record to fail validation if :parent is unset; i.e.,
+              either the association should have been defined with `optional:
+              false`, or there should be a presence validation on :parent)
+            MESSAGE
+
+            expect(&assertion).to fail_with_message(message)
           end
         end
       end

--- a/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -591,7 +591,7 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
         it 'fails with an appropriate message' do
           assertion = lambda do
             expect(belonging_to_parent(required: true)).
-              to belong_to(:parent).optional
+              to belong_to(:parent).optional(true)
           end
 
           message = format_message(<<-MESSAGE, one_line: true)
@@ -650,7 +650,7 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
         context 'when qualified with optional(true)' do
           it 'passes' do
             expect(belonging_to_parent(optional: true)).
-              to belong_to(:parent).optional
+              to belong_to(:parent).optional(true)
           end
         end
 

--- a/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -368,14 +368,14 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
         end
       end
 
-      context 'when qualified with optional' do
+      context 'when qualified with optional(true)' do
         if active_record_supports_optional_for_associations?
           context 'when belongs_to is configured to be required by default' do
             it 'fails with an appropriate message' do
               with_belongs_to_as_required_by_default do
                 assertion = lambda do
                   expect(belonging_to_parent).
-                    to belong_to(:parent).optional
+                    to belong_to(:parent).optional(true)
                 end
 
                 message = format_message(<<-MESSAGE, one_line: true)
@@ -394,13 +394,50 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
           context 'when belongs_to is not configured to be required by default' do
             it 'passes' do
               with_belongs_to_as_optional_by_default do
-                expect(belonging_to_parent).to belong_to(:parent).optional
+                expect(belonging_to_parent).to belong_to(:parent).optional(true)
               end
             end
           end
         else
           it 'passes' do
-            expect(belonging_to_parent).to belong_to(:parent).optional
+            expect(belonging_to_parent).to belong_to(:parent).optional(true)
+          end
+        end
+      end
+
+      context 'when qualified with optional(false)' do
+        if active_record_supports_optional_for_associations?
+          context 'when belongs_to is configured to be required by default' do
+            it 'passes' do
+              with_belongs_to_as_required_by_default do
+                expect(belonging_to_parent).to belong_to(:parent).optional(false)
+              end
+            end
+          end
+
+          context 'when belongs_to is not configured to be required by default' do
+            it 'fails with an appropriate message' do
+              with_belongs_to_as_optional_by_default do
+                assertion = lambda do
+                  expect(belonging_to_parent).
+                    to belong_to(:parent).optional(false)
+                end
+
+                message = format_message(<<-MESSAGE, one_line: true)
+                  Expected Child to have a belongs_to association called parent
+                  (and for the record to fail validation if :parent is
+                  unset; i.e., either the association should have been defined
+                  with `optional: false`, or there should be a presence
+                  validation on :parent)
+                MESSAGE
+
+                expect(&assertion).to fail_with_message(message)
+              end
+            end
+          end
+        else
+          it 'passes' do
+            expect(belonging_to_parent).to belong_to(:parent).optional(false)
           end
         end
       end

--- a/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -587,7 +587,7 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
         end
       end
 
-      context 'when qualified with optional' do
+      context 'when qualified with optional(true)' do
         it 'fails with an appropriate message' do
           assertion = lambda do
             expect(belonging_to_parent(required: true)).
@@ -603,6 +603,13 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
           MESSAGE
 
           expect(&assertion).to fail_with_message(message)
+        end
+      end
+
+      context 'when qualified with optional(false)' do
+        it 'passes' do
+          expect(belonging_to_parent(required: true)).
+            to belong_to(:parent).optional(false)
         end
       end
 
@@ -640,10 +647,28 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
           end
         end
 
-        context 'when qualified with optional' do
+        context 'when qualified with optional(true)' do
           it 'passes' do
             expect(belonging_to_parent(optional: true)).
               to belong_to(:parent).optional
+          end
+        end
+
+        context 'when qualified with optional(false)' do
+          it 'fails with an appropriate message' do
+            assertion = lambda do
+              expect(belonging_to_parent(optional: true)).
+                to belong_to(:parent).optional(false)
+            end
+
+            message = format_message(<<-MESSAGE, one_line: true)
+              Expected Child to have a belongs_to association called parent
+              (and for the record to fail validation if :parent is unset; i.e.,
+              either the association should have been defined with `optional:
+              false`, or there should be a presence validation on :parent)
+            MESSAGE
+
+            expect(&assertion).to fail_with_message(message)
           end
         end
 


### PR DESCRIPTION
Allows `belongs_to` associations with `optional: false`

```ruby
belongs_to :copany, optional: false
```

to be tested with

```ruby
it { should belong_to(:copany).optional(false) }
```

It also adds support for `optional(true)` which is the same as just `optional`.

Fixes #1219 