### PR TITLE
Fix typo in documentation of allow_values

### DIFF
--- a/lib/shoulda/matchers/active_model/allow_value_matcher.rb
+++ b/lib/shoulda/matchers/active_model/allow_value_matcher.rb
@@ -41,7 +41,7 @@ module Shoulda
       #       end
       #
       #       it do
-      #         should_not allow_values('http://foo.com', 'buz').
+      #         should_not allow_values('foo', 'buz').
       #           for(:website_url)
       #       end
       #     end
@@ -51,7 +51,7 @@ module Shoulda
       #       should allow_values('http://foo.com', 'http://bar.com/baz').
       #         for(:website_url)
       #
-      #       should_not allow_values('http://foo.com', 'buz').
+      #       should_not allow_values('foo', 'buz').
       #         for(:website_url)
       #     end
       #


### PR DESCRIPTION
Example in allow_values was wrong. It provides a valid value while using
should_not allow_values, so the test was failling but it was claiming in
documentation that the test will pass