### PR TITLE
Remove minitest reporters

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -21,7 +21,6 @@ shared_spring_dependencies = proc do
 end
 
 shared_test_dependencies = proc do
-  gem 'minitest-reporters'
   gem 'rspec-rails', '~> 3.6'
   gem 'shoulda-context', '~> 1.2.0'
 end

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -23,7 +23,6 @@ gem "therubyrhino", platform: :jruby
 gem "sqlite3", "~> 1.3.6", platform: :ruby
 gem "spring"
 gem "spring-commands-rspec"
-gem "minitest-reporters"
 gem "rspec-rails", "~> 3.6"
 gem "shoulda-context", "~> 1.2.0"
 gem "rails", "~> 4.2.11.1"

--- a/gemfiles/rails_4_2.gemfile.lock
+++ b/gemfiles/rails_4_2.gemfile.lock
@@ -86,11 +86,6 @@ GEM
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
-    minitest-reporters (1.1.14)
-      ansi
-      builder
-      minitest (>= 5.0)
-      ruby-progressbar
     multi_json (1.12.2)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
@@ -235,7 +230,6 @@ DEPENDENCIES
   jquery-rails
   jruby-openssl
   json (~> 1.4)
-  minitest-reporters
   pg (~> 0.15)
   protected_attributes (~> 1.0.6)
   pry

--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -23,7 +23,6 @@ gem "therubyrhino", platform: :jruby
 gem "sqlite3", "~> 1.3.6", platform: :ruby
 gem "spring"
 gem "spring-commands-rspec"
-gem "minitest-reporters"
 gem "rspec-rails", "~> 3.6"
 gem "shoulda-context", "~> 1.2.0"
 gem "rails", "~> 5.0.7.2"

--- a/gemfiles/rails_5_0.gemfile.lock
+++ b/gemfiles/rails_5_0.gemfile.lock
@@ -79,11 +79,6 @@ GEM
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
-    minitest-reporters (1.1.14)
-      ansi
-      builder
-      minitest (>= 5.0)
-      ruby-progressbar
     multi_json (1.12.2)
     nio4r (2.3.1)
     nokogiri (1.10.3)
@@ -227,7 +222,6 @@ DEPENDENCIES
   jquery-rails
   jruby-openssl
   listen (~> 3.0.5)
-  minitest-reporters
   pg (~> 1.1)
   pry
   pry-byebug

--- a/gemfiles/rails_5_1.gemfile
+++ b/gemfiles/rails_5_1.gemfile
@@ -23,7 +23,6 @@ gem "therubyrhino", platform: :jruby
 gem "sqlite3", "~> 1.3.6", platform: :ruby
 gem "spring"
 gem "spring-commands-rspec"
-gem "minitest-reporters"
 gem "rspec-rails", "~> 3.6"
 gem "shoulda-context", "~> 1.2.0"
 gem "rails", "~> 5.1.6.2"

--- a/gemfiles/rails_5_1.gemfile.lock
+++ b/gemfiles/rails_5_1.gemfile.lock
@@ -87,11 +87,6 @@ GEM
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
-    minitest-reporters (1.3.4)
-      ansi
-      builder
-      minitest (>= 5.0)
-      ruby-progressbar
     multi_json (1.13.1)
     nio4r (2.3.1)
     nokogiri (1.10.3)
@@ -243,7 +238,6 @@ DEPENDENCIES
   jdbc-sqlite3
   jruby-openssl
   listen (>= 3.0.5, < 3.2)
-  minitest-reporters
   pg (~> 1.1)
   pry
   pry-byebug

--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -23,7 +23,6 @@ gem "therubyrhino", platform: :jruby
 gem "sqlite3", "~> 1.3.6", platform: :ruby
 gem "spring"
 gem "spring-commands-rspec"
-gem "minitest-reporters"
 gem "rspec-rails", "~> 3.6"
 gem "shoulda-context", "~> 1.2.0"
 gem "rails", "~> 5.2.2.1"

--- a/gemfiles/rails_5_2.gemfile.lock
+++ b/gemfiles/rails_5_2.gemfile.lock
@@ -102,11 +102,6 @@ GEM
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
-    minitest-reporters (1.3.4)
-      ansi
-      builder
-      minitest (>= 5.0)
-      ruby-progressbar
     msgpack (1.2.4)
     multi_json (1.13.1)
     nio4r (2.3.1)
@@ -262,7 +257,6 @@ DEPENDENCIES
   jdbc-sqlite3
   jruby-openssl
   listen (>= 3.0.5, < 3.2)
-  minitest-reporters
   pg (~> 1.1)
   pry
   pry-byebug

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -23,7 +23,6 @@ gem "therubyrhino", platform: :jruby
 gem "sqlite3", "~> 1.3.6", platform: :ruby
 gem "spring"
 gem "spring-commands-rspec"
-gem "minitest-reporters"
 gem "rspec-rails", "~> 3.6"
 gem "shoulda-context", "~> 1.2.0"
 gem "rails", "~> 6.0.0.beta3"

--- a/gemfiles/rails_6_0.gemfile.lock
+++ b/gemfiles/rails_6_0.gemfile.lock
@@ -115,11 +115,6 @@ GEM
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
-    minitest-reporters (1.3.6)
-      ansi
-      builder
-      minitest (>= 5.0)
-      ruby-progressbar
     msgpack (1.2.9)
     multi_json (1.13.1)
     nio4r (2.3.1)
@@ -285,7 +280,6 @@ DEPENDENCIES
   jdbc-sqlite3
   jruby-openssl
   listen (>= 3.0.5, < 3.2)
-  minitest-reporters
   pg (~> 1.1)
   pry
   pry-byebug

--- a/spec/acceptance/independent_matchers_spec.rb
+++ b/spec/acceptance/independent_matchers_spec.rb
@@ -52,7 +52,7 @@ describe 'shoulda-matchers has independent matchers, specifically delegate_metho
       FILE
     end
 
-    result = run_n_unit_tests('test/courier_test.rb')
+    result = run_n_unit_tests('test/courier_test.rb - -v')
 
     expect(result).to indicate_number_of_tests_was_run(1)
     expect(result).to have_output(

--- a/spec/support/acceptance/helpers/step_helpers.rb
+++ b/spec/support/acceptance/helpers/step_helpers.rb
@@ -28,13 +28,8 @@ module AcceptanceTests
     end
 
     def add_minitest_to_project
-      add_gem 'minitest-reporters'
-
       append_to_file 'test/test_helper.rb', <<-FILE
         require 'minitest/autorun'
-        require 'minitest/reporters'
-
-        Minitest::Reporters.use!(Minitest::Reporters::SpecReporter.new)
       FILE
     end
 


### PR DESCRIPTION
It does not look like minitest-reporters dependency provides any benefit to the test suite. Lets drop it.