### PR TITLE
Fix appraisal command in CONTRIBUTING.md file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,7 +142,7 @@ is created and loaded every time you start running tests.
 To run a unit test, you might say something like:
 
 ```bash
-bundle exec appraisal 5.2 rspec spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb
+bundle exec appraisal rails_5_2 rspec spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb
 ```
 
 ### Acceptance tests
@@ -154,7 +154,7 @@ each test.
 To run an acceptance test, you might say something like:
 
 ```bash
-bundle exec appraisal 5.2 rspec spec/acceptance/rails_integration_spec.rb
+bundle exec appraisal rails_5_2 rspec spec/acceptance/rails_integration_spec.rb
 ```
 
 ### All tests


### PR DESCRIPTION
Hello, I was following the CONTRIBUTING.md file.

At some point it suggest to run this command:

```bash
bundle exec appraisal 5.2 rspec spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb
```

But instead of running the tests, it returned:

```bash
bundler: command not found: 5.2
```

So I tried to see the available list of appraisals by running:

```bash
bundle exec appraisal list
```

And this is what I got:

```bash
rails_4_2
rails_5_0
rails_5_1
rails_5_2
rails_6_0
```

Then I replaced the `5.2` with `rails_5_2` and the command worked.