### PR TITLE
Fix intermittent test failures

### DIFF
--- a/spec/support/unit/helpers/model_builder.rb
+++ b/spec/support/unit/helpers/model_builder.rb
@@ -71,6 +71,7 @@ module UnitTests
           options,
           &block
         )
+        model.reset_column_information
         defined_models << model
         model
       end
@@ -86,10 +87,6 @@ module UnitTests
         elsif ::ActiveRecord::Base.connection_pool.respond_to?(:clear_cache!)
           DevelopmentRecord.connection_pool.clear_cache!
           ProductionRecord.connection_pool.clear_cache!
-        end
-
-        defined_models.each do |model|
-          model.reset_column_information
         end
       end
 


### PR DESCRIPTION
Hi, this pull request is a draft for now.

I'm looking for a solution to the issue #1262.

Below are some notes about the problem.

## How to recreate the error locally?

The smallest possible scenario for this error to happen:

```ruby
BUNDLE_GEMFILE=/path/to/shoulda-matchers/gemfiles/rails_X_X.gemfile bundle exec rspec './spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb[1:3:2:8:1:1:1,1:5:2:2:1:2:1]' --seed 7438
```

```bash
Shoulda::Matchers::ActiveRecord::ValidateUniquenessOfMatcher
  when the model has a case-insensitive validation
    when case_insensitive is specified
      it supports ignoring_interference_by_writer
        when the writer method for the attribute changes incoming values
          and the value change causes a test failure
            lists how the value got changed in the failure message
  when the model has a scoped uniqueness validation
    when one of the scoped attributes is a boolean column
      when there is more than one validation on the same attribute with different scopes
        when a record exists beforehand, where all scopes are set
          when each validation has a different message
            accepts (FAILED - 1)

Finished in X seconds (files took X seconds to load)
2 examples, 1 failure
```

If we try to run only the test that failed:

```ruby
BUNDLE_GEMFILE=/path/to/shoulda-matchers/gemfiles/rails_X_X.gemfile bundle exec rspec './spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb[1:3:2:8:1:1:1]' --seed 7438
```
It pass:

```
Shoulda::Matchers::ActiveRecord::ValidateUniquenessOfMatcher
  when the model has a scoped uniqueness validation
    when one of the scoped attributes is a boolean column
      when there is more than one validation on the same attribute with different scopes
        when a record exists beforehand, where all scopes are set
          when each validation has a different message
            accepts

Finished in X seconds (files took X seconds to load)
1 example, 0 failures
```

So what it's happening in the first test to make the second test to go wrong?

If we run these tests separetely will we see that the first test creates this record:
`#<Example:0x000055aa97f1c010 id: 1, attr: "some valuf">`

And when we try to run other alone it creates this:
`#<Example:0x00007fbb0404c128 id: 1, attr: "dummy value", scope1: true, scope2: true>`

Both pass!

But when we run both the second test creates this:
`#<Example:0x000055aa9a305828 id: 1, attr: "dummy value">`

Look, it's missing the scope1 and scope2. That's why the error [missing attribute: :scope1](https://travis-ci.org/thoughtbot/shoulda-matchers/jobs/622356910). This error is happening right [here](https://github.com/thoughtbot/shoulda-matchers/blob/master/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb#L580) after receive the scope1 as `attribute_name`.

One easy fix for this is to change the model name used in the second test, after that the record created in the second test has all his fields (including scope1 and scope2), but I'm don't think this is a good idea. I think I need to understand more about this feature to make a proper fix.

I'll keep digging! :smile: 

PS: My sincere thanks to thoughbot for this video, [rspec-bisect](https://thoughtbot.com/upcase/videos/rspec-bisect), it helped a lot to isolate the smallest possible scenario. Great video! :+1: :+1: :+1:  
