### PR TITLE
HaveSecureTokenMatcher: optional argument to ignore db index check

### DIFF
--- a/lib/shoulda/matchers/active_record/have_secure_token_matcher.rb
+++ b/lib/shoulda/matchers/active_record/have_secure_token_matcher.rb
@@ -41,6 +41,7 @@ module Shoulda
 
         def initialize(token_attribute)
           @token_attribute = token_attribute
+          @options = { ignore_check_for_db_index: false }
         end
 
         def description
@@ -65,6 +66,11 @@ module Shoulda
           @errors.empty?
         end
 
+        def ignoring_check_for_db_index
+          @options[:ignore_check_for_db_index] = true
+          self
+        end
+
         private
 
         def run_checks
@@ -75,7 +81,7 @@ module Shoulda
           if !has_expected_db_column?
             @errors << "missing correct column #{token_attribute}:string"
           end
-          if !has_expected_db_index?
+          if !@options[:ignore_check_for_db_index] && !has_expected_db_index?
             @errors << "missing unique index for #{table_and_column}"
           end
           @errors

--- a/spec/unit/shoulda/matchers/active_record/have_secure_token_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/have_secure_token_matcher_spec.rb
@@ -58,6 +58,16 @@ describe Shoulda::Matchers::ActiveRecord::HaveSecureTokenMatcher,
       end
     end
 
+    it 'matches when called with ignoring_check_for_db_index without db index' do
+      create_table(:users) do |t|
+        t.string :token
+      end
+
+      valid_model = define_model_class(:User) { has_secure_token }
+      expect(valid_model.new).
+        to have_secure_token.ignoring_check_for_db_index
+    end
+
     it 'does not match when missing a token column' do
       create_table(:users)
       invalid_model = define_model_class(:User) { has_secure_token }


### PR DESCRIPTION
Fixes https://github.com/thoughtbot/shoulda-matchers/issues/1277

`has_secure_token` [encourages](https://github.com/rails/rails/blob/a273da7619ac6a2b2f98532a5610238c68ad219b/activerecord/lib/active_record/secure_token.rb#L31) to use an index but does not enforce it.

This PR makes the check `has_expected_db_index?` optional.
The default behavior is not changed.