### PR TITLE
Add support to numericality: :other_than

### DIFF
--- a/lib/shoulda/matchers/active_model/numericality_matchers/comparison_matcher.rb
+++ b/lib/shoulda/matchers/active_model/numericality_matchers/comparison_matcher.rb
@@ -9,7 +9,8 @@ module Shoulda
             :>= => :greater_than_or_equal_to,
             :< => :less_than,
             :<= => :less_than_or_equal_to,
-            :== => :equal_to
+            :== => :equal_to,
+            :!= => :other_than,
           }
 
           def initialize(numericality_matcher, value, operator)
@@ -125,6 +126,8 @@ module Shoulda
               [true, false, false]
             when :<=
               [true, true, false]
+            when :!=
+               [true, false, true]
             end
           end
 
@@ -146,6 +149,7 @@ module Shoulda
               when :== then "equal to"
               when :< then "less than"
               when :<= then "less than or equal to"
+              when :!= then 'other than'
             end
           end
         end

--- a/lib/shoulda/matchers/active_model/validate_numericality_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_numericality_of_matcher.rb
@@ -204,6 +204,33 @@ module Shoulda
       #         is_greater_than(21)
       #     end
       #
+      # ##### is_other_than
+      #
+      # Use `is_other_than` to test usage of the `:other_than` option.
+      # This asserts that the attribute can take a number which is not equal to
+      # the given value.
+      #
+      #     class Person
+      #       include ActiveModel::Model
+      #       attr_accessor :legal_age
+      #
+      #       validates_numericality_of :legal_age, other_than: 21
+      #     end
+      #
+      #     # RSpec
+      #     RSpec.describe Person, type: :model do
+      #       it do
+      #         should validate_numericality_of(:legal_age).
+      #           is_other_than(21)
+      #       end
+      #     end
+      #
+      #     # Minitest (Shoulda)
+      #     class PersonTest < ActiveSupport::TestCase
+      #       should validate_numericality_of(:legal_age).
+      #         is_other_than(21)
+      #     end
+      #
       # ##### even
       #
       # Use `even` to test usage of the `:even` option. This asserts that the
@@ -392,6 +419,11 @@ module Shoulda
 
         def is_less_than_or_equal_to(value)
           prepare_submatcher(comparison_matcher_for(value, :<=).for(@attribute))
+          self
+        end
+
+        def is_other_than(value)
+          prepare_submatcher(comparison_matcher_for(value, :!=).for(@attribute))
           self
         end
 


### PR DESCRIPTION
Add support to validate numericality of a field when set :other_than comparison