### PR TITLE
Fix setup script for RedHat based Linux

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -154,11 +154,6 @@ install-dependencies() {
     start postgresql
   fi
 
-  if ! has-executable heroku; then
-    banner 'Installing Heroku'
-    install brew=heroku/brew/heroku heroku
-  fi
-
   if has-executable rbenv; then
     if ! (rbenv versions | grep $RUBY_VERSION'\>' &>/dev/null); then
       banner "Installing Ruby $RUBY_VERSION with rbenv"

--- a/bin/setup
+++ b/bin/setup
@@ -88,7 +88,7 @@ install() {
       sudo apt-get install -y "$package"
     fi
   elif has-executable yum; then
-    package="${yum_package:-$default_package}"
+    package="${rpm_package:-$default_package}"
 
     if [[ -n $package ]]; then
       sudo yum install -y "$package"
@@ -101,16 +101,20 @@ install() {
 
 check-for-build-tools() {
   if [[ $platform == "linux" ]]; then
-    if ! has-executable apt-get; then
+    if has-executable apt-get; then
+      # TODO: Check if build-essential is installed on Debian?
+      true
+    elif has-executable yum; then
+      # TODO: Check if 'Development Tools' group is installed on RedHat?
+      true
+    else
       error "You don't seem to have a package manager installed."
       echo-wrapped "\
-The setup script assumes you're using Debian or a Debian-derived flavor of
-Linux (i.e. something with Apt). If this is not the case, then we would
+The setup script assumes you're using Debian, RedHat or a derived flavor of
+Linux (i.e. something with Apt or Yum). If this is not the case, then we would
 gladly take a PR fixing this!"
       exit 1
     fi
-
-    # TODO: Check if build-essential is installed on Debian?
   else
     if ! has-executable brew; then
       error "You don't seem to have Homebrew installed."


### PR DESCRIPTION
`bin/setup` seems to have a partial implementation for RedHat based Linux distributions (i.e. those using RPM packages).

This completes what is there and as a side note drops the seemingly unused `heroku` requirement.

* Use `rpm=...` packages with `yum`
* Check for `yum` as a package manager
* Drop requirement on `heroku`

**Please note: I am not using a RedHat based Linux at the moment but have tested this out in a docker image for fedora:31 using rbenv to build ruby 2.6.5.**

Yum seems to be currently available in notable RPM distros:

* Fedora 22+ has adopted `dnf` in favour of `yum` but `yum` still seems to be available there.
* RHEL and CentOS 6 to 8 use `yum`