### PR TITLE
Truncate long values in descriptions.  Fixes #1041

### DIFF
--- a/lib/shoulda/matchers/util.rb
+++ b/lib/shoulda/matchers/util.rb
@@ -4,6 +4,8 @@ module Shoulda
   module Matchers
     # @private
     module Util
+      MAXIMUM_LENGTH_OF_VALUE_TO_DISPLAY = 500
+
       def self.deconstantize(path)
         if defined?(ActiveSupport::Inflector) &&
           ActiveSupport::Inflector.respond_to?(:deconstantize)
@@ -47,7 +49,12 @@ module Shoulda
         when Range
           inspect_range(value)
         else
-          "‹#{value.inspect}›"
+          inspected_value = value.inspect
+          if inspected_value.length > MAXIMUM_LENGTH_OF_VALUE_TO_DISPLAY
+            "‹#{inspected_value[0, MAXIMUM_LENGTH_OF_VALUE_TO_DISPLAY]}...›"
+          else
+            "‹#{inspected_value}›"
+          end
         end
       end
 

--- a/spec/unit/shoulda/matchers/active_model/allow_value_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/allow_value_matcher_spec.rb
@@ -41,6 +41,12 @@ describe Shoulda::Matchers::ActiveModel::AllowValueMatcher, type: :model do
         )
       end
     end
+
+    it 'truncates the description when long' do
+      matcher = allow_value("A" * 10000).for(:baz)
+
+      expect(matcher.description).to eq "allow :baz to be ‹\"#{"A" * 499}...›"
+    end
   end
 
   describe '#_after_setting_value' do


### PR DESCRIPTION
@mcmire Thanks for reminding me about #1041 by closing it!

Here's the commit I referenced there, rebased onto the latest master.