### PR TITLE
Fix exception raised by ActiveSupport Object#in?

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
@@ -327,8 +327,8 @@ validation for you? Instead of using `validate_presence_of`, try
         end
 
         def collection_association?
-          association? && association_reflection.macro.in?(
-            [:has_many, :has_and_belongs_to_many],
+          association? && [:has_many, :has_and_belongs_to_many].include?(
+            association_reflection.macro
           )
         end
 


### PR DESCRIPTION
PR #879 refactored to replace invocations of `ActiveSupport`'s' `#in?`
method. This patch follows suit to fix the following exception, which 
occurs when `ActiveSupport` isn't a project dependency:

```
1) Stocking is expected to validate that :bin cannot be empty/falsy
    Failure/Error: it { should validate_presence_of(:bin) }

    NoMethodError:
      undefined method `in?' for :belongs_to:Symbol
      Did you mean?  nil?
```