### PR TITLE
Update rack to 2.2.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ GEM
       pry (~> 0.10)
     pygments.rb (1.2.1)
       multi_json (>= 1.0.0)
-    rack (2.0.8)
+    rack (2.2.2)
     rainbow (3.0.0)
     rake (13.0.1)
     redcarpet (3.5.0)

--- a/gemfiles/rails_4_2.gemfile.lock
+++ b/gemfiles/rails_4_2.gemfile.lock
@@ -101,7 +101,7 @@ GEM
       pry (~> 0.10)
     pygments.rb (1.2.1)
       multi_json (>= 1.0.0)
-    rack (1.6.12)
+    rack (1.6.13)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.11.1)

--- a/gemfiles/rails_5_0.gemfile.lock
+++ b/gemfiles/rails_5_0.gemfile.lock
@@ -94,7 +94,7 @@ GEM
     puma (3.12.2)
     pygments.rb (1.2.1)
       multi_json (>= 1.0.0)
-    rack (2.0.8)
+    rack (2.2.2)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (5.0.7.2)

--- a/gemfiles/rails_5_1.gemfile.lock
+++ b/gemfiles/rails_5_1.gemfile.lock
@@ -102,7 +102,7 @@ GEM
     puma (3.12.2)
     pygments.rb (1.2.1)
       multi_json (>= 1.0.0)
-    rack (2.0.8)
+    rack (2.2.2)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.1.7)

--- a/gemfiles/rails_5_2.gemfile.lock
+++ b/gemfiles/rails_5_2.gemfile.lock
@@ -118,7 +118,7 @@ GEM
     puma (3.12.2)
     pygments.rb (1.2.1)
       multi_json (>= 1.0.0)
-    rack (2.0.8)
+    rack (2.2.2)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.4.1)

--- a/gemfiles/rails_6_0.gemfile.lock
+++ b/gemfiles/rails_6_0.gemfile.lock
@@ -127,7 +127,7 @@ GEM
       nio4r (~> 2.0)
     pygments.rb (1.2.1)
       multi_json (>= 1.0.0)
-    rack (2.0.8)
+    rack (2.2.2)
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)


### PR DESCRIPTION
This includes a fix for CVE-2020-8161.