### PR TITLE
Remove webpacker from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ matrix:
 cache: bundler
 # Source: <https://docs.travis-ci.com/user/languages/ruby/#bundler-20>
 before_install:
-  - nvm install 12
   - gem update --system '2.7.8' --no-document
   - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
   - gem install bundler -v '< 2' --no-document

--- a/Appraisals
+++ b/Appraisals
@@ -116,7 +116,6 @@ if Gem::Requirement.new('>= 2.5.0').satisfied_by?(Gem::Version.new(RUBY_VERSION)
     gem 'puma', '~> 4.1'
     gem 'bootsnap', '>= 1.4.2', require: false
     gem 'sass-rails', '>= 6'
-    gem 'webpacker', '~> 4.0'
     gem 'turbolinks', '~> 5'
     gem 'jbuilder', '~> 2.7'
     gem 'bcrypt', '~> 3.1.7'

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -24,7 +24,6 @@ gem "rails", "6.0.2.1"
 gem "puma", "~> 4.1"
 gem "bootsnap", ">= 1.4.2", require: false
 gem "sass-rails", ">= 6"
-gem "webpacker", "~> 4.0"
 gem "turbolinks", "~> 5"
 gem "jbuilder", "~> 2.7"
 gem "bcrypt", "~> 3.1.7"

--- a/gemfiles/rails_6_0.gemfile.lock
+++ b/gemfiles/rails_6_0.gemfile.lock
@@ -128,8 +128,6 @@ GEM
     pygments.rb (1.2.1)
       multi_json (>= 1.0.0)
     rack (2.2.2)
-    rack-proxy (0.6.5)
-      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.0.2.1)
@@ -244,10 +242,6 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (>= 3.0, < 4.0)
-    webpacker (4.2.2)
-      activesupport (>= 4.2)
-      rack-proxy (>= 0.6.1)
-      railties (>= 4.2)
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
@@ -293,7 +287,6 @@ DEPENDENCIES
   sqlite3 (~> 1.4)
   turbolinks (~> 5)
   webdrivers
-  webpacker (~> 4.0)
   yard
   zeus
 

--- a/spec/support/acceptance/helpers/step_helpers.rb
+++ b/spec/support/acceptance/helpers/step_helpers.rb
@@ -58,8 +58,11 @@ module AcceptanceTests
 
     def create_rails_application
       fs.clean
-
-      command = "bundle exec rails new #{fs.project_directory} --skip-bundle --no-rc"
+      if rails_version =~ '~> 6.0'
+        command = "bundle exec rails new #{fs.project_directory} --skip-bundle --skip-javascript --no-rc"
+      else
+        command = "bundle exec rails new #{fs.project_directory} --skip-bundle --no-rc"
+      end
 
       run_command!(command) do |runner|
         runner.directory = nil


### PR DESCRIPTION
 - Remove webpacker gem from Appraisals for version 6.0.
 - Remove nvm installation before running CI tests
 - On acceptance tests, generate apps without webpacker

Conditionally include --skip-javascript in rails 6.0