### PR TITLE
word_wrap: fix Ruby 2.7 warning

### DIFF
--- a/lib/shoulda/matchers/util/word_wrap.rb
+++ b/lib/shoulda/matchers/util/word_wrap.rb
@@ -5,7 +5,7 @@ module Shoulda
       TERMINAL_WIDTH = 72
 
       def word_wrap(document, options = {})
-        Document.new(document, options).wrap
+        Document.new(document, **options).wrap
       end
     end
 


### PR DESCRIPTION
This fixes the following warning:

```
vendor/gems/ruby/2.7.0/gems/shoulda-matchers-4.3.0/lib/shoulda/matchers/util/word_wrap.rb:8: 
  warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```