### PR TITLE
Fix habtm matcher to support symbols for join_table

### DIFF
--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -920,21 +920,21 @@ module Shoulda
       # asserts that the table you're referring to actually exists.
       #
       #     class Person < ActiveRecord::Base
-      #       has_and_belongs_to_many :issues, join_table: 'people_tickets'
+      #       has_and_belongs_to_many :issues, join_table: :people_tickets
       #     end
       #
       #     # RSpec
       #     RSpec.describe Person, type: :model do
       #       it do
       #         should have_and_belong_to_many(:issues).
-      #           join_table('people_tickets')
+      #           join_table(:people_tickets)
       #       end
       #     end
       #
       #     # Minitest (Shoulda)
       #     class PersonTest < ActiveSupport::TestCase
       #       should have_and_belong_to_many(:issues).
-      #         join_table('people_tickets')
+      #         join_table(:people_tickets)
       #     end
       #
       # ##### validate

--- a/lib/shoulda/matchers/active_record/association_matchers/join_table_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matchers/join_table_matcher.rb
@@ -29,7 +29,7 @@ module Shoulda
               if option_verifier.correct_for_string?(:join_table, options[:join_table_name])
                 true
               else
-                @failure_message = "#{name} should use '#{options[:join_table_name]}' for :join_table option"
+                @failure_message = "#{name} should use #{options[:join_table_name].inspect} for :join_table option"
                 false
               end
             else
@@ -38,7 +38,7 @@ module Shoulda
           end
 
           def join_table_exists?
-            if RailsShim.tables_and_views(connection).include?(join_table_name)
+            if RailsShim.tables_and_views(connection).include?(join_table_name.to_s)
               true
             else
               @failure_message = missing_table_message


### PR DESCRIPTION
The fix is simple but required slightly rewriting the tests, as it turns
out the existing tests weren't exercising all of the possible checks
that join_table makes.

---

Fixes #1321.