### PR TITLE
Release v4.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 4.4.0 - 2020-08-25
 
 ### Bug fixes
 

--- a/lib/shoulda/matchers/version.rb
+++ b/lib/shoulda/matchers/version.rb
@@ -1,6 +1,6 @@
 module Shoulda
   module Matchers
     # @private
-    VERSION = '4.3.0'.freeze
+    VERSION = '4.4.0'.freeze
   end
 end


### PR DESCRIPTION
### Features

* Add an `ignoring_check_for_db_index` qualifier to the `have_secure_token`
  matcher, since `has_secure_token` encourages use of an index but does not
  enforce it. ([#1278])

* Add `allow_blank` to `validate_length_of` to match other validation matchers.
  ([#725], [#1318])

* Add new matcher `have_implicit_order_column` which can be used to test the
  `implicit_order_column` setting for ActiveRecord models under Rails 6+.
  ([#1243])

* Add a new `is_other_than` qualifier to `validate_numericality_of` to be able
  to test the numericality validation's `:other_than` option. ([#1282])

* Add a new `have_one_attached` and `have_many_attached` matchers for testing
  the new model-level ActiveStorage macros in Rails 6. ([#1102])

[#1278]: https://github.com/thoughtbot/shoulda-matchers/pull/1278
[#725]: https://github.com/thoughtbot/shoulda-matchers/pull/725
[#1318]: https://github.com/thoughtbot/shoulda-matchers/pull/1318
[#1243]: https://github.com/thoughtbot/shoulda-matchers/pull/1243
[#1282]: https://github.com/thoughtbot/shoulda-matchers/pull/1282
[#1102]: https://github.com/thoughtbot/shoulda-matchers/pull/1102

### Bug fixes

* Fix performance of `allow_value` so that it doesn't hang if the given value is
  really long. ([#1290])

* Fix `have_many` so that it is possible to test an association that has a scope
  that takes an argument. ([#952], [#992])

* Update `validate_uniqueness_of` to use the public `validators_on` instead of
  the private `_validators` when reading validations off of a model. This
  enables shoulda-matchers to be used with the [schema_validations] gem.
  ([#995])

* Update `validate_uniqueness_of` to work with scopes that are `time` columns.
  ([#1190])

* Fix `have_and_belong_to_many` so that when using the `join_table` qualifier
  you can pass a symbol rather than a string. ([#1323])

[#1290]: https://github.com/thoughtbot/shoulda-matchers/issues/952
[#952]: https://github.com/thoughtbot/shoulda-matchers/issues/952
[#992]: https://github.com/thoughtbot/shoulda-matchers/pull/992
[schema_validations]: https://github.com/SchemaPlus/schema_validations
[#995]: https://github.com/thoughtbot/shoulda-matchers/pull/995
[#1190]: https://github.com/thoughtbot/shoulda-matchers/pull/1190
[#1323]: https://github.com/thoughtbot/shoulda-matchers/pull/1323

### Improvements

* Update `have_many` when used against a `:through` association so that it fails
  if the inverse model does not have a `belongs_to` association. ([#646],
  [#723], [c0a1578])

* Add Ruby 2.7 to test matrix and default development Ruby. ([#1310])

* Remove warnings emitted on Ruby 2.7 in `word_wrap`. ([#1314])

* Remove warnings emitted on Ruby 2.7 in Doublespeak. ([#1328])

* Clean up requires within the code by converting them to `autoload`s. ([#1320])

[#646]: https://github.com/thoughtbot/shoulda-matchers/issues/646
[#723]: https://github.com/thoughtbot/shoulda-matchers/pull/723
[c0a1578]: https://github.com/thoughtbot/shoulda-matchers/commit/c0a1578435f66d6fbf0db1164205bd8d99f6aa2f
[#1310]: https://github.com/thoughtbot/shoulda-matchers/pull/1310
[#1314]: https://github.com/thoughtbot/shoulda-matchers/pull/1314
[#1328]: https://github.com/thoughtbot/shoulda-matchers/pull/1328
[#1320]: https://github.com/thoughtbot/shoulda-matchers/pull/1320