### PR TITLE
Release v4.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 4.4.1 - 2020-08-26
+
+### Bug fixes
+
+* Revert reorganization around autoloading introduced in 4.4.0 which prevented
+  matchers from being loaded. ([#1334])
+
+[#1334]: https://github.com/thoughtbot/shoulda-matchers/pulls/1334
+
 ## 4.4.0 - 2020-08-25
 
 ### Bug fixes

--- a/lib/shoulda/matchers/version.rb
+++ b/lib/shoulda/matchers/version.rb
@@ -1,6 +1,6 @@
 module Shoulda
   module Matchers
     # @private
-    VERSION = '4.4.0'.freeze
+    VERSION = '4.4.1'.freeze
   end
 end


### PR DESCRIPTION
### Bug fixes

* Revert reorganization around autoloading introduced in 4.4.0 which prevented
  matchers from being loaded. ([#1334])

[#1334]: https://github.com/thoughtbot/shoulda-matchers/pulls/1334