### PR TITLE
fix(docs): Rename remaining NEWS to CHANGELOG [ci skip]

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -6,5 +6,5 @@
 --hide-tag param
 -e ./doc_config/yard/setup.rb
 -
-NEWS.md
+CHANGELOG.md
 docs/**/*.md

--- a/shoulda-matchers.gemspec
+++ b/shoulda-matchers.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.description = 'Shoulda Matchers provides RSpec- and Minitest-compatible one-liners to test common Rails functionality that, if written by hand, would be much longer, more complex, and error-prone.'
   s.metadata    = {
     'bug_tracker_uri' => 'https://github.com/thoughtbot/shoulda-matchers/issues',
-    'changelog_uri' => 'https://github.com/thoughtbot/shoulda-matchers/blob/master/NEWS.md',
+    'changelog_uri' => 'https://github.com/thoughtbot/shoulda-matchers/blob/master/CHANGELOG.md',
     'documentation_uri' => 'https://matchers.shoulda.io/docs',
     'homepage_uri' => 'https://matchers.shoulda.io',
     'source_code_uri' => 'https://github.com/thoughtbot/shoulda-matchers',

--- a/tasks/documentation.rb
+++ b/tasks/documentation.rb
@@ -54,7 +54,7 @@ module Shoulda
 
             FSSM.monitor do
               path project_directory do
-                glob '{README.md,NEWS.md,.yardopts,docs/**/*.md,doc_config/yard/**/*.{rb,js,css,erb},lib/**/*.rb}'
+                glob '{README.md,CHANGELOG.md,.yardopts,docs/**/*.md,doc_config/yard/**/*.{rb,js,css,erb},lib/**/*.rb}'
                 create(&regenerate_docs)
                 update(&regenerate_docs)
               end


### PR DESCRIPTION
Related to #1308 which renamed NEWS.md to CHANGELOG.md