### PR TITLE
Increase rails integration tests

### DIFF
--- a/spec/acceptance/rails_integration_spec.rb
+++ b/spec/acceptance/rails_integration_spec.rb
@@ -8,18 +8,6 @@ describe 'shoulda-matchers integrates with Rails' do
     # TODO: ActionController matchers
     # configure_routes_with_single_wildcard_route
 
-    # if rails_gt_5? && bundle.includes?('actiontext')
-    #   run_rake_tasks!('action_text:install:migrations')
-    # end
-
-    # if rails_gte_5_2? && bundle.includes?('activestorage')
-    #   run_rake_tasks!('active_storage:install:migrations')
-    # end
-
-    # TODO: Fix uninitialized constant Rails
-
-    run_rake_tasks!('action_text:install:migrations')
-    run_rake_tasks!('active_storage:install:migrations')
     run_rake_tasks!('db:drop', 'db:create', 'db:migrate')
   end
 
@@ -90,42 +78,7 @@ describe 'shoulda-matchers integrates with Rails' do
   end
 
   def run_tests_for_n_unit
-    write_file 'test/unit/user_test.rb', <<-FILE
-      require 'test_helper'
-
-      class UserTest < ActiveSupport::TestCase
-        # ActiveModel matchers
-        should allow_value('https://foo.com').for(:website_url)
-        should have_secure_password
-        should validate_absence_of(:first_name)
-        should validate_acceptance_of(:terms_of_service)
-        should validate_confirmation_of(:email)
-        should validate_exclusion_of(:age).in_array(0..17)
-        should validate_inclusion_of(:role).in_array(%w( admin manager ))
-        should validate_length_of(:password).is_at_least(10).on(:create)
-        should validate_numericality_of(:number_of_dependents).on(:create)
-        should validate_presence_of(:email)
-
-        # ActiveRecord matchers
-        should have_many(:issues)
-        should accept_nested_attributes_for(:issues)
-        should belong_to(:organization)
-        should define_enum_for(:status)
-        should have_and_belong_to_many(:categories)
-        should have_db_column(:email)
-        should have_db_index(:organization_id)
-        should have_implicit_order_column(:created_at)
-        should have_many_attached(:photos)
-        should have_one(:profile)
-        should have_one_attached(:avatar)
-        should have_readonly_attribute(:username)
-        should have_rich_text(:description)
-        should serialize(:social_networks)
-        should validate_uniqueness_of(:email)
-      end
-    FILE
-
-    # TODO: ActionController matchers tests
+    create_files_for_minitest
 
     result = run_n_unit_test_suite
 
@@ -133,64 +86,10 @@ describe 'shoulda-matchers integrates with Rails' do
   end
 
   def run_tests_for_rspec
-    add_rspec_file 'spec/models/user_spec.rb', <<-FILE
-      describe User do
-        # ActiveModel matchers
-        it { should allow_value('https://foo.com').for(:website_url) }
-        it { should have_secure_password }
-        it { should validate_absence_of(:first_name) }
-        it { should validate_acceptance_of(:terms_of_service) }
-        it { should validate_confirmation_of(:email) }
-        it { should validate_exclusion_of(:age).in_array(0..17) }
-        it { should validate_inclusion_of(:role).in_array(%w( admin manager )) }
-        it { should validate_length_of(:password).is_at_least(10).on(:create) }
-        it { should validate_numericality_of(:number_of_dependents).on(:create) }
-        it { should validate_presence_of(:email) }
-
-        # ActiveRecord matchers
-        it { should have_many(:issues) }
-        it { should accept_nested_attributes_for(:issues) }
-        it { should belong_to(:organization) }
-        it { should define_enum_for(:status) }
-        it { should have_and_belong_to_many(:categories) }
-        it { should have_db_column(:email) }
-        it { should have_db_index(:organization_id) }
-        it { should have_implicit_order_column(:created_at) } # Rails 6 +
-        it { should have_many_attached(:photos) }             # Rails 5.2 +
-        it { should have_one(:profile) }
-        it { should have_one_attached(:avatar) }              # Rails 5.2 +
-        it { should have_readonly_attribute(:username) }
-        it { should have_rich_text(:description) }            # Rails 6 +
-        it { should serialize(:social_networks) }
-        it { should validate_uniqueness_of(:email) }
-      end
-    FILE
-
-    # TODO: ActionController matchers tests
+    create_files_for_rspec
 
     result = run_rspec_suite
 
     expect(result).to have_output("#{number_of_unit_tests} examples, 0 failures")
-  end
-
-  # TODO: Change the number depending the rails version
-  def number_of_unit_tests
-    # if rails_gt_5?
-    #   25
-    # elsif rails_gte_5_2?
-    #   # Note: It should not test:
-    #   # - have_implicit_order_column
-    #   # - have_rich_text
-    #   23
-    # else
-    #   # Note: It should not test:
-    #   # - have_implicit_order_column
-    #   # - have_many_attached matchers
-    #   # - have_one_attached
-    #   # - have_rich_text
-    #   21
-    # end
-
-    25
   end
 end

--- a/spec/acceptance/rails_integration_spec.rb
+++ b/spec/acceptance/rails_integration_spec.rb
@@ -5,9 +5,6 @@ describe 'shoulda-matchers integrates with Rails' do
     create_rails_application
     create_files_in_rails_application
 
-    # TODO: ActionController matchers
-    # configure_routes_with_single_wildcard_route
-
     run_rake_tasks!('db:drop', 'db:create', 'db:migrate')
   end
 
@@ -82,7 +79,7 @@ describe 'shoulda-matchers integrates with Rails' do
 
     result = run_n_unit_test_suite
 
-    expect(result).to indicate_that_tests_were_run(unit: number_of_unit_tests)
+    expect(result).to indicate_that_tests_were_run(unit: number_of_unit_tests, functional: number_of_functional_tests)
   end
 
   def run_tests_for_rspec
@@ -90,6 +87,12 @@ describe 'shoulda-matchers integrates with Rails' do
 
     result = run_rspec_suite
 
-    expect(result).to have_output("#{number_of_unit_tests} examples, 0 failures")
+    expect(result).to have_output("#{tests_count} examples, 0 failures")
   end
+
+  def tests_count
+    number_of_unit_tests + number_of_functional_tests
+  end
+
+  let(:number_of_functional_tests) { 3 }
 end

--- a/spec/acceptance/rails_integration_spec.rb
+++ b/spec/acceptance/rails_integration_spec.rb
@@ -3,11 +3,23 @@ require 'acceptance_spec_helper'
 describe 'shoulda-matchers integrates with Rails' do
   before do
     create_rails_application
-    write_files_in_rails_application
+    create_files_in_rails_application
 
     # TODO: ActionController matchers
     # configure_routes_with_single_wildcard_route
 
+    # if rails_gt_5? && bundle.includes?('actiontext')
+    #   run_rake_tasks!('action_text:install:migrations')
+    # end
+
+    # if rails_gte_5_2? && bundle.includes?('activestorage')
+    #   run_rake_tasks!('active_storage:install:migrations')
+    # end
+
+    # TODO: Fix uninitialized constant Rails
+
+    run_rake_tasks!('action_text:install:migrations')
+    run_rake_tasks!('active_storage:install:migrations')
     run_rake_tasks!('db:drop', 'db:create', 'db:migrate')
   end
 
@@ -94,7 +106,22 @@ describe 'shoulda-matchers integrates with Rails' do
         should validate_numericality_of(:number_of_dependents).on(:create)
         should validate_presence_of(:email)
 
-        # TODO: ActiveRecord matchers
+        # ActiveRecord matchers
+        should have_many(:issues)
+        should accept_nested_attributes_for(:issues)
+        should belong_to(:organization)
+        should define_enum_for(:status)
+        should have_and_belong_to_many(:categories)
+        should have_db_column(:email)
+        should have_db_index(:organization_id)
+        should have_implicit_order_column(:created_at)
+        should have_many_attached(:photos)
+        should have_one(:profile)
+        should have_one_attached(:avatar)
+        should have_readonly_attribute(:username)
+        should have_rich_text(:description)
+        should serialize(:social_networks)
+        should validate_uniqueness_of(:email)
       end
     FILE
 
@@ -102,7 +129,7 @@ describe 'shoulda-matchers integrates with Rails' do
 
     result = run_n_unit_test_suite
 
-    expect(result).to indicate_that_tests_were_run(unit: 10)
+    expect(result).to indicate_that_tests_were_run(unit: number_of_unit_tests)
   end
 
   def run_tests_for_rspec
@@ -120,7 +147,22 @@ describe 'shoulda-matchers integrates with Rails' do
         it { should validate_numericality_of(:number_of_dependents).on(:create) }
         it { should validate_presence_of(:email) }
 
-        # TODO: ActiveRecord matchers
+        # ActiveRecord matchers
+        it { should have_many(:issues) }
+        it { should accept_nested_attributes_for(:issues) }
+        it { should belong_to(:organization) }
+        it { should define_enum_for(:status) }
+        it { should have_and_belong_to_many(:categories) }
+        it { should have_db_column(:email) }
+        it { should have_db_index(:organization_id) }
+        it { should have_implicit_order_column(:created_at) } # Rails 6 +
+        it { should have_many_attached(:photos) }             # Rails 5.2 +
+        it { should have_one(:profile) }
+        it { should have_one_attached(:avatar) }              # Rails 5.2 +
+        it { should have_readonly_attribute(:username) }
+        it { should have_rich_text(:description) }            # Rails 6 +
+        it { should serialize(:social_networks) }
+        it { should validate_uniqueness_of(:email) }
       end
     FILE
 
@@ -128,6 +170,27 @@ describe 'shoulda-matchers integrates with Rails' do
 
     result = run_rspec_suite
 
-    expect(result).to have_output('10 examples, 0 failures')
+    expect(result).to have_output("#{number_of_unit_tests} examples, 0 failures")
+  end
+
+  # TODO: Change the number depending the rails version
+  def number_of_unit_tests
+    # if rails_gt_5?
+    #   25
+    # elsif rails_gte_5_2?
+    #   # Note: It should not test:
+    #   # - have_implicit_order_column
+    #   # - have_rich_text
+    #   23
+    # else
+    #   # Note: It should not test:
+    #   # - have_implicit_order_column
+    #   # - have_many_attached matchers
+    #   # - have_one_attached
+    #   # - have_rich_text
+    #   21
+    # end
+
+    25
   end
 end

--- a/spec/acceptance/rails_integration_spec.rb
+++ b/spec/acceptance/rails_integration_spec.rb
@@ -3,35 +3,12 @@ require 'acceptance_spec_helper'
 describe 'shoulda-matchers integrates with Rails' do
   before do
     create_rails_application
+    write_files_in_rails_application
 
-    write_file 'db/migrate/1_create_users.rb', <<-FILE
-      class CreateUsers < #{migration_class_name}
-        def self.up
-          create_table :users do |t|
-            t.string :name
-          end
-        end
-      end
-    FILE
+    # TODO: ActionController matchers
+    # configure_routes_with_single_wildcard_route
 
     run_rake_tasks!('db:drop', 'db:create', 'db:migrate')
-
-    write_file 'app/models/user.rb', <<-FILE
-      class User < ActiveRecord::Base
-        validates_presence_of :name
-      end
-    FILE
-
-    write_file 'app/controllers/examples_controller.rb', <<-FILE
-      class ExamplesController < ApplicationController
-        def show
-          @example = 'hello'
-          head :ok
-        end
-      end
-    FILE
-
-    configure_routes_with_single_wildcard_route
   end
 
   specify 'in a project that uses the default test framework' do
@@ -105,52 +82,52 @@ describe 'shoulda-matchers integrates with Rails' do
       require 'test_helper'
 
       class UserTest < ActiveSupport::TestCase
-        should validate_presence_of(:name)
+        # ActiveModel matchers
+        should allow_value('https://foo.com').for(:website_url)
+        should have_secure_password
+        should validate_absence_of(:first_name)
+        should validate_acceptance_of(:terms_of_service)
+        should validate_confirmation_of(:email)
+        should validate_exclusion_of(:age).in_array(0..17)
+        should validate_inclusion_of(:role).in_array(%w( admin manager ))
+        should validate_length_of(:password).is_at_least(10).on(:create)
+        should validate_numericality_of(:number_of_dependents).on(:create)
+        should validate_presence_of(:email)
+
+        # TODO: ActiveRecord matchers
       end
     FILE
 
-    write_file 'test/functional/examples_controller_test.rb', <<-FILE
-      require 'test_helper'
-
-      class ExamplesControllerTest < ActionController::TestCase
-        def setup
-          get :show
-        end
-
-        should respond_with(:success)
-      end
-    FILE
+    # TODO: ActionController matchers tests
 
     result = run_n_unit_test_suite
 
-    expect(result).to indicate_that_tests_were_run(unit: 1, functional: 1)
-    expect(result).to have_output(
-      'User should validate that :name cannot be empty/falsy',
-    )
-    expect(result).to have_output('should respond with 200')
+    expect(result).to indicate_that_tests_were_run(unit: 10)
   end
 
   def run_tests_for_rspec
     add_rspec_file 'spec/models/user_spec.rb', <<-FILE
       describe User do
-        it { should validate_presence_of(:name) }
+        # ActiveModel matchers
+        it { should allow_value('https://foo.com').for(:website_url) }
+        it { should have_secure_password }
+        it { should validate_absence_of(:first_name) }
+        it { should validate_acceptance_of(:terms_of_service) }
+        it { should validate_confirmation_of(:email) }
+        it { should validate_exclusion_of(:age).in_array(0..17) }
+        it { should validate_inclusion_of(:role).in_array(%w( admin manager )) }
+        it { should validate_length_of(:password).is_at_least(10).on(:create) }
+        it { should validate_numericality_of(:number_of_dependents).on(:create) }
+        it { should validate_presence_of(:email) }
+
+        # TODO: ActiveRecord matchers
       end
     FILE
 
-    add_rspec_file 'spec/controllers/examples_controller_spec.rb', <<-FILE
-      describe ExamplesController, "show" do
-        before { get :show }
-
-        it { should respond_with(:success) }
-      end
-    FILE
+    # TODO: ActionController matchers tests
 
     result = run_rspec_suite
 
-    expect(result).to have_output('2 examples, 0 failures')
-    expect(result).to have_output(
-      'is expected to validate that :name cannot be empty/falsy',
-    )
-    expect(result).to have_output('is expected to respond with 200')
+    expect(result).to have_output('10 examples, 0 failures')
   end
 end

--- a/spec/support/acceptance/helpers/step_helpers.rb
+++ b/spec/support/acceptance/helpers/step_helpers.rb
@@ -84,7 +84,7 @@ module AcceptanceTests
       end
     end
 
-    def write_files_in_rails_application
+    def create_files_in_rails_application
       write_file 'db/migrate/1_create_users.rb', <<-FILE
         class CreateUsers < #{migration_class_name}
           def self.up
@@ -100,16 +100,29 @@ module AcceptanceTests
               t.integer :user_id
             end
 
-            create_table :users do |t|
-              t.integer :age
-              t.string  :email
-              t.string  :first_name
-              t.integer :number_of_dependents
-              t.string  :gender
-              t.string  :password_digest
-              t.string  :role
-              t.string  :website_url
+            create_table :profiles do |t|
+              t.integer :user_id
             end
+
+            create_table :organizations do |t|
+            end
+
+            create_table :users do |t|
+              t.integer  :age
+              t.string   :email
+              t.string   :first_name
+              t.integer  :number_of_dependents
+              t.string   :gender
+              t.integer  :organization_id
+              t.string   :password_digest
+              t.string   :role
+              t.integer  :status
+              t.string   :social_networks
+              t.string   :website_url
+              t.datetime :created_at
+            end
+
+            add_index :users, :organization_id
           end
         end
       FILE
@@ -121,6 +134,16 @@ module AcceptanceTests
 
       write_file 'app/models/issue.rb', <<-FILE
         class Issue < ActiveRecord::Base
+        end
+      FILE
+
+      write_file 'app/models/organization.rb', <<-FILE
+        class Organization < ActiveRecord::Base
+        end
+      FILE
+
+      write_file 'app/models/profile.rb', <<-FILE
+        class Profile < ActiveRecord::Base
         end
       FILE
 
@@ -141,7 +164,20 @@ module AcceptanceTests
           validates_numericality_of :number_of_dependents, on: :create
           validates_presence_of     :email
 
-          # TODO: ActiveRecord
+          # ActiveRecord
+          has_many                      :issues
+          accepts_nested_attributes_for :issues
+          belongs_to                    :organization
+          enum status:                  [:active, :blocked]
+          has_and_belongs_to_many       :categories
+          self.implicit_order_column    = :created_at
+          has_many_attached             :photos
+          has_one                       :profile
+          has_one_attached              :avatar
+          attr_readonly                 :username
+          has_rich_text                 :description
+          serialize                     :social_networks
+          validates                     :email, uniqueness: true
         end
       FILE
 

--- a/spec/support/tests/filesystem.rb
+++ b/spec/support/tests/filesystem.rb
@@ -78,6 +78,7 @@ module Tests
       end
     end
 
+    # TODO
     def comment_lines_matching(path, pattern)
       transform(path) do |lines|
         lines.map do |line|

--- a/spec/support/tests/rails_versions.rb
+++ b/spec/support/tests/rails_versions.rb
@@ -19,8 +19,8 @@ module Tests
       rails_version =~ '~> 5.0'
     end
 
-    def rails_gt_5?
-      rails_version > 5
+    def rails_6_x?
+      rails_version =~ '~> 6.0'
     end
 
     def rails_gte_5_2?

--- a/spec/support/tests/rails_versions.rb
+++ b/spec/support/tests/rails_versions.rb
@@ -1,4 +1,4 @@
-module UnitTests
+module Tests
   module RailsVersions
     extend self
 

--- a/spec/support/unit/helpers/rails_versions.rb
+++ b/spec/support/unit/helpers/rails_versions.rb
@@ -19,6 +19,10 @@ module UnitTests
       rails_version =~ '~> 5.0'
     end
 
+    def rails_gt_5?
+      rails_version > 5
+    end
+
     def rails_gte_5_2?
       rails_version >= 5.2
     end

--- a/spec/support/unit/rails_application.rb
+++ b/spec/support/unit/rails_application.rb
@@ -2,7 +2,7 @@ require_relative '../tests/bundle'
 require_relative '../tests/command_runner'
 require_relative '../tests/database'
 require_relative '../tests/filesystem'
-require_relative 'helpers/rails_versions'
+require_relative '../tests/rails_versions'
 
 require 'yaml'
 

--- a/spec/unit_spec_helper.rb
+++ b/spec/unit_spec_helper.rb
@@ -15,6 +15,7 @@ end
 RSpec.configure do |config|
   config.include RSpec::Matchers::FailMatchers
 
+  Tests::RailsVersions.configure_example_group(config)
   UnitTests::ActionPackVersions.configure_example_group(config)
   UnitTests::ActiveModelHelpers.configure_example_group(config)
   UnitTests::ActiveModelVersions.configure_example_group(config)
@@ -23,7 +24,6 @@ RSpec.configure do |config|
   UnitTests::I18nFaker.configure_example_group(config)
   UnitTests::MailerBuilder.configure_example_group(config)
   UnitTests::ModelBuilder.configure_example_group(config)
-  UnitTests::RailsVersions.configure_example_group(config)
   UnitTests::ActiveRecordVersions.configure_example_group(config)
   UnitTests::ActiveModelVersions.configure_example_group(config)
   UnitTests::DatabaseHelpers.configure_example_group(config)


### PR DESCRIPTION
Adding more rails integration tests similar to those in [Shoulda](https://github.com/thoughtbot/shoulda/blob/master/test/acceptance/integrates_with_rails_test.rb).

The lists below track which tests are missing.

ActiveModel Matchers:

- [x] allow_value
- [x] have_secure_password
- [x] validate_absence_of
- [x] validate_acceptance_of
- [x] validate_confirmation_of
- [x] validate_exclusion_of
- [x] validate_inclusion_of
- [x] validate_length_of
- [x] validate_numericality_of
- [x] validate_presence_of

ActiveRecord Matchers:

- [x] accept_nested_attributes_for
- [x] belong_to
- [x] define_enum_for
- [x] have_and_belong_to_many
- [x] have_db_column
- [x] have_db_index
- [x] have_implicit_order_column (Rails 6 +)
- [x] have_many
- [x] have_many_attached (Rails 5.2 +)
- [x] have_one
- [x] have_one_attached (Rails 5.2 +)
- [x] have_readonly_attribute
- [x] have_rich_text (Rails 6 +)
- [x] serialize
- [x] validate_uniqueness_of

ActionController Matchers:

- [x] filter_param
- [x] permit
- [ ] redirect_to
- [ ] render_template
- [ ] render_with_layout
- [ ] rescue_from
- [x] respond_with
- [ ] route
- [ ] set_session
- [ ] set_flash
- [ ] use_after_action
- [ ] use_around_action
- [ ] use_before_action