### PR TITLE
Drop `git ls-files` in gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
-require: rubocop-rails
+require:
+  - rubocop-packaging
+  - rubocop-rails
 AllCops:
   NewCops: disable
   TargetRubyVersion: 2.4

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'pry-byebug'
 gem 'rake', '13.0.1'
 gem 'rspec', '~> 3.9'
 gem 'rubocop', require: false
+gem 'rubocop-packaging', require: false
 gem 'rubocop-rails', require: false
 gem 'warnings_logger'
 gem 'zeus', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,8 @@ GEM
       unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-ast (0.3.0)
       parser (>= 2.7.1.4)
+    rubocop-packaging (0.4.0)
+      rubocop (~> 0.89)
     rubocop-rails (2.0.1)
       rack (>= 1.1)
       rubocop (>= 0.70.0)
@@ -76,6 +78,7 @@ DEPENDENCIES
   rouge
   rspec (~> 3.9)
   rubocop
+  rubocop-packaging
   rubocop-rails
   warnings_logger
   yard

--- a/shoulda-matchers.gemspec
+++ b/shoulda-matchers.gemspec
@@ -27,10 +27,7 @@ Gem::Specification.new do |s|
     'source_code_uri' => 'https://github.com/thoughtbot/shoulda-matchers',
   }
 
-  s.files = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z -- {docs,lib,README.md,MIT-LICENSE,shoulda-matchers.gemspec}`.
-      split("\x0")
-  end
+  s.files = Dir['{docs,lib}/**/*', 'README.md', 'MIT-LICENSE', 'shoulda-matchers.gemspec']
   s.require_paths = ['lib']
 
   s.required_ruby_version = '>= 2.4.0'

--- a/tasks/documentation.rb
+++ b/tasks/documentation.rb
@@ -1,4 +1,4 @@
-require_relative '../lib/shoulda/matchers/version'
+require 'shoulda/matchers/version'
 require 'erb'
 
 module Shoulda


### PR DESCRIPTION
Hi again 👋🏻 

As discussed in #1353, this PR drops `git` in gemspec, thereby also helping in smooth downstream maintenance (in Debian, Fedora, and so on).
Also adds the `Packaging` extension of RuboCop. More about it can be found on https://docs.rubocop.org/rubocop-packaging.

Closes: #1353 

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>