### PR TITLE
Support custom has_secure_password attributes

### DIFF
--- a/spec/support/unit/helpers/active_model_versions.rb
+++ b/spec/support/unit/helpers/active_model_versions.rb
@@ -32,5 +32,9 @@ module UnitTests
     def active_model_supports_full_attributes_api?
       active_model_version >= '5.2'
     end
+
+    def active_model_supports_custom_has_secure_password_attribute?
+      active_model_version >= '6.0'
+    end
   end
 end

--- a/spec/unit/shoulda/matchers/active_model/have_secure_password_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/have_secure_password_matcher_spec.rb
@@ -1,18 +1,39 @@
 require 'unit_spec_helper'
 
 describe Shoulda::Matchers::ActiveModel::HaveSecurePasswordMatcher, type: :model do
-  it 'matches when the subject configures has_secure_password with default options' do
-    working_model = define_model(:example, password_digest: :string) { has_secure_password }
-    expect(working_model.new).to have_secure_password
+  context "with no arguments passed to has_secure_password" do
+    it 'matches when the subject configures has_secure_password with default options' do
+      working_model = define_model(:example, password_digest: :string) { has_secure_password }
+      expect(working_model.new).to have_secure_password
+    end
+
+    it 'does not match when the subject does not authenticate a password' do
+      no_secure_password = define_model(:example)
+      expect(no_secure_password.new).not_to have_secure_password
+    end
+
+    it 'does not match when the subject is missing the password_digest attribute' do
+      no_digest_column = define_model(:example) { has_secure_password }
+      expect(no_digest_column.new).not_to have_secure_password
+    end
   end
 
-  it 'does not match when the subject does not authenticate a password' do
-    no_secure_password = define_model(:example)
-    expect(no_secure_password.new).not_to have_secure_password
-  end
+  if active_model_supports_custom_has_secure_password_attribute?
+    context "when custom attribute is given to has_secure_password" do
+      it 'matches when the subject configures has_secure_password with correct options' do
+        working_model = define_model(:example, reset_password_digest: :string) { has_secure_password :reset_password }
+        expect(working_model.new).to have_secure_password :reset_password
+      end
 
-  it 'does not match when the subject is missing the password_digest attribute' do
-    no_digest_column = define_model(:example) { has_secure_password }
-    expect(no_digest_column.new).not_to have_secure_password
+      it 'does not match when the subject does not authenticate a password' do
+        no_secure_password = define_model(:example)
+        expect(no_secure_password.new).not_to have_secure_password :reset_password
+      end
+
+      it 'does not match when the subject is missing the custom digest attribute' do
+        no_digest_column = define_model(:example) { has_secure_password :reset_password }
+        expect(no_digest_column.new).not_to have_secure_password :reset_password
+      end
+    end
   end
 end


### PR DESCRIPTION
Starting with version 6, Rails accepts custom attributes for `has_secure_password` macro.
Without one it defaults to `password`, so everything should still work without breaking for older versions of Rails as well.

Rails pull request for allowing configurable attribute name on `#has_secure_password` - https://github.com/rails/rails/pull/26764