### PR TITLE
fix have_db_column.with_options misspelled options

### DIFF
--- a/lib/shoulda/matchers/active_record/have_db_column_matcher.rb
+++ b/lib/shoulda/matchers/active_record/have_db_column_matcher.rb
@@ -84,6 +84,8 @@ module Shoulda
 
       # @private
       class HaveDbColumnMatcher
+        OPTIONS = %i(precision limit default null scale primary)
+
         def initialize(column)
           @column = column
           @options = {}
@@ -95,7 +97,8 @@ module Shoulda
         end
 
         def with_options(opts = {})
-          %w(precision limit default null scale primary).each do |attribute|
+          validate_options(opts)
+          OPTIONS.each do |attribute|
             if opts.key?(attribute.to_sym)
               @options[attribute.to_sym] = opts[attribute.to_sym]
             end
@@ -136,6 +139,13 @@ module Shoulda
         end
 
         protected
+
+        def validate_options(opts)
+          invalid_options = opts.keys.map(&:to_sym) - OPTIONS
+          if invalid_options.any?
+            raise ArgumentError, "Unknown option(s): #{invalid_options.map(&:inspect).join(", ")}"
+          end
+        end
 
         def column_exists?
           if model_class.column_names.include?(@column.to_s)

--- a/spec/unit/shoulda/matchers/active_record/have_db_column_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/have_db_column_matcher_spec.rb
@@ -98,6 +98,14 @@ describe Shoulda::Matchers::ActiveRecord::HaveDbColumnMatcher, type: :model do
     end
   end
 
+  context 'with invalid argument option' do
+    it 'raises an error with the unknown options' do
+      expect {
+        have_db_column(:salary).with_options(preccision: 5, primaryy: true)
+      }.to raise_error("Unknown option(s): :preccision, :primaryy")
+    end
+  end
+
   def model(options = {})
     define_model(:employee, options).new
   end


### PR DESCRIPTION
Hi!! This is my first contribuition to `shoulda-matchers`. If you got any feedback for this PR, I'll be very happy to listen.

This PR looks to solve the bug reported here #1281. 

### Solution descripton 

When there is an argument this matcher doesn't expect, it should raise an `ArgumentError`. I created a new protected method `validate_options` to be responsible for this.
 