### PR TITLE
Fix deprecation warning 

### DIFF
--- a/spec/acceptance/rails_integration_spec.rb
+++ b/spec/acceptance/rails_integration_spec.rb
@@ -24,14 +24,13 @@ describe 'shoulda-matchers integrates with Rails' do
 
     write_file 'app/controllers/examples_controller.rb', <<-FILE
       class ExamplesController < ApplicationController
-        def show
-          @example = 'hello'
+        def index
           head :ok
         end
       end
     FILE
 
-    configure_routes_with_single_wildcard_route
+    configure_routes
   end
 
   specify 'in a project that uses the default test framework' do
@@ -114,7 +113,7 @@ describe 'shoulda-matchers integrates with Rails' do
 
       class ExamplesControllerTest < ActionController::TestCase
         def setup
-          get :show
+          get :index
         end
 
         should respond_with(:success)
@@ -139,7 +138,7 @@ describe 'shoulda-matchers integrates with Rails' do
 
     add_rspec_file 'spec/controllers/examples_controller_spec.rb', <<-FILE
       describe ExamplesController, "show" do
-        before { get :show }
+        before { get :index }
 
         it { should respond_with(:success) }
       end

--- a/spec/support/acceptance/helpers/step_helpers.rb
+++ b/spec/support/acceptance/helpers/step_helpers.rb
@@ -83,10 +83,10 @@ module AcceptanceTests
       end
     end
 
-    def configure_routes_with_single_wildcard_route
+    def configure_routes
       write_file 'config/routes.rb', <<-FILE
         Rails.application.routes.draw do
-          get ':controller(/:action(/:id(.:format)))'
+          resources :examples, only: :index
         end
       FILE
     end


### PR DESCRIPTION
This PR corrects two warnings that I ended up encountering when running acceptance tests with Rails 6:

```bash
       DEPRECATION WARNING: Using a dynamic :controller segment in a route is deprecated and will be removed in Rails 6.1. (called from block in <main> at /tmp/shoulda-matchers-acceptance/test-project/config/routes.rb:2)
       DEPRECATION WARNING: Using a dynamic :action segment in a route is deprecated and will be removed in Rails 6.1. (called from block in <main> at /tmp/shoulda-matchers-acceptance/test-project/config/routes.rb:2)
```

~~There is a problem with this PR: The CI will fail when the version of Rails is 4.2. To make it work it's necessary to update the `before { get :show, params: { id: 1 } }` to `before { get :show, { id: 1 } }`, but doing so the tests on the other versions will fail.~~

~~I was even wondering if it would be better to remove support for this older version instead of adding a condition to it.~~ :sweat_smile: 

EDIT 1: If you want to know more about the warnings: https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/routing/route_set.rb#L597-L608

EDIT 2: To fix the problem with the older version of Rails it was necessary to update the controller action from show to index.