### PR TITLE
Use build  instead of create in validate_uniqueness

### DIFF
--- a/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
+++ b/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
@@ -80,7 +80,7 @@ module Shoulda
       #
       #     RSpec.describe Post, type: :model do
       #       describe "validations" do
-      #         subject { Post.create(content: "Here is the content") }
+      #         subject { Post.new(content: "Here is the content") }
       #         it { should validate_uniqueness_of(:title) }
       #       end
       #     end
@@ -92,7 +92,7 @@ module Shoulda
       #
       #     RSpec.describe Post, type: :model do
       #       describe "validations" do
-      #         subject { FactoryBot.create(:post) }
+      #         subject { FactoryBot.build(:post) }
       #         it { should validate_uniqueness_of(:title) }
       #       end
       #     end


### PR DESCRIPTION
Thank you for the awesome library!

You don't actually have to persist the record to get the validates_uniqueness test to pass. Everyone who copies the current code from here is slowing down their test suite unnecessarily. 