### PR TITLE
fix: Run actiontext migrations for rails >= 6

### DIFF
--- a/spec/support/unit/rails_application.rb
+++ b/spec/support/unit/rails_application.rb
@@ -26,9 +26,7 @@ module UnitTests
     def load
       load_environment
 
-      if rails_version > 5 && bundle.includes?('actiontext')
-        add_action_text_migration
-      end
+      add_action_text_migration if bundle.includes?('actiontext')
 
       run_migrations
     end


### PR DESCRIPTION
... as actiontext is made available on rails 6.0