### PR TITLE
Fix HaveRichTextMatcher class name

### DIFF
--- a/lib/shoulda/matchers/active_record/have_rich_text_matcher.rb
+++ b/lib/shoulda/matchers/active_record/have_rich_text_matcher.rb
@@ -20,14 +20,14 @@ module Shoulda
       #       should have_rich_text(:content)
       #     end
       #
-      # @return [HaveRichText]
+      # @return [HaveRichTextMatcher]
       #
       def have_rich_text(rich_text_attribute)
-        HaveRichText.new(rich_text_attribute)
+        HaveRichTextMatcher.new(rich_text_attribute)
       end
 
       # @private
-      class HaveRichText
+      class HaveRichTextMatcher
         def initialize(rich_text_attribute)
           @rich_text_attribute = rich_text_attribute
         end

--- a/spec/unit/shoulda/matchers/active_record/have_rich_text_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/have_rich_text_matcher_spec.rb
@@ -1,6 +1,6 @@
 require 'unit_spec_helper'
 
-describe Shoulda::Matchers::ActiveRecord::HaveRichText, type: :model do
+describe Shoulda::Matchers::ActiveRecord::HaveRichTextMatcher, type: :model do
   def self.rich_text_is_defined?
     defined?(ActionText::RichText)
   end


### PR DESCRIPTION
The name should be HaveRichTextMatcher and not HaveRichText.

Thank you, @KapilSachdev, you made me notice this mistake when you reviewed the #1366. Thank you very much.