### PR TITLE
Fix module

### DIFF
--- a/lib/shoulda/matchers/active_record/uniqueness.rb
+++ b/lib/shoulda/matchers/active_record/uniqueness.rb
@@ -1,6 +1,6 @@
 module Shoulda
   module Matchers
-    module ActiveModel
+    module ActiveRecord
       # @private
       module Uniqueness
       end


### PR DESCRIPTION
I find this PR([Move uniqueness validation to ActiveRecord module](https://github.com/VSPPedro/shoulda-matchers/commit/cf76d747eef4e04a787fb43badfaa2d459aa5021)) and it seems that this file was the only one missing the update on the module.