### PR TITLE
fix: with_foreign_key modifier fails with wrong error message

### DIFF
--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -1394,17 +1394,26 @@ module Shoulda
         end
 
         def class_has_foreign_key?(klass)
-          if options.key?(:foreign_key)
-            option_verifier.correct_for_string?(
-              :foreign_key,
-              options[:foreign_key],
-            )
-          elsif column_names_for(klass).include?(foreign_key)
-            true
-          else
-            @missing = "#{klass} does not have a #{foreign_key} foreign key."
+          if options.key?(:foreign_key) && !foreign_key_correct?
+            @missing = foreign_key_failure_message(klass, options[:foreign_key])
             false
+          elsif !column_names_for(klass).include?(foreign_key)
+            @missing = foreign_key_failure_message(klass, foreign_key)
+            false
+          else
+            true
           end
+        end
+
+        def foreign_key_correct?
+          option_verifier.correct_for_string?(
+            :foreign_key,
+            options[:foreign_key],
+          )
+        end
+
+        def foreign_key_failure_message(klass, foreign_key)
+          "#{klass} does not have a #{foreign_key} foreign key."
         end
 
         def primary_key_correct?(klass)

--- a/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -1414,6 +1414,20 @@ Expected Parent to have a has_many association called children through conceptio
       expect(having_one_non_existent(:person, :detail, class_name: 'Detail')).not_to have_one(:detail)
     end
 
+    it 'rejects an association with a valid :class_name and a bad :primary_key option' do
+      define_model :person_detail
+      define_model :person do
+        has_one :detail, class_name: 'PersonDetail', foreign_key: :person_detail_id
+      end
+
+      expected_message = 'Expected Person to have a has_one association called detail ' \
+        '(PersonDetail does not have a custom_primary_id foreign key.)'
+
+      expect { have_one(:detail).class_name('PersonDetail').with_foreign_key(:custom_primary_id) }.
+        not_to match_against(Person.new).
+        and_fail_with(expected_message)
+    end
+
     it 'adds error message when rejecting an association with non-existent class' do
       message = 'Expected Person to have a has_one association called detail (Detail2 does not exist)'
       expect {


### PR DESCRIPTION
Closes #1374

I noticed that for the scenario described on issue #1374 the class_has_foreign_key?(klass) was entering in the first conditional and than running this piece of code:

```
option_verifier.correct_for_string?(
  :foreign_key,
  options[:foreign_key],
)
```

It seems to me that the problem with this flow is that it just returns false without updating the failure message. What do you think?