### PR TITLE
fix: Remove lint-action github action and add custom RuboCop action

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,38 +1,30 @@
-name: Rubocop
+name: RuboCop
 
 on: [push, pull_request]
 
 jobs:
-  run-linters:
-    name: Run linters
+  build:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out Git repository
-        uses: actions/checkout@v2
+    - name: Checkout Repository
+      uses: actions/checkout@v2
 
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 2.7.2
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
 
-      - name: Set up bundle cache
-        uses: actions/cache@v2
-        with:
-          path: /vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('./Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
+    - name: Cache gems
+      uses: actions/cache@v1
+      with:
+        path: ../vendor/bundle
+        key: ${{ runner.os }}-rubocop-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-rubocop-
 
-      - name: Install Ruby dependencies
-        run: |
-          bundle config path /vendor/bundle
-          bundle install --jobs 4 --retry 3
+    - name: Install gems
+      run: |
+        bundle config path ../vendor/bundle
+        bundle install --jobs 4 --retry 3
 
-      - name: Run linters
-        uses: wearerequired/lint-action@v1
-        with:
-          github_token: ${{ secrets.github_token }}
-          rubocop: true
-          rubocop_command_prefix: bundle exec
-          rubocop_args: -c ./.rubocop.yml
+    - name: Run RuboCop
+      run: bundle exec rubocop --parallel

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,3 +1,0 @@
-ruby:
-  enabled: true
-  config_file: .rubocop.yml

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Shoulda Matchers [![Gem Version][version-badge]][rubygems] [![Build Status][travis-badge]][travis] [![Total Downloads][downloads-total]][rubygems] [![Downloads][downloads-badge]][rubygems] [![Hound][hound-badge]][hound]
+# Shoulda Matchers [![Gem Version][version-badge]][rubygems] [![Build Status][travis-badge]][travis] [![Total Downloads][downloads-total]][rubygems] [![Downloads][downloads-badge]][rubygems]
 
 [version-badge]: https://img.shields.io/gem/v/shoulda-matchers.svg
 [rubygems]: https://rubygems.org/gems/shoulda-matchers
@@ -7,8 +7,6 @@
 [downloads-total]: https://img.shields.io/gem/dt/shoulda-matchers.svg
 [downloads-badge]: https://img.shields.io/gem/dtv/shoulda-matchers.svg
 [downloads-badge]: https://img.shields.io/gem/dtv/shoulda-matchers.svg
-[hound-badge]: https://img.shields.io/badge/Reviewed_by-Hound-8E64B0.svg
-[hound]: https://houndci.com
 
 [![shoulda-matchers][logo]][website]
 


### PR DESCRIPTION
- Annotations feature provided by lint-action is not working with PRs from fork repos
- pull_request_target feature is also not behaving reliably 
- Remove hound
- Note:Not using `bundler-cache: true` for caching as it uses uses `./vendor/bundle` as bundle path and `rubocop` lint vendor as well. So caching under `../vendor/bundle` using `actions/cache`
- Using `actions/cache@v1` rather `v2` as gems are not getting cached due to unknown reason

Related: #1345, #1371 