### PR TITLE
fix: actual_value_for(validate) returns false instead of true when there is no validate option

### DIFF
--- a/lib/shoulda/matchers/active_record/association_matchers/option_verifier.rb
+++ b/lib/shoulda/matchers/active_record/association_matchers/option_verifier.rb
@@ -6,6 +6,11 @@ module Shoulda
         class OptionVerifier
           delegate :reflection, to: :reflector
 
+          DEFAULT_VALUE_OF_OPTIONS = {
+            has_many: {
+              validate: true,
+            },
+          }.freeze
           RELATION_OPTIONS = [:conditions, :order].freeze
 
           def initialize(reflector)
@@ -55,7 +60,7 @@ module Shoulda
               if respond_to?(method_name, true)
                 __send__(method_name)
               else
-                reflection.options[name]
+                actual_value_for_option(name)
               end
             end
           end
@@ -115,6 +120,16 @@ module Shoulda
 
           def actual_value_for_class_name
             reflector.associated_class
+          end
+
+          def actual_value_for_option(name)
+            option_value = reflection.options[name]
+
+            if option_value.nil?
+              DEFAULT_VALUE_OF_OPTIONS.dig(reflection.macro, name)
+            else
+              option_value
+            end
           end
         end
       end

--- a/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -1177,20 +1177,40 @@ Expected Parent to have a has_many association called children through conceptio
     end
 
     context 'validate' do
-      it 'accepts when the :validate option matches' do
+      it 'accepts validate(false) when the :validate option is false' do
         expect(having_many_children(validate: false)).to have_many(:children).validate(false)
       end
 
-      it 'rejects when the :validate option does not match' do
+      it 'accepts validate(true) when the :validate option is true' do
+        expect(having_many_children(validate: true)).to have_many(:children).validate(true)
+      end
+
+      it 'rejects validate(false) when the :validate option is true' do
         expect(having_many_children(validate: true)).not_to have_many(:children).validate(false)
       end
 
+      it 'rejects validate(true) when the :validate option is false' do
+        expect(having_many_children(validate: false)).not_to have_many(:children).validate(true)
+      end
+
       it 'assumes validate() means validate(true)' do
+        expect(having_many_children(validate: true)).to have_many(:children).validate
+      end
+
+      it 'rejects validate() when :validate option is false' do
         expect(having_many_children(validate: false)).not_to have_many(:children).validate
       end
 
-      it 'matches validate(false) to having no validate option specified' do
-        expect(having_many_children).to have_many(:children).validate(false)
+      it 'rejects validate(false) when no :validate option was specified' do
+        expect(having_many_children).not_to have_many(:children).validate(false)
+      end
+
+      it 'accepts validate(true) when no :validate option was specified' do
+        expect(having_many_children).to have_many(:children).validate(true)
+      end
+
+      it 'accepts validate() when no :validate option was specified' do
+        expect(having_many_children).to have_many(:children).validate
       end
     end
 


### PR DESCRIPTION
Closes #1357

It seems to me that the problem here is that when there is no validate option on the relationship the value being returned by `actual_value_for(name)` is nil instead of true - the default value.

In case you want to check the default value for this macro: [documantation](https://apidock.com/rails/ActiveRecord/Associations/ClassMethods/has_many) and [active_record/associations/has_many_association.rb#L56](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/associations/has_many_association.rb#L56).

To avoid this I added a check to validate the value and if it is null the default value will be returned instead, otherwise the code will follow its normal flow. I added some tests just to be sure about the behaviour. What do you think?



