### PR TITLE
Fix validate_absence_of failing for array columns

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_absence_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_absence_of_matcher.rb
@@ -107,6 +107,8 @@ module Shoulda
             else
               obj
             end
+          elsif array_column?
+            ['an arbitary value']
           else
             case column_type
             when :integer, :float then 1
@@ -136,6 +138,12 @@ module Shoulda
         def reflection
           @subject.class.respond_to?(:reflect_on_association) &&
             @subject.class.reflect_on_association(@attribute)
+        end
+
+        def array_column?
+          @subject.class.respond_to?(:columns_hash) &&
+            @subject.class.columns_hash[@attribute.to_s].respond_to?(:array) &&
+            @subject.class.columns_hash[@attribute.to_s].array
         end
       end
     end

--- a/spec/unit/shoulda/matchers/active_model/validate_absence_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_absence_of_matcher_spec.rb
@@ -48,6 +48,49 @@ describe Shoulda::Matchers::ActiveModel::ValidateAbsenceOfMatcher, type: :model 
         end
       end
 
+      if database_supports_array_columns? && active_record_supports_array_columns?
+        context 'when the column backing the attribute is an array' do
+          context 'of varchar' do
+            it 'still works' do
+              record = validating_absence_of(
+                :attr,
+                {},
+                type: :varchar,
+                options: { array: true, default: [], null: false },
+              )
+
+              expect(record).to validate_absence_of(:attr)
+            end
+          end
+
+          context 'of string' do
+            it 'still works' do
+              record = validating_absence_of(
+                :attr,
+                {},
+                type: :string,
+                options: { array: true, default: [], null: false },
+              )
+
+              expect(record).to validate_absence_of(:attr)
+            end
+          end
+
+          context 'of a type other than string' do
+            it 'still works' do
+              record = validating_absence_of(
+                :possible_meeting_dates,
+                {},
+                type: :date,
+                options: { array: true, default: [], null: false },
+              )
+
+              expect(record).to validate_absence_of(:possible_meeting_dates)
+            end
+          end
+        end
+      end
+
       context 'when used in the negative' do
         it 'fails' do
           assertion = lambda do


### PR DESCRIPTION
My very first time contributing to this gem. 🤓  I love that the [contributing guide](https://github.com/thoughtbot/shoulda-matchers/blob/master/CONTRIBUTING.md) is well-written! 🎉 

This fixes #1240.

## Changelog
- Made `ValidatingAbsenceOfMatcher#value` check whether column is array
- Added tests on array columns for `ValidateAbsenceOfMatcher`