### PR TITLE
Fix RuboCop offenses

### DIFF
--- a/lib/shoulda/matchers/active_record/have_db_column_matcher.rb
+++ b/lib/shoulda/matchers/active_record/have_db_column_matcher.rb
@@ -84,7 +84,7 @@ module Shoulda
 
       # @private
       class HaveDbColumnMatcher
-        OPTIONS = %i(precision limit default null scale primary)
+        OPTIONS = %i(precision limit default null scale primary).freeze
 
         def initialize(column)
           @column = column
@@ -147,7 +147,10 @@ module Shoulda
         def validate_options(opts)
           invalid_options = opts.keys.map(&:to_sym) - OPTIONS
           if invalid_options.any?
-            raise ArgumentError, "Unknown option(s): #{invalid_options.map(&:inspect).join(", ")}"
+            raise(
+              ArgumentError,
+              "Unknown option(s): #{invalid_options.map(&:inspect).join(', ')}",
+            )
           end
         end
 

--- a/spec/unit/shoulda/matchers/active_record/have_db_column_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/have_db_column_matcher_spec.rb
@@ -102,7 +102,7 @@ describe Shoulda::Matchers::ActiveRecord::HaveDbColumnMatcher, type: :model do
     it 'raises an error with the unknown options' do
       expect {
         have_db_column(:salary).with_options(preccision: 5, primaryy: true)
-      }.to raise_error("Unknown option(s): :preccision, :primaryy")
+      }.to raise_error('Unknown option(s): :preccision, :primaryy')
     end
   end
 


### PR DESCRIPTION
These were introduced after #1358 was merged. Rather bizarrely, RuboCop didn't run when the PR was opened.