### PR TITLE
refactor class_has_foreign_key method from association_matcher.rb

### DIFF
--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -1394,15 +1394,13 @@ module Shoulda
         end
 
         def class_has_foreign_key?(klass)
-          if options.key?(:foreign_key) && !foreign_key_correct?
-            @missing = foreign_key_failure_message(klass, options[:foreign_key])
-            false
-          elsif !column_names_for(klass).include?(foreign_key)
-            @missing = foreign_key_failure_message(klass, foreign_key)
-            false
-          else
-            true
-          end
+          @missing = if options.key?(:foreign_key) && !foreign_key_correct?
+                       foreign_key_failure_message(klass, options[:foreign_key])
+                     elsif !column_names_for(klass).include?(foreign_key)
+                       foreign_key_failure_message(klass, foreign_key)
+                     end
+
+          @missing.nil?
         end
 
         def foreign_key_correct?


### PR DESCRIPTION
I'm just trying to clean up a mess I made. I believe that this way it is easier to read. What do you think?

It only passes if there is no error message.

