### PR TITLE
Test against ruby-head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
     - DATABASE_ADAPTER=sqlite3
     - DATABASE_ADAPTER=postgresql
 rvm:
-  - head
+  - ruby-head
   - 2.7.2
   - 2.6.6
   - 2.5.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
     - DATABASE_ADAPTER=sqlite3
     - DATABASE_ADAPTER=postgresql
 rvm:
+  - head
   - 2.7.2
   - 2.6.6
   - 2.5.8


### PR DESCRIPTION
There is issue running shoulda-matchers test suite against Ruby 3.0 [[1]]. To prevent issues like this, it would be beneficial to test ahead the official release.


[1]: https://bugs.ruby-lang.org/issues/17536