### PR TITLE
Fix exception raised by ActiveSupport Object#in?

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
@@ -327,8 +327,8 @@ validation for you? Instead of using `validate_presence_of`, try
         end
 
         def collection_association?
-          association? && association_reflection.macro.in?(
-            [:has_many, :has_and_belongs_to_many],
+          association? && [:has_many, :has_and_belongs_to_many].include?(
+            association_reflection.macro,
           )
         end
 

--- a/spec/acceptance/active_record_integration_spec.rb
+++ b/spec/acceptance/active_record_integration_spec.rb
@@ -1,0 +1,89 @@
+require 'acceptance_spec_helper'
+
+describe 'shoulda-matchers integrates with active record' do
+  before do
+    create_active_record_project
+
+    write_file 'Rakefile', <<-FILE
+      require 'active_record'
+      require 'sqlite3'
+
+      namespace :db do
+        desc 'Create the database'
+        task :create do
+          File.unlink 'test.sqlite3' if File.exist?('test.sqlite3')
+          db = SQLite3::Database.new('test.sqlite3')
+          db.execute("CREATE TABLE users (id integer)")
+          db.execute("CREATE TABLE profiles (id integer, user_id integer)")
+        end
+      end
+    FILE
+
+    run_rake_tasks!('db:create')
+
+    write_file 'lib/user.rb', <<-FILE
+      require 'active_record'
+
+      class User < ActiveRecord::Base
+      end
+    FILE
+
+    write_file 'lib/profile.rb', <<-FILE
+      require 'active_record'
+      require 'user'
+
+      class Profile < ActiveRecord::Base
+        belongs_to :user
+        validates_presence_of :user
+      end
+    FILE
+
+    write_file 'spec/profile_spec.rb', <<-FILE
+      require 'spec_helper'
+      require 'profile'
+
+      describe Profile, type: :model do
+        it { should validate_presence_of(:user) }
+      end
+    FILE
+
+    updating_bundle do
+      add_rspec_to_project
+      add_shoulda_matchers_to_project(
+        manually: true,
+        with_configuration: false,
+      )
+
+      write_file 'spec/spec_helper.rb', <<-FILE
+        require 'active_record'
+        require 'shoulda-matchers'
+
+        RSpec.configure do |config|
+          config.before(:suite) do
+            ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: 'test.sqlite3')
+          end
+        end
+
+        Shoulda::Matchers.configure do |config|
+          config.integrate do |with|
+            with.test_framework :rspec
+
+            with.library :active_record
+            with.library :active_model
+          end
+        end
+      FILE
+    end
+  end
+
+  context 'when using both active_record and active_model libraries' do
+    it 'allows the use of matchers from both libraries' do
+      result = run_rspec_tests('spec/profile_spec.rb')
+
+      expect(result).to have_output('1 example, 0 failures')
+      expect(result).to have_output(
+        'is expected to validate that :user cannot be empty/falsy',
+      )
+    end
+  end
+end

--- a/spec/support/acceptance/helpers.rb
+++ b/spec/support/acceptance/helpers.rb
@@ -1,4 +1,5 @@
 require_relative 'helpers/active_model_helpers'
+require_relative 'helpers/active_record_helpers'
 require_relative 'helpers/base_helpers'
 require_relative 'helpers/command_helpers'
 require_relative 'helpers/gem_helpers'
@@ -20,6 +21,7 @@ module AcceptanceTests
     end
 
     include ActiveModelHelpers
+    include ActiveRecordHelpers
     include BaseHelpers
     include CommandHelpers
     include GemHelpers

--- a/spec/support/acceptance/helpers/active_record_helpers.rb
+++ b/spec/support/acceptance/helpers/active_record_helpers.rb
@@ -1,0 +1,11 @@
+require_relative 'gem_helpers'
+
+module AcceptanceTests
+  module ActiveRecordHelpers
+    include GemHelpers
+
+    def active_record_version
+      bundle_version_of('activerecord')
+    end
+  end
+end

--- a/spec/support/acceptance/helpers/step_helpers.rb
+++ b/spec/support/acceptance/helpers/step_helpers.rb
@@ -17,6 +17,19 @@ module AcceptanceTests
       add_gem 'activemodel', active_model_version
     end
 
+    def create_active_record_project
+      create_generic_bundler_project
+      add_gem 'activemodel',  active_model_version
+      add_gem 'activerecord', active_record_version
+      add_gem 'rake'
+
+      if rails_version =~ '~> 6.0'
+        add_gem 'sqlite3', '~>1.4'
+      else
+        add_gem 'sqlite3', '~>1.3.6'
+      end
+    end
+
     def create_generic_bundler_project
       fs.clean
       fs.create


### PR DESCRIPTION
Closes https://github.com/thoughtbot/shoulda-matchers/pull/1291

> The part you quoted was the next thing I was going to say :) ActiveSupport is loaded whether you're explicitly using it or not (because both ActiveModel and ActiveRecord depend on it), but it's designed to be quasi-modular, so the exact file that provides `.in?` may not be required yet.
> 
> In any case, you've convinced me on the consistency argument. The only thing I'd like to see here is a test that exercises the scenario you're in so that we don't run into this problem again. We already some some high-level tests which set up an app and double-check that certain matchers are able to be used. We have a [scenario](https://github.com/thoughtbot/shoulda-matchers/blob/master/spec/acceptance/multiple_libraries_integration_spec.rb) which creates a Rails app and plugs into `:active_record` and `:active_model`, and we also have a [non-Rails app scenario](https://github.com/thoughtbot/shoulda-matchers/blob/master/spec/acceptance/active_model_integration_spec.rb) which only plugs into `:active_model`, but what we don't have is a scenario for a non-Rails app which plugs into `:active_record` and `:active_model`. So, what if you did this:
> 
>     * Comment out the change you made.
> 
>     * Add a new file `spec/support/acceptance/helpers/active_record_helpers.rb` that's similar to [`active_model_helpers`](https://github.com/thoughtbot/shoulda-matchers/blob/master/spec/support/acceptance/helpers/active_model_helpers.rb) but adds an `active_record_version` helper method.
> 
>     * Require and include the new module in [this helpers file](https://github.com/thoughtbot/shoulda-matchers/blob/master/spec/support/acceptance/helpers/active_model_helpers.rb).
> 
>     * Add a new [step helper](https://github.com/thoughtbot/shoulda-matchers/blob/master/spec/support/acceptance/helpers/step_helpers.rb#L15) called `create_active_record_project` that is similar to `create_active_model_project` but also adds the active_record gem in addition to active_model.
> 
>     * Make a new file in `spec/acceptance` that's like `multiple_libraries_integration_spec.rb`, only instead of `create_rails_application` on [line 5](https://github.com/thoughtbot/shoulda-matchers/blob/master/spec/acceptance/multiple_libraries_integration_spec.rb#L5) you use your new `create_active_record_application` helper.
> 
>     * Run the new test with: `bundle exec appraisal rails_6_0 rspec spec/acceptance/name_of_your_file_spec.rb`. Watch it fail with the same error you posted.
> 
>     * Uncomment your change from earlier and re-run the test. It should now pass.

Thanks for this comment on the PR https://github.com/thoughtbot/shoulda-matchers/pull/1291, @mcmire! Helped a lot.

