### PR TITLE
Handle argument delegation for Ruby 3

### DIFF
--- a/lib/shoulda/matchers/rails_shim.rb
+++ b/lib/shoulda/matchers/rails_shim.rb
@@ -65,7 +65,7 @@ module Shoulda
               request_params
             end
 
-          context.__send__(verb, action, params)
+          context.__send__(verb, action, **params)
         end
 
         def serialized_attributes_for(model)


### PR DESCRIPTION
Hi,

I'm trying to get rid of all the warnings I have when I launch Rspec on my project. Like this one:

> ruby/gems/2.7.0/gems/shoulda-matchers-4.5.1/lib/shoulda/matchers/rails_shim.rb:68: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call

That double splat does fix it.