### PR TITLE
Fix ruby warnings

### DIFF
--- a/spec/support/unit/active_record/create_table.rb
+++ b/spec/support/unit/active_record/create_table.rb
@@ -109,7 +109,7 @@ module UnitTests
           )
         end
 
-        table.column(column_name, column_type, column_options)
+        table.column(column_name, column_type, **column_options)
       end
     end
   end

--- a/spec/support/unit/helpers/model_builder.rb
+++ b/spec/support/unit/helpers/model_builder.rb
@@ -44,7 +44,7 @@ module UnitTests
 
         begin
           connection.execute("DROP TABLE IF EXISTS #{table_name}")
-          connection.create_table(table_name, options, &block)
+          connection.create_table(table_name, **options, &block)
           created_tables << table_name
           connection
         rescue StandardError => e

--- a/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb
@@ -21,7 +21,7 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
 
       def build_object(**options, &block)
         build_object_with_generic_attribute(
-          options.merge(column_type: :integer, value: 1),
+          **options.merge(column_type: :integer, value: 1),
           &block
         )
       end
@@ -45,7 +45,7 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
 
       def build_object(**options, &block)
         build_object_with_generic_attribute(
-          options.merge(
+          **options.merge(
             column_type: :integer,
             column_options: { limit: 2 },
             value: 1,
@@ -71,7 +71,7 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
 
       def build_object(**options, &block)
         build_object_with_generic_attribute(
-          options.merge(column_type: :float, value: 1.0),
+          **options.merge(column_type: :float, value: 1.0),
           &block
         )
       end
@@ -99,7 +99,7 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
 
       def build_object(**options, &block)
         build_object_with_generic_attribute(
-          options.merge(column_type: :decimal, value: BigDecimal('1.0')),
+          **options.merge(column_type: :decimal, value: BigDecimal('1.0')),
           &block
         )
       end
@@ -130,7 +130,7 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
 
       define_method :build_object do |options = {}, &block|
         build_object_with_generic_attribute(
-          options.merge(column_type: :date, value: today),
+          **options.merge(column_type: :date, value: today),
           &block
         )
       end
@@ -158,7 +158,7 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
 
       define_method :build_object do |options = {}, &block|
         build_object_with_generic_attribute(
-          options.merge(column_type: :datetime, value: now),
+          **options.merge(column_type: :datetime, value: now),
           &block
         )
       end
@@ -186,7 +186,7 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
 
       define_method :build_object do |options = {}, &block|
         build_object_with_generic_attribute(
-          options.merge(column_type: :time, value: default_time),
+          **options.merge(column_type: :time, value: default_time),
           &block
         )
       end
@@ -207,7 +207,7 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
 
       def build_object(**options, &block)
         build_object_with_generic_attribute(
-          options.merge(column_type: :string),
+          **options.merge(column_type: :string),
           &block
         )
       end
@@ -798,7 +798,7 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
 
       define_method :build_object do |options = {}, &block|
         build_object_with_generic_attribute(
-          options.merge(column_type: :timestamp, value: now),
+          **options.merge(column_type: :timestamp, value: now),
           &block
         )
       end
@@ -842,7 +842,7 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
 
         def build_object(**options, &block)
           super(
-            options.merge(column_options: { null: true }, value: true),
+            **options.merge(column_options: { null: true }, value: true),
             &block
           )
         end
@@ -863,13 +863,13 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
         end
 
         def build_object(**options, &block)
-          super(options.merge(column_options: { null: false }), &block)
+          super(**options.merge(column_options: { null: false }), &block)
         end
       end
 
       def build_object(**options, &block)
         build_object_with_generic_attribute(
-          options.merge(column_type: :boolean),
+          **options.merge(column_type: :boolean),
           &block
         )
       end
@@ -896,7 +896,7 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
       include_context 'against a boolean attribute for true and false'
 
       def build_object(**options, &block)
-        build_object_with_generic_attribute(options.merge(value: true), &block)
+        build_object_with_generic_attribute(**options.merge(value: true), &block)
       end
     end
 
@@ -904,7 +904,7 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
       include_context 'against a boolean attribute for true and false'
 
       def build_object(**options, &block)
-        build_object_with_generic_attribute(options.merge(value: false), &block)
+        build_object_with_generic_attribute(**options.merge(value: false), &block)
       end
     end
 
@@ -1010,7 +1010,7 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
       column_options: column_options,
     }.compact
 
-    define_simple_model(model_options) do |model|
+    define_simple_model(**model_options) do |model|
       if validation_options
         model.validates_inclusion_of(attribute_name, validation_options)
       end

--- a/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -714,7 +714,7 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
       define_model(:parent, parent_options)
 
       define_model :child, parent_id: :integer do
-        belongs_to :parent, options
+        belongs_to :parent, **options
 
         if block
           class_eval(&block)
@@ -743,7 +743,7 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
 
     def belonging_to_non_existent_class(model_name, assoc_name, options = {})
       define_model model_name, "#{assoc_name}_id" => :integer do
-        belongs_to assoc_name, options
+        belongs_to assoc_name, **options
       end.new
     end
   end
@@ -1158,14 +1158,14 @@ Expected Parent to have a has_many association called children through conceptio
           order = options.delete(:order)
           define_association_with_order(model, :has_many, :children, order, options)
         else
-          model.has_many :children, options
+          model.has_many :children, **options
         end
       end.new
     end
 
     def having_many_non_existent_class(model_name, assoc_name, options = {})
       define_model model_name do
-        has_many assoc_name, options
+        has_many assoc_name, **options
       end.new
     end
   end
@@ -1496,14 +1496,14 @@ Expected Parent to have a has_many association called children through conceptio
           order = options.delete(:order)
           define_association_with_order(model, :has_one, :detail, order, options)
         else
-          model.has_one :detail, options
+          model.has_one :detail, **options
         end
       end.new
     end
 
     def having_one_non_existent(model_name, assoc_name, options = {})
       define_model model_name do
-        has_one assoc_name, options
+        has_one assoc_name, **options
       end.new
     end
   end
@@ -2126,25 +2126,17 @@ Expected Person to have a has_and_belongs_to_many association called relatives (
 
     def having_and_belonging_to_many_non_existent_class(model_name, assoc_name, options = {})
       define_model model_name do
-        has_and_belongs_to_many assoc_name, options
+        has_and_belongs_to_many assoc_name, **options
       end.new
     end
   end
 
   def define_association_with_conditions(model, macro, name, conditions, _other_options = {})
-    args = []
-    options = {}
-    args << proc { where(conditions) }
-    args << options
-    model.__send__(macro, name, *args)
+    model.__send__(macro, name, proc { where(conditions) }, **{})
   end
 
   def define_association_with_order(model, macro, name, order, _other_options = {})
-    args = []
-    options = {}
-    args << proc { order(order) }
-    args << options
-    model.__send__(macro, name, *args)
+    model.__send__(macro, name, proc { order(order) }, **{})
   end
 
   def dependent_options

--- a/spec/unit/shoulda/matchers/active_record/have_db_column_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/have_db_column_matcher_spec.rb
@@ -112,7 +112,7 @@ describe Shoulda::Matchers::ActiveRecord::HaveDbColumnMatcher, type: :model do
 
   def with_table(column_name, column_type, options)
     create_table 'employees' do |table|
-      table.__send__(column_type, column_name, options)
+      table.__send__(column_type, column_name, **options)
     end
     define_model_class('Employee').new
   end


### PR DESCRIPTION
Fixing all warnings raised by ruby when running bundle exec rake:

```
<path-to>/shoulda-matchers/spec/support/unit/helpers/model_builder.rb:47: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
<path-to>/shoulda-matchers/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb:844: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
<path-to>/shoulda-matchers/spec/support/unit/active_record/create_table.rb:128: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
<path-to>/shoulda-matchers/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb:160: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
<path-to>/shoulda-matchers/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb:1013: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
<path-to>/shoulda-matchers/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb:188: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
<path-to>/shoulda-matchers/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb:800: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
<path-to>/shoulda-matchers/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb:101: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
<path-to>/shoulda-matchers/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb:871: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
<path-to>/shoulda-matchers/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb:866: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
<path-to>/shoulda-matchers/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb:47: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
<path-to>/shoulda-matchers/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb:132: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
<path-to>/shoulda-matchers/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb:73: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
<path-to>/shoulda-matchers/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb:209: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
<path-to>/shoulda-matchers/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb:23: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
<path-to>/shoulda-matchers/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb:907: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
<path-to>/shoulda-matchers/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb:899: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
<path-to>/shoulda-matchers/spec/unit/shoulda/matchers/active_record/have_db_column_matcher_spec.rb:115: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
<path-to>/shoulda-matchers/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb:1259: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
<path-to>/shoulda-matchers/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb:1266: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
<path-to>/shoulda-matchers/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb:1599: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
<path-to>/shoulda-matchers/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb:1606: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
<path-to>/shoulda-matchers/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb:2229: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
<path-to>/shoulda-matchers/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb:815: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
<path-to>/shoulda-matchers/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb:844: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
<path-to>/shoulda-matchers/spec/unit/shoulda/matchers/active_record/have_db_index_matcher_spec.rb:10: warning: The called method is defined here
<path-to>/shoulda-matchers/spec/unit/shoulda/matchers/active_record/have_db_index_matcher_spec.rb:358: warning: The called method is defined here
<path-to>/shoulda-matchers/spec/support/unit/matchers/fail_with_message_matcher.rb:5: warning: The called method is defined here
<path-to>/shoulda-matchers/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb:2243: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
<path-to>/shoulda-matchers/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb:2255: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
 ```