### PR TITLE
Remove Ruby 2.4 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,6 @@ jobs:
           - 2.7.2
           - 2.6.6
           - 2.5.8
-          - 2.4.10
         appraisal:
           - rails_6_0
           - rails_5_2
@@ -43,7 +42,6 @@ jobs:
         exclude:
           - { ruby: 2.7.2, appraisal: rails_4_2 }
           - { ruby: 2.6.6, appraisal: rails_4_2 }
-          - { ruby: 2.4.10, appraisal: rails_6_0 }
     env:
       DATABASE_ADAPTER: ${{ matrix.adapter }}
       BUNDLE_GEMFILE: gemfiles/${{ matrix.appraisal }}.gemfile

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
   - rubocop-rails
 AllCops:
   NewCops: disable
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   Exclude:
     - 'gemfiles/*'
 Bundler/OrderedGems:

--- a/README.md
+++ b/README.md
@@ -468,12 +468,14 @@ machine, understanding the codebase, and creating a good pull request.
 
 ## Compatibility
 
-Shoulda Matchers is [tested][travis] and supported against Ruby 2.4+, Rails
+Shoulda Matchers is [tested][travis] and supported against Ruby 2.5+, Rails
 4.2+, RSpec 3.x, and Minitest 5.x.
 
 For Ruby < 2.4 and Rails < 4.1 compatibility, please use [v3.1.3][v3.1.3].
+For Ruby < 3.0 and Rails < 6.1 compatibility, please use [v4.5.1][v4.5.1].
 
 [v3.1.3]: https://github.com/thoughtbot/shoulda-matchers/tree/v3.1.3
+[v4.5.1]: https://github.com/thoughtbot/shoulda-matchers/tree/v4.5.1
 
 ## Versioning
 

--- a/shoulda-matchers.gemspec
+++ b/shoulda-matchers.gemspec
@@ -36,6 +36,6 @@ Gem::Specification.new do |s|
     'shoulda-matchers.gemspec']
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 2.4.0'
+  s.required_ruby_version = '>= 2.5.0'
   s.add_dependency('activesupport', '>= 4.2.0')
 end


### PR DESCRIPTION
Official support for Ruby 2.4 ended in April 2020.

Ref: https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/

