### PR TITLE
Remove ruby 2.5 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,6 @@ jobs:
         ruby:
           - 2.7.2
           - 2.6.6
-          - 2.5.8
         appraisal:
           - rails_6_0
           - rails_5_2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
   - rubocop-rails
 AllCops:
   NewCops: disable
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
   Exclude:
     - 'gemfiles/*'
 Bundler/OrderedGems:

--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ machine, understanding the codebase, and creating a good pull request.
 
 ## Compatibility
 
-Shoulda Matchers is tested and supported against Ruby 2.5+, Rails
+Shoulda Matchers is tested and supported against Ruby 2.6+, Rails
 5.0+, RSpec 3.x, and Minitest 5.x.
 
 - For Ruby < 2.4 and Rails < 4.1 compatibility, please use [v3.1.3][v3.1.3].

--- a/doc_config/yard/templates/default/layout/html/setup.rb
+++ b/doc_config/yard/templates/default/layout/html/setup.rb
@@ -32,7 +32,7 @@ def preprocess_index(contents)
       map do |value|
         value.
           split('_').
-          map { |word| word[0].upcase + word[1..-1] }.
+          map { |word| word[0].upcase + word[1..] }.
           join
       end.
       join('::')

--- a/lib/shoulda/matchers/active_model/validate_numericality_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_numericality_of_matcher.rb
@@ -643,7 +643,7 @@ module Shoulda
             if number_of_submatchers_for_failure_message > 1
               "In checking that #{model.name} #{submatcher_description}, " +
                 failure_message[0].downcase +
-                failure_message[1..-1]
+                failure_message[1..]
             else
               failure_message
             end

--- a/lib/shoulda/matchers/util/word_wrap.rb
+++ b/lib/shoulda/matchers/util/word_wrap.rb
@@ -185,7 +185,7 @@ module Shoulda
           leftover = ''
         else
           fitted_line = line[0..index].rstrip
-          leftover = line[index + 1..-1]
+          leftover = line[index + 1..]
         end
 
         { fitted_line: fitted_line, leftover: leftover }

--- a/shoulda-matchers.gemspec
+++ b/shoulda-matchers.gemspec
@@ -36,6 +36,6 @@ Gem::Specification.new do |s|
     'shoulda-matchers.gemspec']
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 2.5.0'
+  s.required_ruby_version = '>= 2.6.0'
   s.add_dependency('activesupport', '>= 5.0.0')
 end

--- a/spec/support/tests/command_runner.rb
+++ b/spec/support/tests/command_runner.rb
@@ -95,7 +95,7 @@ module Tests
         new_lines << "(...#{lines.size - 10} more lines...)"
       end
 
-      new_lines << lines[-5..-1]
+      new_lines << lines[-5..]
       new_lines.join("\n")
     end
 

--- a/spec/support/unit/matchers/fail_with_message_matcher.rb
+++ b/spec/support/unit/matchers/fail_with_message_matcher.rb
@@ -31,7 +31,7 @@ module UnitTests
         lines << Shoulda::Matchers::Util.indent(expected, 2)
 
         if @actual
-          diff = differ.diff(@actual, expected)[1..-1]
+          diff = differ.diff(@actual, expected)[1..]
 
           lines << 'Actually failed with:'
           lines << Shoulda::Matchers::Util.indent(@actual, 2)

--- a/spec/support/unit/matchers/match_against.rb
+++ b/spec/support/unit/matchers/match_against.rb
@@ -205,7 +205,7 @@ Diff:
       end
 
       def diff(expected, actual)
-        differ.diff(expected, actual)[1..-1]
+        differ.diff(expected, actual)[1..]
       end
 
       def differ

--- a/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb
@@ -454,7 +454,7 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
 
     it 'matches given a subset of the valid values' do
       builder = build_object_allowing(possible_values)
-      expect_to_match_on_values(builder, possible_values[1..-1])
+      expect_to_match_on_values(builder, possible_values[1..])
     end
 
     if zero


### PR DESCRIPTION
The support of ruby 2.5 will end at the end of March 2021. 

Ref: https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/

I'm just leaving the project one step ahead.

What do you think?