### PR TITLE
Standardize error message of association matcher

### DIFF
--- a/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -1350,7 +1350,7 @@ Expected Parent to have a has_many association called children through conceptio
       end
 
       expected_message = 'Expected Person to have a has_one association called detail ' \
-        '(PersonDetail does not have a ["company_id", "person_detail_id"] foreign key.)'
+        '(PersonDetail does not have a [:company_id, :person_detail_id] foreign key.)'
 
       expect do
         have_one(:detail).class_name('PersonDetail').


### PR DESCRIPTION
I noticed that the association matcher was returning a slightly different message between the tests below:

https://github.com/thoughtbot/shoulda-matchers/blob/9763c17d27221c5d3946b0b297b0c17b8f5644f5/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb#L1451-L1454

https://github.com/thoughtbot/shoulda-matchers/blob/9763c17d27221c5d3946b0b297b0c17b8f5644f5/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb#L1436-L1439

Pay attention to the foreign_keys, their types are different. This PR standardized the error message  - in both cases the foreign_keys will be symbols. Besides that, these modifications fix one of the four tests that are failing with Rails 6.1.