### PR TITLE
Refactor ActiveRecordVersions

### DIFF
--- a/spec/support/unit/active_record/create_table.rb
+++ b/spec/support/unit/active_record/create_table.rb
@@ -55,12 +55,6 @@ module UnitTests
       attr_reader :table_name, :columns, :connection, :customizer
 
       delegate(
-        :active_record_supports_array_columns?,
-        :active_record_version,
-        to: UnitTests::ActiveRecordVersions,
-      )
-
-      delegate(
         :database_supports_array_columns?,
         :database_adapter,
         to: UnitTests::DatabaseHelpers,
@@ -99,22 +93,12 @@ module UnitTests
         column_type = column_specification.delete(:type)
         column_options = column_specification.delete(:options) { {} }
 
-        if column_options[:array]
-          if !active_record_supports_array_columns?
-            raise ArgumentError.new(
-              'An array column is being added to a table, but this version '\
-              "of ActiveRecord (#{active_record_version}) "\
-              'does not support array columns.',
-            )
-          end
-
-          if !database_supports_array_columns?
-            raise ArgumentError.new(
-              'An array column is being added to a table, but this '\
-              "database adapter (#{database_adapter}) "\
-              'does not support array columns.',
-            )
-          end
+        if column_options[:array] && !database_supports_array_columns?
+          raise ArgumentError.new(
+            'An array column is being added to a table, but this '\
+            "database adapter (#{database_adapter}) "\
+            'does not support array columns.',
+          )
         end
 
         if column_specification.any?

--- a/spec/support/unit/helpers/active_record_versions.rb
+++ b/spec/support/unit/helpers/active_record_versions.rb
@@ -11,10 +11,6 @@ module UnitTests
       Tests::Version.new(::ActiveRecord::VERSION::STRING)
     end
 
-    def active_record_enum_supports_prefix_and_suffix?
-      active_record_version >= 5
-    end
-
     def active_record_supports_has_secure_password?
       active_record_version >= 3.1
     end

--- a/spec/support/unit/helpers/active_record_versions.rb
+++ b/spec/support/unit/helpers/active_record_versions.rb
@@ -11,10 +11,6 @@ module UnitTests
       Tests::Version.new(::ActiveRecord::VERSION::STRING)
     end
 
-    def active_record_supports_has_secure_password?
-      active_record_version >= 3.1
-    end
-
     def active_record_supports_has_secure_token?
       active_record_version >= 5.0
     end

--- a/spec/support/unit/helpers/active_record_versions.rb
+++ b/spec/support/unit/helpers/active_record_versions.rb
@@ -11,10 +11,6 @@ module UnitTests
       Tests::Version.new(::ActiveRecord::VERSION::STRING)
     end
 
-    def active_record_uniqueness_supports_array_columns?
-      active_record_version < 5
-    end
-
     def active_record_supports_optional_for_associations?
       active_record_version >= 5
     end

--- a/spec/support/unit/helpers/active_record_versions.rb
+++ b/spec/support/unit/helpers/active_record_versions.rb
@@ -11,10 +11,6 @@ module UnitTests
       Tests::Version.new(::ActiveRecord::VERSION::STRING)
     end
 
-    def active_record_supports_array_columns?
-      active_record_version > 4.2
-    end
-
     def active_record_supports_relations?
       active_record_version >= 4
     end

--- a/spec/support/unit/helpers/active_record_versions.rb
+++ b/spec/support/unit/helpers/active_record_versions.rb
@@ -11,10 +11,6 @@ module UnitTests
       Tests::Version.new(::ActiveRecord::VERSION::STRING)
     end
 
-    def active_record_supports_has_secure_token?
-      active_record_version >= 5.0
-    end
-
     def active_record_supports_array_columns?
       active_record_version > 4.2
     end

--- a/spec/support/unit/helpers/active_record_versions.rb
+++ b/spec/support/unit/helpers/active_record_versions.rb
@@ -11,10 +11,6 @@ module UnitTests
       Tests::Version.new(::ActiveRecord::VERSION::STRING)
     end
 
-    def active_record_supports_optional_for_associations?
-      active_record_version >= 5
-    end
-
     def active_record_supports_expression_indexes?
       active_record_version >= 5
     end

--- a/spec/support/unit/helpers/active_record_versions.rb
+++ b/spec/support/unit/helpers/active_record_versions.rb
@@ -11,10 +11,6 @@ module UnitTests
       Tests::Version.new(::ActiveRecord::VERSION::STRING)
     end
 
-    def active_record_supports_relations?
-      active_record_version >= 4
-    end
-
     def active_record_supports_more_dependent_options?
       active_record_version >= 4
     end

--- a/spec/support/unit/helpers/active_record_versions.rb
+++ b/spec/support/unit/helpers/active_record_versions.rb
@@ -11,10 +11,6 @@ module UnitTests
       Tests::Version.new(::ActiveRecord::VERSION::STRING)
     end
 
-    def active_record_supports_more_dependent_options?
-      active_record_version >= 4
-    end
-
     def active_record_uniqueness_supports_array_columns?
       active_record_version < 5
     end

--- a/spec/support/unit/helpers/active_record_versions.rb
+++ b/spec/support/unit/helpers/active_record_versions.rb
@@ -11,10 +11,6 @@ module UnitTests
       Tests::Version.new(::ActiveRecord::VERSION::STRING)
     end
 
-    def active_record_supports_expression_indexes?
-      active_record_version >= 5
-    end
-
     def active_record_supports_active_storage?
       active_record_version >= 5.2
     end

--- a/spec/unit/shoulda/matchers/active_model/validate_absence_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_absence_of_matcher_spec.rb
@@ -48,7 +48,7 @@ describe Shoulda::Matchers::ActiveModel::ValidateAbsenceOfMatcher, type: :model 
         end
       end
 
-      if database_supports_array_columns? && active_record_supports_array_columns?
+      if database_supports_array_columns?
         context 'when the column backing the attribute is an array' do
           context 'of varchar' do
             it 'still works' do

--- a/spec/unit/shoulda/matchers/active_model/validate_presence_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_presence_of_matcher_spec.rb
@@ -502,68 +502,67 @@ this could not be proved.
   end
 
   context 'against a belongs_to association' do
-    if active_record_supports_optional_for_associations?
-      context 'declared with optional: true' do
-        context 'and an explicit presence validation is on the association' do
-          it 'matches' do
-            record = record_belonging_to(
-              :parent,
-              optional: true,
-              validate_presence: true,
-            )
+    context 'declared with optional: true' do
+      context 'and an explicit presence validation is on the association' do
+        it 'matches' do
+          record = record_belonging_to(
+            :parent,
+            optional: true,
+            validate_presence: true,
+          )
 
-            expect { validate_presence_of(:parent) }.to match_against(record)
-          end
+          expect { validate_presence_of(:parent) }.to match_against(record)
         end
+      end
 
-        context 'and an explicit presence validation is not on the association' do
-          it 'does not match' do
-            record = record_belonging_to(
-              :parent,
-              optional: true,
-              validate_presence: false,
-              model_name: 'Child',
-              parent_model_name: 'Parent',
-            )
+      context 'and an explicit presence validation is not on the association' do
+        it 'does not match' do
+          record = record_belonging_to(
+            :parent,
+            optional: true,
+            validate_presence: false,
+            model_name: 'Child',
+            parent_model_name: 'Parent',
+          )
 
-            expect { validate_presence_of(:parent) }.
-              not_to match_against(record).
-              and_fail_with(<<-MESSAGE)
+          expect { validate_presence_of(:parent) }.
+            not_to match_against(record).
+            and_fail_with(<<-MESSAGE)
 Expected Child to validate that :parent cannot be empty/falsy, but this
 could not be proved.
   After setting :parent to ‹nil›, the matcher expected the Child to be
   invalid, but it was valid instead.
-              MESSAGE
-          end
+            MESSAGE
+        end
+      end
+    end
+
+    context 'declared with optional: false' do
+      context 'and an explicit presence validation is on the association' do
+        it 'matches' do
+          record = record_belonging_to(
+            :parent,
+            optional: false,
+            validate_presence: true,
+          )
+
+          expect { validate_presence_of(:parent) }.to match_against(record)
         end
       end
 
-      context 'declared with optional: false' do
-        context 'and an explicit presence validation is on the association' do
-          it 'matches' do
-            record = record_belonging_to(
-              :parent,
-              optional: false,
-              validate_presence: true,
-            )
+      context 'and an explicit presence validation is not on the association' do
+        it 'does not match, instructing the user to use belongs_to instead' do
+          record = record_belonging_to(
+            :parent,
+            optional: false,
+            validate_presence: false,
+            model_name: 'Child',
+            parent_model_name: 'Parent',
+          )
 
-            expect { validate_presence_of(:parent) }.to match_against(record)
-          end
-        end
-
-        context 'and an explicit presence validation is not on the association' do
-          it 'does not match, instructing the user to use belongs_to instead' do
-            record = record_belonging_to(
-              :parent,
-              optional: false,
-              validate_presence: false,
-              model_name: 'Child',
-              parent_model_name: 'Parent',
-            )
-
-            expect { validate_presence_of(:parent) }.
-              not_to match_against(record).
-              and_fail_with(<<-MESSAGE)
+          expect { validate_presence_of(:parent) }.
+            not_to match_against(record).
+            and_fail_with(<<-MESSAGE)
 Expected Child to validate that :parent cannot be empty/falsy, but this
 could not be proved.
   After setting :parent to ‹nil›, the matcher expected the Child to be
@@ -584,37 +583,37 @@ could not be proved.
 
       it { should belong_to(:parent).optional(false) }
       it { should belong_to(:parent).required(true) }
-              MESSAGE
-          end
+            MESSAGE
+        end
+      end
+    end
+
+    context 'declared with required: true' do
+      context 'and an explicit presence validation is on the association' do
+        it 'matches' do
+          record = record_belonging_to(
+            :parent,
+            required: true,
+            validate_presence: true,
+          )
+
+          expect { validate_presence_of(:parent) }.to match_against(record)
         end
       end
 
-      context 'declared with required: true' do
-        context 'and an explicit presence validation is on the association' do
-          it 'matches' do
-            record = record_belonging_to(
-              :parent,
-              required: true,
-              validate_presence: true,
-            )
+      context 'and an explicit presence validation is not on the association' do
+        it 'does not match, instructing the user to use belongs_to instead' do
+          record = record_belonging_to(
+            :parent,
+            required: true,
+            validate_presence: false,
+            model_name: 'Child',
+            parent_model_name: 'Parent',
+          )
 
-            expect { validate_presence_of(:parent) }.to match_against(record)
-          end
-        end
-
-        context 'and an explicit presence validation is not on the association' do
-          it 'does not match, instructing the user to use belongs_to instead' do
-            record = record_belonging_to(
-              :parent,
-              required: true,
-              validate_presence: false,
-              model_name: 'Child',
-              parent_model_name: 'Parent',
-            )
-
-            expect { validate_presence_of(:parent) }.
-              not_to match_against(record).
-              and_fail_with(<<-MESSAGE)
+          expect { validate_presence_of(:parent) }.
+            not_to match_against(record).
+            and_fail_with(<<-MESSAGE)
 Expected Child to validate that :parent cannot be empty/falsy, but this
 could not be proved.
   After setting :parent to ‹nil›, the matcher expected the Child to be
@@ -635,75 +634,75 @@ could not be proved.
 
       it { should belong_to(:parent).optional(false) }
       it { should belong_to(:parent).required(true) }
-              MESSAGE
-          end
+            MESSAGE
+        end
+      end
+    end
+
+    context 'declared with required: false' do
+      context 'and an explicit presence validation is on the association' do
+        it 'matches' do
+          record = record_belonging_to(
+            :parent,
+            required: false,
+            validate_presence: true,
+          )
+
+          expect { validate_presence_of(:parent) }.to match_against(record)
         end
       end
 
-      context 'declared with required: false' do
-        context 'and an explicit presence validation is on the association' do
-          it 'matches' do
-            record = record_belonging_to(
-              :parent,
-              required: false,
-              validate_presence: true,
-            )
+      context 'and an explicit presence validation is not on the association' do
+        it 'does not match' do
+          record = record_belonging_to(
+            :parent,
+            required: false,
+            validate_presence: false,
+            model_name: 'Child',
+            parent_model_name: 'Parent',
+          )
 
-            expect { validate_presence_of(:parent) }.to match_against(record)
-          end
-        end
-
-        context 'and an explicit presence validation is not on the association' do
-          it 'does not match' do
-            record = record_belonging_to(
-              :parent,
-              required: false,
-              validate_presence: false,
-              model_name: 'Child',
-              parent_model_name: 'Parent',
-            )
-
-            expect { validate_presence_of(:parent) }.
-              not_to match_against(record).
-              and_fail_with(<<-MESSAGE)
+          expect { validate_presence_of(:parent) }.
+            not_to match_against(record).
+            and_fail_with(<<-MESSAGE)
 Expected Child to validate that :parent cannot be empty/falsy, but this
 could not be proved.
   After setting :parent to ‹nil›, the matcher expected the Child to be
   invalid, but it was valid instead.
-              MESSAGE
-          end
+            MESSAGE
         end
       end
+    end
 
-      context 'not declared with an optional or required option' do
-        context 'when belongs_to is configured to be required by default' do
-          context 'and an explicit presence validation is on the association' do
-            it 'matches' do
-              with_belongs_to_as_required_by_default do
-                record = record_belonging_to(
-                  :parent,
-                  validate_presence: true,
-                )
+    context 'not declared with an optional or required option' do
+      context 'when belongs_to is configured to be required by default' do
+        context 'and an explicit presence validation is on the association' do
+          it 'matches' do
+            with_belongs_to_as_required_by_default do
+              record = record_belonging_to(
+                :parent,
+                validate_presence: true,
+              )
 
-                expect { validate_presence_of(:parent) }.
-                  to match_against(record)
-              end
+              expect { validate_presence_of(:parent) }.
+                to match_against(record)
             end
           end
+        end
 
-          context 'and an explicit presence validation is not on the association' do
-            it 'does not match, instructing the user to use belong_to instead' do
-              with_belongs_to_as_required_by_default do
-                record = record_belonging_to(
-                  :parent,
-                  validate_presence: false,
-                  model_name: 'Child',
-                  parent_model_name: 'Parent',
-                )
+        context 'and an explicit presence validation is not on the association' do
+          it 'does not match, instructing the user to use belong_to instead' do
+            with_belongs_to_as_required_by_default do
+              record = record_belonging_to(
+                :parent,
+                validate_presence: false,
+                model_name: 'Child',
+                parent_model_name: 'Parent',
+              )
 
-                expect { validate_presence_of(:parent) }.
-                  not_to match_against(record).
-                  and_fail_with(<<-MESSAGE)
+              expect { validate_presence_of(:parent) }.
+                not_to match_against(record).
+                and_fail_with(<<-MESSAGE)
 Expected Child to validate that :parent cannot be empty/falsy, but this
 could not be proved.
   After setting :parent to ‹nil›, the matcher expected the Child to be
@@ -723,133 +722,46 @@ could not be proved.
   the following instead:
 
       it { should belong_to(:parent) }
-                  MESSAGE
-              end
-            end
-          end
-        end
-
-        context 'when belongs_to is configured to be optional by default' do
-          context 'and an explicit presence validation is on the association' do
-            it 'matches' do
-              with_belongs_to_as_optional_by_default do
-                record = record_belonging_to(
-                  :parent,
-                  validate_presence: true,
-                )
-
-                expect { validate_presence_of(:parent) }.
-                  to match_against(record)
-              end
-            end
-          end
-
-          context 'and an explicit presence validation is not on the association' do
-            it 'does not match' do
-              with_belongs_to_as_optional_by_default do
-                record = record_belonging_to(
-                  :parent,
-                  validate_presence: false,
-                  model_name: 'Child',
-                  parent_model_name: 'Parent',
-                )
-
-                expect { validate_presence_of(:parent) }.
-                  not_to match_against(record).
-                  and_fail_with(<<-MESSAGE)
-Expected Child to validate that :parent cannot be empty/falsy, but this
-could not be proved.
-  After setting :parent to ‹nil›, the matcher expected the Child to be
-  invalid, but it was valid instead.
-                  MESSAGE
-              end
+                MESSAGE
             end
           end
         end
       end
-    else
-      context 'declared with required: true' do
+
+      context 'when belongs_to is configured to be optional by default' do
         context 'and an explicit presence validation is on the association' do
           it 'matches' do
-            record = record_belonging_to(
-              :parent,
-              required: true,
-              validate_presence: true,
-            )
+            with_belongs_to_as_optional_by_default do
+              record = record_belonging_to(
+                :parent,
+                validate_presence: true,
+              )
 
-            expect { validate_presence_of(:parent) }.to match_against(record)
-          end
-        end
-
-        context 'and an explicit presence validation is not on the association' do
-          it 'still matches' do
-            record = record_belonging_to(
-              :parent,
-              required: true,
-              validate_presence: false,
-            )
-
-            expect { validate_presence_of(:parent) }.to match_against(record)
-          end
-        end
-      end
-
-      context 'declared with required: false' do
-        context 'and an explicit presence validation is on the association' do
-          it 'matches' do
-            record = record_belonging_to(
-              :parent,
-              required: false,
-              validate_presence: true,
-            )
-
-            expect { validate_presence_of(:parent) }.to match_against(record)
+              expect { validate_presence_of(:parent) }.
+                to match_against(record)
+            end
           end
         end
 
         context 'and an explicit presence validation is not on the association' do
           it 'does not match' do
-            record = record_belonging_to(
-              :parent,
-              required: false,
-              validate_presence: false,
-              model_name: 'Child',
-              parent_model_name: 'Parent',
-            )
+            with_belongs_to_as_optional_by_default do
+              record = record_belonging_to(
+                :parent,
+                validate_presence: false,
+                model_name: 'Child',
+                parent_model_name: 'Parent',
+              )
 
-            expect { validate_presence_of(:parent) }.
-              not_to match_against(record).
-              and_fail_with(<<-MESSAGE)
+              expect { validate_presence_of(:parent) }.
+                not_to match_against(record).
+                and_fail_with(<<-MESSAGE)
 Expected Child to validate that :parent cannot be empty/falsy, but this
 could not be proved.
   After setting :parent to ‹nil›, the matcher expected the Child to be
   invalid, but it was valid instead.
-              MESSAGE
-          end
-        end
-      end
-
-      context 'not declared with a required option' do
-        context 'and an explicit presence validation is on the association' do
-          it 'matches' do
-            record = record_belonging_to(:parent, validate_presence: true)
-
-            expect { validate_presence_of(:parent) }.to match_against(record)
-          end
-        end
-
-        context 'and an explicit presence validation is not on the association' do
-          it 'does not match' do
-            record = record_belonging_to(:parent, validate_presence: false)
-
-            expect { validate_presence_of(:parent) }.
-              not_to match_against(record).
-              and_fail_with(<<-MESSAGE)
-Expected Child to validate that :parent cannot be empty/falsy, but this
-could not be proved.
-  After setting :parent to ‹nil›, the matcher expected the Child to be
-  invalid, but it was valid instead.
-              MESSAGE
+                MESSAGE
+            end
           end
         end
       end

--- a/spec/unit/shoulda/matchers/active_model/validate_presence_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_presence_of_matcher_spec.rb
@@ -116,7 +116,7 @@ this could not be proved.
       end
     end
 
-    if database_supports_array_columns? && active_record_supports_array_columns?
+    if database_supports_array_columns?
       context 'when the column backing the attribute is an array' do
         context 'of varchar' do
           it 'still works' do

--- a/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -2248,10 +2248,6 @@ Expected Person to have a has_and_belongs_to_many association called relatives (
   end
 
   def dependent_options
-    if active_record_supports_more_dependent_options?
-      [:destroy, :delete, :nullify, :restrict_with_exception, :restrict_with_error]
-    else
-      [:destroy, :delete, :nullify, :restrict]
-    end
+    [:destroy, :delete, :nullify, :restrict_with_exception, :restrict_with_error]
   end
 end

--- a/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -2234,11 +2234,7 @@ Expected Person to have a has_and_belongs_to_many association called relatives (
   def define_association_with_conditions(model, macro, name, conditions, _other_options = {})
     args = []
     options = {}
-    if active_record_supports_relations?
-      args << proc { where(conditions) }
-    else
-      options[:conditions] = conditions
-    end
+    args << proc { where(conditions) }
     args << options
     model.__send__(macro, name, *args)
   end
@@ -2246,11 +2242,7 @@ Expected Person to have a has_and_belongs_to_many association called relatives (
   def define_association_with_order(model, macro, name, order, _other_options = {})
     args = []
     options = {}
-    if active_record_supports_relations?
-      args << proc { order(order) }
-    else
-      options[:order] = order
-    end
+    args << proc { order(order) }
     args << options
     model.__send__(macro, name, *args)
   end

--- a/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -283,281 +283,187 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
 
     context 'given the association is neither configured to be required nor optional' do
       context 'when qualified with required(true)' do
-        if active_record_supports_optional_for_associations?
-          context 'when belongs_to is configured to be required by default' do
-            it 'passes' do
-              with_belongs_to_as_required_by_default do
-                expect(belonging_to_parent).to belong_to(:parent).required(true)
-              end
+        context 'when belongs_to is configured to be required by default' do
+          it 'passes' do
+            with_belongs_to_as_required_by_default do
+              expect(belonging_to_parent).to belong_to(:parent).required(true)
             end
           end
+        end
 
-          context 'when belongs_to is not configured to be required by default' do
-            it 'fails with an appropriate message' do
-              with_belongs_to_as_optional_by_default do
-                assertion = lambda do
-                  expect(belonging_to_parent).
-                    to belong_to(:parent).required(true)
-                end
-
-                message = format_message(<<-MESSAGE, one_line: true)
-                  Expected Child to have a belongs_to association called parent
-                  (and for the record to fail validation if :parent is unset;
-                  i.e., either the association should have been defined with
-                  `required: true`, or there should be a presence validation on
-                  :parent)
-                MESSAGE
-
-                expect(&assertion).to fail_with_message(message)
-              end
-            end
-          end
-        else
+        context 'when belongs_to is not configured to be required by default' do
           it 'fails with an appropriate message' do
-            assertion = lambda do
-              expect(belonging_to_parent).
-                to belong_to(:parent).required(true)
+            with_belongs_to_as_optional_by_default do
+              assertion = lambda do
+                expect(belonging_to_parent).
+                  to belong_to(:parent).required(true)
+              end
+
+              message = format_message(<<-MESSAGE, one_line: true)
+                Expected Child to have a belongs_to association called parent
+                (and for the record to fail validation if :parent is unset;
+                i.e., either the association should have been defined with
+                `required: true`, or there should be a presence validation on
+                :parent)
+              MESSAGE
+
+              expect(&assertion).to fail_with_message(message)
             end
-
-            message = format_message(<<-MESSAGE, one_line: true)
-              Expected Child to have a belongs_to association called parent
-              (and for the record to fail validation if :parent is unset; i.e.,
-              either the association should have been defined with `required:
-              true`, or there should be a presence validation on :parent)
-            MESSAGE
-
-            expect(&assertion).to fail_with_message(message)
           end
         end
       end
 
       context 'when qualified with required(false)' do
-        if active_record_supports_optional_for_associations?
-          context 'when belongs_to is configured to be required by default' do
-            it 'fails with an appropriate message' do
-              with_belongs_to_as_required_by_default do
-                assertion = lambda do
-                  expect(belonging_to_parent).
-                    to belong_to(:parent).required(false)
-                end
-
-                message = format_message(<<-MESSAGE, one_line: true)
-                  Expected Child to have a belongs_to association called parent
-                  (and for the record not to fail validation if :parent is
-                  unset; i.e., either the association should have been defined
-                  with `required: false`, or there should not be a presence
-                  validation on :parent)
-                MESSAGE
-
-                expect(&assertion).to fail_with_message(message)
+        context 'when belongs_to is configured to be required by default' do
+          it 'fails with an appropriate message' do
+            with_belongs_to_as_required_by_default do
+              assertion = lambda do
+                expect(belonging_to_parent).
+                  to belong_to(:parent).required(false)
               end
+
+              message = format_message(<<-MESSAGE, one_line: true)
+                Expected Child to have a belongs_to association called parent
+                (and for the record not to fail validation if :parent is
+                unset; i.e., either the association should have been defined
+                with `required: false`, or there should not be a presence
+                validation on :parent)
+              MESSAGE
+
+              expect(&assertion).to fail_with_message(message)
             end
           end
+        end
 
-          context 'when belongs_to is not configured to be required by default' do
-            it 'passes' do
-              with_belongs_to_as_optional_by_default do
-                expect(belonging_to_parent).to belong_to(:parent).required(false)
-              end
-            end
-          end
-        else
+        context 'when belongs_to is not configured to be required by default' do
           it 'passes' do
-            expect(belonging_to_parent).to belong_to(:parent).required(false)
+            with_belongs_to_as_optional_by_default do
+              expect(belonging_to_parent).to belong_to(:parent).required(false)
+            end
           end
         end
       end
 
       context 'when qualified with optional(true)' do
-        if active_record_supports_optional_for_associations?
-          context 'when belongs_to is configured to be required by default' do
-            it 'fails with an appropriate message' do
-              with_belongs_to_as_required_by_default do
-                assertion = lambda do
-                  expect(belonging_to_parent).
-                    to belong_to(:parent).optional(true)
-                end
-
-                message = format_message(<<-MESSAGE, one_line: true)
-                  Expected Child to have a belongs_to association called parent
-                  (and for the record not to fail validation if :parent is
-                  unset; i.e., either the association should have been defined
-                  with `optional: true`, or there should not be a presence
-                  validation on :parent)
-                MESSAGE
-
-                expect(&assertion).to fail_with_message(message)
+        context 'when belongs_to is configured to be required by default' do
+          it 'fails with an appropriate message' do
+            with_belongs_to_as_required_by_default do
+              assertion = lambda do
+                expect(belonging_to_parent).
+                  to belong_to(:parent).optional(true)
               end
+
+              message = format_message(<<-MESSAGE, one_line: true)
+                Expected Child to have a belongs_to association called parent
+                (and for the record not to fail validation if :parent is
+                unset; i.e., either the association should have been defined
+                with `optional: true`, or there should not be a presence
+                validation on :parent)
+              MESSAGE
+
+              expect(&assertion).to fail_with_message(message)
             end
           end
+        end
 
-          context 'when belongs_to is not configured to be required by default' do
-            it 'passes' do
-              with_belongs_to_as_optional_by_default do
-                expect(belonging_to_parent).to belong_to(:parent).optional(true)
-              end
-            end
-          end
-        else
+        context 'when belongs_to is not configured to be required by default' do
           it 'passes' do
-            expect(belonging_to_parent).to belong_to(:parent).optional(true)
+            with_belongs_to_as_optional_by_default do
+              expect(belonging_to_parent).to belong_to(:parent).optional(true)
+            end
           end
         end
       end
 
       context 'when qualified with optional(false)' do
-        if active_record_supports_optional_for_associations?
-          context 'when belongs_to is configured to be required by default' do
-            it 'passes' do
-              with_belongs_to_as_required_by_default do
-                expect(belonging_to_parent).to belong_to(:parent).optional(false)
-              end
+        context 'when belongs_to is configured to be required by default' do
+          it 'passes' do
+            with_belongs_to_as_required_by_default do
+              expect(belonging_to_parent).to belong_to(:parent).optional(false)
             end
           end
+        end
 
-          context 'when belongs_to is not configured to be required by default' do
-            it 'fails with an appropriate message' do
-              with_belongs_to_as_optional_by_default do
-                assertion = lambda do
-                  expect(belonging_to_parent).
-                    to belong_to(:parent).optional(false)
-                end
-
-                message = format_message(<<-MESSAGE, one_line: true)
-                  Expected Child to have a belongs_to association called parent
-                  (and for the record to fail validation if :parent is
-                  unset; i.e., either the association should have been defined
-                  with `optional: false`, or there should be a presence
-                  validation on :parent)
-                MESSAGE
-
-                expect(&assertion).to fail_with_message(message)
-              end
-            end
-          end
-        else
+        context 'when belongs_to is not configured to be required by default' do
           it 'fails with an appropriate message' do
-            assertion = lambda do
-              expect(belonging_to_parent).
-                to belong_to(:parent).optional(false)
+            with_belongs_to_as_optional_by_default do
+              assertion = lambda do
+                expect(belonging_to_parent).
+                  to belong_to(:parent).optional(false)
+              end
+
+              message = format_message(<<-MESSAGE, one_line: true)
+                Expected Child to have a belongs_to association called parent
+                (and for the record to fail validation if :parent is
+                unset; i.e., either the association should have been defined
+                with `optional: false`, or there should be a presence
+                validation on :parent)
+              MESSAGE
+
+              expect(&assertion).to fail_with_message(message)
             end
-
-            message = format_message(<<-MESSAGE, one_line: true)
-              Expected Child to have a belongs_to association called parent
-              (and for the record to fail validation if :parent is unset; i.e.,
-              either the association should have been defined with `optional:
-              false`, or there should be a presence validation on :parent)
-            MESSAGE
-
-            expect(&assertion).to fail_with_message(message)
           end
         end
       end
 
       context 'when qualified with nothing' do
-        if active_record_supports_optional_for_associations?
-          context 'when belongs_to is configured to be required by default' do
-            it 'passes' do
-              with_belongs_to_as_required_by_default do
-                expect(belonging_to_parent).to belong_to(:parent)
-              end
-            end
-          end
-
-          context 'when belongs_to is not configured to be required by default' do
-            it 'passes' do
-              with_belongs_to_as_optional_by_default do
-                expect(belonging_to_parent).to belong_to(:parent)
-              end
-            end
-
-            context 'and a presence validation is on the attribute instead of using required: true' do
-              it 'passes' do
-                with_belongs_to_as_optional_by_default do
-                  record = belonging_to_parent do
-                    validates_presence_of :parent
-                  end
-
-                  expect(record).to belong_to(:parent)
-                end
-              end
-            end
-
-            context 'and a presence validation is on the attribute with a condition' do
-              context 'and the condition is true' do
-                it 'passes' do
-                  with_belongs_to_as_optional_by_default do
-                    child_model = create_child_model_belonging_to_parent do
-                      attr_accessor :condition
-
-                      validates_presence_of :parent, if: :condition
-                    end
-
-                    record = child_model.new(condition: true)
-
-                    expect(record).to belong_to(:parent)
-                  end
-                end
-              end
-
-              context 'and the condition is false' do
-                it 'passes' do
-                  with_belongs_to_as_optional_by_default do
-                    child_model = create_child_model_belonging_to_parent do
-                      attr_accessor :condition
-
-                      validates_presence_of :parent, if: :condition
-                    end
-
-                    record = child_model.new(condition: false)
-
-                    expect(record).to belong_to(:parent)
-                  end
-                end
-              end
-            end
-          end
-        else
+        context 'when belongs_to is configured to be required by default' do
           it 'passes' do
-            expect(belonging_to_parent).to belong_to(:parent)
+            with_belongs_to_as_required_by_default do
+              expect(belonging_to_parent).to belong_to(:parent)
+            end
+          end
+        end
+
+        context 'when belongs_to is not configured to be required by default' do
+          it 'passes' do
+            with_belongs_to_as_optional_by_default do
+              expect(belonging_to_parent).to belong_to(:parent)
+            end
           end
 
           context 'and a presence validation is on the attribute instead of using required: true' do
             it 'passes' do
-              record = belonging_to_parent do
-                validates_presence_of :parent
-              end
+              with_belongs_to_as_optional_by_default do
+                record = belonging_to_parent do
+                  validates_presence_of :parent
+                end
 
-              expect(record).to belong_to(:parent)
+                expect(record).to belong_to(:parent)
+              end
             end
           end
 
           context 'and a presence validation is on the attribute with a condition' do
             context 'and the condition is true' do
               it 'passes' do
-                child_model = create_child_model_belonging_to_parent do
-                  attr_accessor :condition
+                with_belongs_to_as_optional_by_default do
+                  child_model = create_child_model_belonging_to_parent do
+                    attr_accessor :condition
 
-                  validates_presence_of :parent, if: :condition
+                    validates_presence_of :parent, if: :condition
+                  end
+
+                  record = child_model.new(condition: true)
+
+                  expect(record).to belong_to(:parent)
                 end
-
-                record = child_model.new(condition: true)
-
-                expect(record).to belong_to(:parent)
               end
             end
 
             context 'and the condition is false' do
               it 'passes' do
-                child_model = create_child_model_belonging_to_parent do
-                  attr_accessor :condition
+                with_belongs_to_as_optional_by_default do
+                  child_model = create_child_model_belonging_to_parent do
+                    attr_accessor :condition
 
-                  validates_presence_of :parent, if: :condition
+                    validates_presence_of :parent, if: :condition
+                  end
+
+                  record = child_model.new(condition: false)
+
+                  expect(record).to belong_to(:parent)
                 end
-
-                record = child_model.new(condition: false)
-
-                expect(record).to belong_to(:parent)
               end
             end
           end
@@ -624,171 +530,167 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
       end
     end
 
-    if active_record_supports_optional_for_associations?
-      context 'given the association is configured as optional: true' do
-        context 'when qualified with required(true)' do
-          it 'fails with an appropriate message' do
-            assertion = lambda do
-              expect(belonging_to_parent(optional: true)).
-                to belong_to(:parent).required(true)
-            end
-
-            message = format_message(<<-MESSAGE, one_line: true)
-              Expected Child to have a belongs_to association called parent
-              (and for the record to fail validation if :parent is unset; i.e.,
-              either the association should have been defined with `required:
-              true`, or there should be a presence validation on :parent)
-            MESSAGE
-
-            expect(&assertion).to fail_with_message(message)
-          end
-        end
-
-        context 'when qualified with required(false)' do
-          it 'passes' do
+    context 'given the association is configured as optional: true' do
+      context 'when qualified with required(true)' do
+        it 'fails with an appropriate message' do
+          assertion = lambda do
             expect(belonging_to_parent(optional: true)).
-              to belong_to(:parent).required(false)
+              to belong_to(:parent).required(true)
           end
-        end
 
-        context 'when qualified with optional(true)' do
-          it 'passes' do
+          message = format_message(<<-MESSAGE, one_line: true)
+            Expected Child to have a belongs_to association called parent
+            (and for the record to fail validation if :parent is unset; i.e.,
+            either the association should have been defined with `required:
+            true`, or there should be a presence validation on :parent)
+          MESSAGE
+
+          expect(&assertion).to fail_with_message(message)
+        end
+      end
+
+      context 'when qualified with required(false)' do
+        it 'passes' do
+          expect(belonging_to_parent(optional: true)).
+            to belong_to(:parent).required(false)
+        end
+      end
+
+      context 'when qualified with optional(true)' do
+        it 'passes' do
+          expect(belonging_to_parent(optional: true)).
+            to belong_to(:parent).optional(true)
+        end
+      end
+
+      context 'when qualified with optional(false)' do
+        it 'fails with an appropriate message' do
+          assertion = lambda do
             expect(belonging_to_parent(optional: true)).
-              to belong_to(:parent).optional(true)
+              to belong_to(:parent).optional(false)
           end
+
+          message = format_message(<<-MESSAGE, one_line: true)
+            Expected Child to have a belongs_to association called parent
+            (and for the record to fail validation if :parent is unset; i.e.,
+            either the association should have been defined with `optional:
+            false`, or there should be a presence validation on :parent)
+          MESSAGE
+
+          expect(&assertion).to fail_with_message(message)
         end
+      end
 
-        context 'when qualified with optional(false)' do
-          it 'fails with an appropriate message' do
-            assertion = lambda do
-              expect(belonging_to_parent(optional: true)).
-                to belong_to(:parent).optional(false)
-            end
-
-            message = format_message(<<-MESSAGE, one_line: true)
-              Expected Child to have a belongs_to association called parent
-              (and for the record to fail validation if :parent is unset; i.e.,
-              either the association should have been defined with `optional:
-              false`, or there should be a presence validation on :parent)
-            MESSAGE
-
-            expect(&assertion).to fail_with_message(message)
+      context 'when qualified with nothing' do
+        it 'fails with an appropriate message' do
+          assertion = lambda do
+            expect(belonging_to_parent(optional: true)).
+              to belong_to(:parent)
           end
-        end
 
-        context 'when qualified with nothing' do
-          it 'fails with an appropriate message' do
-            assertion = lambda do
-              expect(belonging_to_parent(optional: true)).
-                to belong_to(:parent)
-            end
+          message = format_message(<<-MESSAGE, one_line: true)
+            Expected Child to have a belongs_to association called parent
+            (and for the record to fail validation if :parent is unset; i.e.,
+            either the association should have been defined with `required:
+            true`, or there should be a presence validation on :parent)
+          MESSAGE
 
-            message = format_message(<<-MESSAGE, one_line: true)
-              Expected Child to have a belongs_to association called parent
-              (and for the record to fail validation if :parent is unset; i.e.,
-              either the association should have been defined with `required:
-              true`, or there should be a presence validation on :parent)
-            MESSAGE
-
-            expect(&assertion).to fail_with_message(message)
-          end
+          expect(&assertion).to fail_with_message(message)
         end
       end
     end
 
-    if active_record_supports_optional_for_associations?
-      context 'when the model ensures the association is set' do
-        context 'and the matcher is not qualified with anything' do
-          context 'and the matcher is not qualified with without_validating_presence' do
-            it 'fails with an appropriate message' do
-              model = create_child_model_belonging_to_parent do
-                before_validation :ensure_parent_is_set
+    context 'when the model ensures the association is set' do
+      context 'and the matcher is not qualified with anything' do
+        context 'and the matcher is not qualified with without_validating_presence' do
+          it 'fails with an appropriate message' do
+            model = create_child_model_belonging_to_parent do
+              before_validation :ensure_parent_is_set
 
-                def ensure_parent_is_set
-                  self.parent = Parent.create
-                end
+              def ensure_parent_is_set
+                self.parent = Parent.create
               end
-
-              assertion = lambda do
-                with_belongs_to_as_required_by_default do
-                  expect(model.new).to belong_to(:parent)
-                end
-              end
-
-              message = format_message(<<-MESSAGE, one_line: true)
-                Expected Child to have a belongs_to association called parent (and
-                for the record to fail validation if :parent is unset; i.e.,
-                either the association should have been defined with `required:
-                true`, or there should be a presence validation on :parent)
-              MESSAGE
-
-              expect(&assertion).to fail_with_message(message)
             end
-          end
 
-          context 'and the matcher is qualified with without_validating_presence' do
-            it 'passes' do
-              model = create_child_model_belonging_to_parent do
-                before_validation :ensure_parent_is_set
-
-                def ensure_parent_is_set
-                  self.parent = Parent.create
-                end
-              end
-
+            assertion = lambda do
               with_belongs_to_as_required_by_default do
-                expect(model.new).
-                  to belong_to(:parent).
-                  without_validating_presence
+                expect(model.new).to belong_to(:parent)
               end
             end
+
+            message = format_message(<<-MESSAGE, one_line: true)
+              Expected Child to have a belongs_to association called parent (and
+              for the record to fail validation if :parent is unset; i.e.,
+              either the association should have been defined with `required:
+              true`, or there should be a presence validation on :parent)
+            MESSAGE
+
+            expect(&assertion).to fail_with_message(message)
           end
         end
 
-        context 'and the matcher is qualified with required' do
-          context 'and the matcher is not qualified with without_validating_presence' do
-            it 'fails with an appropriate message' do
-              model = create_child_model_belonging_to_parent do
-                before_validation :ensure_parent_is_set
+        context 'and the matcher is qualified with without_validating_presence' do
+          it 'passes' do
+            model = create_child_model_belonging_to_parent do
+              before_validation :ensure_parent_is_set
 
-                def ensure_parent_is_set
-                  self.parent = Parent.create
-                end
+              def ensure_parent_is_set
+                self.parent = Parent.create
               end
+            end
 
-              assertion = lambda do
-                with_belongs_to_as_required_by_default do
-                  expect(model.new).to belong_to(:parent).required
-                end
-              end
-
-              message = format_message(<<-MESSAGE, one_line: true)
-                Expected Child to have a belongs_to association called parent
-                (and for the record to fail validation if :parent is unset; i.e.,
-                either the association should have been defined with `required:
-                true`, or there should be a presence validation on :parent)
-              MESSAGE
-
-              expect(&assertion).to fail_with_message(message)
+            with_belongs_to_as_required_by_default do
+              expect(model.new).
+                to belong_to(:parent).
+                without_validating_presence
             end
           end
+        end
+      end
 
-          context 'and the matcher is also qualified with without_validating_presence' do
-            it 'passes' do
-              model = create_child_model_belonging_to_parent do
-                before_validation :ensure_parent_is_set
+      context 'and the matcher is qualified with required' do
+        context 'and the matcher is not qualified with without_validating_presence' do
+          it 'fails with an appropriate message' do
+            model = create_child_model_belonging_to_parent do
+              before_validation :ensure_parent_is_set
 
-                def ensure_parent_is_set
-                  self.parent = Parent.create
-                end
+              def ensure_parent_is_set
+                self.parent = Parent.create
               end
+            end
 
+            assertion = lambda do
               with_belongs_to_as_required_by_default do
-                expect(model.new).
-                  to belong_to(:parent).
-                  required.
-                  without_validating_presence
+                expect(model.new).to belong_to(:parent).required
               end
+            end
+
+            message = format_message(<<-MESSAGE, one_line: true)
+              Expected Child to have a belongs_to association called parent
+              (and for the record to fail validation if :parent is unset; i.e.,
+              either the association should have been defined with `required:
+              true`, or there should be a presence validation on :parent)
+            MESSAGE
+
+            expect(&assertion).to fail_with_message(message)
+          end
+        end
+
+        context 'and the matcher is also qualified with without_validating_presence' do
+          it 'passes' do
+            model = create_child_model_belonging_to_parent do
+              before_validation :ensure_parent_is_set
+
+              def ensure_parent_is_set
+                self.parent = Parent.create
+              end
+            end
+
+            with_belongs_to_as_required_by_default do
+              expect(model.new).
+                to belong_to(:parent).
+                required.
+                without_validating_presence
             end
           end
         end
@@ -1562,12 +1464,10 @@ Expected Parent to have a has_many association called children through conceptio
       end
     end
 
-    if active_record_supports_optional_for_associations?
-      context 'given an association with a matching :required option' do
-        it 'passes' do
-          expect(having_one_detail(required: true)).
-            to have_one(:detail).required
-        end
+    context 'given an association with a matching :required option' do
+      it 'passes' do
+        expect(having_one_detail(required: true)).
+          to have_one(:detail).required
       end
     end
 

--- a/spec/unit/shoulda/matchers/active_record/define_enum_for_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/define_enum_for_matcher_spec.rb
@@ -367,331 +367,361 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
     end
   end
 
-  if active_record_enum_supports_prefix_and_suffix?
-    context 'qualified with #with_prefix' do
-      context 'when the prefix is explicit' do
-        context 'if the attribute was not defined with a prefix' do
-          it 'rejects with an appropriate failure message' do
-            record = build_record_with_array_values(
-              model_name: 'Example',
-              attribute_name: :attr,
-              column_type: :integer,
-              values: [:active, :archived],
-            )
+  context 'qualified with #with_prefix' do
+    context 'when the prefix is explicit' do
+      context 'if the attribute was not defined with a prefix' do
+        it 'rejects with an appropriate failure message' do
+          record = build_record_with_array_values(
+            model_name: 'Example',
+            attribute_name: :attr,
+            column_type: :integer,
+            values: [:active, :archived],
+          )
 
-            assertion = lambda do
-              expect(record).
-                to define_enum_for(:attr).
-                with_values([:active, :archived]).
-                with_prefix(:foo)
-            end
-
-            message = format_message(<<-MESSAGE)
-              Expected Example to define :attr as an enum backed by an integer,
-              mapping ‹"active"› to ‹0› and ‹"archived"› to ‹1› and prefixing
-              accessor methods with "foo_". :attr does map to these values, but
-              the enum is configured with either a different prefix or no prefix
-              at all (we can't tell which).
-            MESSAGE
-
-            expect(&assertion).to fail_with_message(message)
-          end
-        end
-
-        context 'if the attribute was defined with a different prefix' do
-          it 'rejects with an appropriate failure message' do
-            record = build_record_with_array_values(
-              model_name: 'Example',
-              attribute_name: :attr,
-              column_type: :integer,
-              values: [:active, :archived],
-              prefix: :foo,
-            )
-
-            assertion = lambda do
-              expect(record).
-                to define_enum_for(:attr).
-                with_values([:active, :archived]).
-                with_prefix(:bar)
-            end
-
-            message = format_message(<<-MESSAGE)
-              Expected Example to define :attr as an enum backed by an integer,
-              mapping ‹"active"› to ‹0› and ‹"archived"› to ‹1› and prefixing
-              accessor methods with "bar_". :attr does map to these values, but
-              the enum is configured with either a different prefix or no prefix
-              at all (we can't tell which).
-            MESSAGE
-
-            expect(&assertion).to fail_with_message(message)
-          end
-        end
-
-        context 'if the attribute was defined with the same prefix' do
-          it 'matches' do
-            record = build_record_with_array_values(
-              model_name: 'Example',
-              attribute_name: :attr,
-              values: [:active, :archived],
-              prefix: :foo,
-            )
-
-            matcher = lambda do
-              define_enum_for(:attr).
-                with_values([:active, :archived]).
-                with_prefix(:foo)
-            end
-
-            expect(&matcher).
-              to match_against(record).
-              or_fail_with(<<-MESSAGE, wrap: true)
-                Expected Example not to define :attr as an enum backed by an
-                integer, mapping ‹"active"› to ‹0› and ‹"archived"› to ‹1› and
-                prefixing accessor methods with "foo_", but it did.
-            MESSAGE
-          end
-
-          it 'has the right description' do
-            matcher = define_enum_for(:attr).
+          assertion = lambda do
+            expect(record).
+              to define_enum_for(:attr).
               with_values([:active, :archived]).
               with_prefix(:foo)
-
-            expect(matcher.description).to eq(<<~MESSAGE.strip)
-              define :attr as an enum backed by an integer with values ‹[:active, :archived]›, prefix: :foo
-            MESSAGE
           end
+
+          message = format_message(<<-MESSAGE)
+            Expected Example to define :attr as an enum backed by an integer,
+            mapping ‹"active"› to ‹0› and ‹"archived"› to ‹1› and prefixing
+            accessor methods with "foo_". :attr does map to these values, but
+            the enum is configured with either a different prefix or no prefix
+            at all (we can't tell which).
+          MESSAGE
+
+          expect(&assertion).to fail_with_message(message)
         end
       end
 
-      context 'when the prefix is implicit' do
-        context 'if the attribute was not defined with a prefix' do
-          it 'rejects with an appropriate failure message' do
-            record = build_record_with_array_values(
-              model_name: 'Example',
-              attribute_name: :attr,
-              column_type: :integer,
-              values: [:active, :archived],
-            )
+      context 'if the attribute was defined with a different prefix' do
+        it 'rejects with an appropriate failure message' do
+          record = build_record_with_array_values(
+            model_name: 'Example',
+            attribute_name: :attr,
+            column_type: :integer,
+            values: [:active, :archived],
+            prefix: :foo,
+          )
 
-            assertion = lambda do
-              expect(record).
-                to define_enum_for(:attr).
-                with_values([:active, :archived]).
-                with_prefix
-            end
-
-            message = format_message(<<-MESSAGE)
-              Expected Example to define :attr as an enum backed by an integer,
-              mapping ‹"active"› to ‹0› and ‹"archived"› to ‹1› and prefixing
-              accessor methods with "attr_". :attr does map to these values, but
-              the enum is configured with either a different prefix or no prefix
-              at all (we can't tell which).
-            MESSAGE
-
-            expect(&assertion).to fail_with_message(message)
+          assertion = lambda do
+            expect(record).
+              to define_enum_for(:attr).
+              with_values([:active, :archived]).
+              with_prefix(:bar)
           end
+
+          message = format_message(<<-MESSAGE)
+            Expected Example to define :attr as an enum backed by an integer,
+            mapping ‹"active"› to ‹0› and ‹"archived"› to ‹1› and prefixing
+            accessor methods with "bar_". :attr does map to these values, but
+            the enum is configured with either a different prefix or no prefix
+            at all (we can't tell which).
+          MESSAGE
+
+          expect(&assertion).to fail_with_message(message)
+        end
+      end
+
+      context 'if the attribute was defined with the same prefix' do
+        it 'matches' do
+          record = build_record_with_array_values(
+            model_name: 'Example',
+            attribute_name: :attr,
+            values: [:active, :archived],
+            prefix: :foo,
+          )
+
+          matcher = lambda do
+            define_enum_for(:attr).
+              with_values([:active, :archived]).
+              with_prefix(:foo)
+          end
+
+          expect(&matcher).
+            to match_against(record).
+            or_fail_with(<<-MESSAGE, wrap: true)
+              Expected Example not to define :attr as an enum backed by an
+              integer, mapping ‹"active"› to ‹0› and ‹"archived"› to ‹1› and
+              prefixing accessor methods with "foo_", but it did.
+          MESSAGE
         end
 
-        context 'if the attribute was defined with a prefix' do
-          it 'matches' do
-            record = build_record_with_array_values(
-              model_name: 'Example',
-              attribute_name: :attr,
-              values: [:active, :archived],
-              prefix: true,
-            )
+        it 'has the right description' do
+          matcher = define_enum_for(:attr).
+            with_values([:active, :archived]).
+            with_prefix(:foo)
 
-            matcher = lambda do
-              define_enum_for(:attr).
-                with_values([:active, :archived]).
-                with_prefix
-            end
+          expect(matcher.description).to eq(<<~MESSAGE.strip)
+            define :attr as an enum backed by an integer with values ‹[:active, :archived]›, prefix: :foo
+          MESSAGE
+        end
+      end
+    end
 
-            expect(&matcher).
-              to match_against(record).
-              or_fail_with(<<-MESSAGE, wrap: true)
-                Expected Example not to define :attr as an enum backed by an
-                integer, mapping ‹"active"› to ‹0› and ‹"archived"› to ‹1› and
-                prefixing accessor methods with "attr_", but it did.
-              MESSAGE
-          end
+    context 'when the prefix is implicit' do
+      context 'if the attribute was not defined with a prefix' do
+        it 'rejects with an appropriate failure message' do
+          record = build_record_with_array_values(
+            model_name: 'Example',
+            attribute_name: :attr,
+            column_type: :integer,
+            values: [:active, :archived],
+          )
 
-          it 'has the right description' do
-            matcher = define_enum_for(:attr).
+          assertion = lambda do
+            expect(record).
+              to define_enum_for(:attr).
               with_values([:active, :archived]).
               with_prefix
-
-            expect(matcher.description).to eq(<<~MESSAGE.strip)
-              define :attr as an enum backed by an integer with values ‹[:active, :archived]›, prefix: true
-            MESSAGE
           end
+
+          message = format_message(<<-MESSAGE)
+            Expected Example to define :attr as an enum backed by an integer,
+            mapping ‹"active"› to ‹0› and ‹"archived"› to ‹1› and prefixing
+            accessor methods with "attr_". :attr does map to these values, but
+            the enum is configured with either a different prefix or no prefix
+            at all (we can't tell which).
+          MESSAGE
+
+          expect(&assertion).to fail_with_message(message)
+        end
+      end
+
+      context 'if the attribute was defined with a prefix' do
+        it 'matches' do
+          record = build_record_with_array_values(
+            model_name: 'Example',
+            attribute_name: :attr,
+            values: [:active, :archived],
+            prefix: true,
+          )
+
+          matcher = lambda do
+            define_enum_for(:attr).
+              with_values([:active, :archived]).
+              with_prefix
+          end
+
+          expect(&matcher).
+            to match_against(record).
+            or_fail_with(<<-MESSAGE, wrap: true)
+              Expected Example not to define :attr as an enum backed by an
+              integer, mapping ‹"active"› to ‹0› and ‹"archived"› to ‹1› and
+              prefixing accessor methods with "attr_", but it did.
+            MESSAGE
+        end
+
+        it 'has the right description' do
+          matcher = define_enum_for(:attr).
+            with_values([:active, :archived]).
+            with_prefix
+
+          expect(matcher.description).to eq(<<~MESSAGE.strip)
+            define :attr as an enum backed by an integer with values ‹[:active, :archived]›, prefix: true
+          MESSAGE
         end
       end
     end
+  end
 
-    context 'qualified with #with_suffix' do
-      context 'when the suffix is explicit' do
-        context 'if the attribute was not defined with a suffix' do
-          it 'rejects with an appropriate failure message' do
-            record = build_record_with_array_values(
-              model_name: 'Example',
-              attribute_name: :attr,
-              column_type: :integer,
-              values: [:active, :archived],
-            )
+  context 'qualified with #with_suffix' do
+    context 'when the suffix is explicit' do
+      context 'if the attribute was not defined with a suffix' do
+        it 'rejects with an appropriate failure message' do
+          record = build_record_with_array_values(
+            model_name: 'Example',
+            attribute_name: :attr,
+            column_type: :integer,
+            values: [:active, :archived],
+          )
 
-            assertion = lambda do
-              expect(record).
-                to define_enum_for(:attr).
-                with_values([:active, :archived]).
-                with_suffix(:foo)
-            end
-
-            message = format_message(<<-MESSAGE)
-              Expected Example to define :attr as an enum backed by an integer,
-              mapping ‹"active"› to ‹0› and ‹"archived"› to ‹1› and suffixing
-              accessor methods with "_foo". :attr does map to these values, but
-              the enum is configured with either a different suffix or no suffix
-              at all (we can't tell which).
-            MESSAGE
-
-            expect(&assertion).to fail_with_message(message)
-          end
-        end
-
-        context 'if the attribute was defined with a different suffix' do
-          it 'rejects with an appropriate failure message' do
-            record = build_record_with_array_values(
-              model_name: 'Example',
-              attribute_name: :attr,
-              column_type: :integer,
-              values: [:active, :archived],
-              suffix: :foo,
-            )
-
-            assertion = lambda do
-              expect(record).
-                to define_enum_for(:attr).
-                with_values([:active, :archived]).
-                with_suffix(:bar)
-            end
-
-            message = format_message(<<-MESSAGE)
-              Expected Example to define :attr as an enum backed by an integer,
-              mapping ‹"active"› to ‹0› and ‹"archived"› to ‹1› and suffixing
-              accessor methods with "_bar". :attr does map to these values, but
-              the enum is configured with either a different suffix or no suffix
-              at all (we can't tell which).
-            MESSAGE
-
-            expect(&assertion).to fail_with_message(message)
-          end
-        end
-
-        context 'if the attribute was defined with the same suffix' do
-          it 'matches' do
-            record = build_record_with_array_values(
-              model_name: 'Example',
-              attribute_name: :attr,
-              values: [:active, :archived],
-              suffix: :foo,
-            )
-
-            matcher = lambda do
-              define_enum_for(:attr).
-                with_values([:active, :archived]).
-                with_suffix(:foo)
-            end
-
-            expect(&matcher).
-              to match_against(record).
-              or_fail_with(<<-MESSAGE, wrap: true)
-                Expected Example not to define :attr as an enum backed by an
-                integer, mapping ‹"active"› to ‹0› and ‹"archived"› to ‹1› and
-                suffixing accessor methods with "_foo", but it did.
-              MESSAGE
-          end
-
-          it 'has the right description' do
-            matcher = define_enum_for(:attr).
+          assertion = lambda do
+            expect(record).
+              to define_enum_for(:attr).
               with_values([:active, :archived]).
               with_suffix(:foo)
-
-            expect(matcher.description).to eq(<<~MESSAGE.strip)
-              define :attr as an enum backed by an integer with values ‹[:active, :archived]›, suffix: :foo
-            MESSAGE
           end
+
+          message = format_message(<<-MESSAGE)
+            Expected Example to define :attr as an enum backed by an integer,
+            mapping ‹"active"› to ‹0› and ‹"archived"› to ‹1› and suffixing
+            accessor methods with "_foo". :attr does map to these values, but
+            the enum is configured with either a different suffix or no suffix
+            at all (we can't tell which).
+          MESSAGE
+
+          expect(&assertion).to fail_with_message(message)
         end
       end
 
-      context 'when the suffix is implicit' do
-        context 'if the attribute was not defined with a suffix' do
-          it 'rejects with an appropriate failure message' do
-            record = build_record_with_array_values(
-              model_name: 'Example',
-              attribute_name: :attr,
-              column_type: :integer,
-              values: [:active, :archived],
-            )
+      context 'if the attribute was defined with a different suffix' do
+        it 'rejects with an appropriate failure message' do
+          record = build_record_with_array_values(
+            model_name: 'Example',
+            attribute_name: :attr,
+            column_type: :integer,
+            values: [:active, :archived],
+            suffix: :foo,
+          )
 
-            assertion = lambda do
-              expect(record).
-                to define_enum_for(:attr).
-                with_values([:active, :archived]).
-                with_suffix
-            end
-
-            message = format_message(<<-MESSAGE)
-              Expected Example to define :attr as an enum backed by an integer,
-              mapping ‹"active"› to ‹0› and ‹"archived"› to ‹1› and suffixing
-              accessor methods with "_attr". :attr does map to these values, but
-              the enum is configured with either a different suffix or no suffix
-              at all (we can't tell which).
-            MESSAGE
-
-            expect(&assertion).to fail_with_message(message)
+          assertion = lambda do
+            expect(record).
+              to define_enum_for(:attr).
+              with_values([:active, :archived]).
+              with_suffix(:bar)
           end
+
+          message = format_message(<<-MESSAGE)
+            Expected Example to define :attr as an enum backed by an integer,
+            mapping ‹"active"› to ‹0› and ‹"archived"› to ‹1› and suffixing
+            accessor methods with "_bar". :attr does map to these values, but
+            the enum is configured with either a different suffix or no suffix
+            at all (we can't tell which).
+          MESSAGE
+
+          expect(&assertion).to fail_with_message(message)
+        end
+      end
+
+      context 'if the attribute was defined with the same suffix' do
+        it 'matches' do
+          record = build_record_with_array_values(
+            model_name: 'Example',
+            attribute_name: :attr,
+            values: [:active, :archived],
+            suffix: :foo,
+          )
+
+          matcher = lambda do
+            define_enum_for(:attr).
+              with_values([:active, :archived]).
+              with_suffix(:foo)
+          end
+
+          expect(&matcher).
+            to match_against(record).
+            or_fail_with(<<-MESSAGE, wrap: true)
+              Expected Example not to define :attr as an enum backed by an
+              integer, mapping ‹"active"› to ‹0› and ‹"archived"› to ‹1› and
+              suffixing accessor methods with "_foo", but it did.
+            MESSAGE
         end
 
-        context 'if the attribute was defined with a suffix' do
-          it 'matches' do
-            record = build_record_with_array_values(
-              model_name: 'Example',
-              attribute_name: :attr,
-              values: [:active, :archived],
-              suffix: true,
-            )
+        it 'has the right description' do
+          matcher = define_enum_for(:attr).
+            with_values([:active, :archived]).
+            with_suffix(:foo)
 
-            matcher = lambda do
-              define_enum_for(:attr).
-                with_values([:active, :archived]).
-                with_suffix
-            end
-
-            expect(&matcher).
-              to match_against(record).
-              or_fail_with(<<-MESSAGE, wrap: true)
-                Expected Example not to define :attr as an enum backed by an
-                integer, mapping ‹"active"› to ‹0› and ‹"archived"› to ‹1› and
-                suffixing accessor methods with "_attr", but it did.
-              MESSAGE
-          end
-
-          it 'has the right description' do
-            matcher = define_enum_for(:attr).
-              with_values([:active, :archived]).
-              with_suffix
-
-            expect(matcher.description).to eq(<<~MESSAGE.strip)
-              define :attr as an enum backed by an integer with values ‹[:active, :archived]›, suffix: true
-            MESSAGE
-          end
+          expect(matcher.description).to eq(<<~MESSAGE.strip)
+            define :attr as an enum backed by an integer with values ‹[:active, :archived]›, suffix: :foo
+          MESSAGE
         end
       end
     end
 
-    context 'qualified with both #with_prefix and #with_suffix' do
-      context 'if the attribute was not defined with a different prefix' do
+    context 'when the suffix is implicit' do
+      context 'if the attribute was not defined with a suffix' do
+        it 'rejects with an appropriate failure message' do
+          record = build_record_with_array_values(
+            model_name: 'Example',
+            attribute_name: :attr,
+            column_type: :integer,
+            values: [:active, :archived],
+          )
+
+          assertion = lambda do
+            expect(record).
+              to define_enum_for(:attr).
+              with_values([:active, :archived]).
+              with_suffix
+          end
+
+          message = format_message(<<-MESSAGE)
+            Expected Example to define :attr as an enum backed by an integer,
+            mapping ‹"active"› to ‹0› and ‹"archived"› to ‹1› and suffixing
+            accessor methods with "_attr". :attr does map to these values, but
+            the enum is configured with either a different suffix or no suffix
+            at all (we can't tell which).
+          MESSAGE
+
+          expect(&assertion).to fail_with_message(message)
+        end
+      end
+
+      context 'if the attribute was defined with a suffix' do
+        it 'matches' do
+          record = build_record_with_array_values(
+            model_name: 'Example',
+            attribute_name: :attr,
+            values: [:active, :archived],
+            suffix: true,
+          )
+
+          matcher = lambda do
+            define_enum_for(:attr).
+              with_values([:active, :archived]).
+              with_suffix
+          end
+
+          expect(&matcher).
+            to match_against(record).
+            or_fail_with(<<-MESSAGE, wrap: true)
+              Expected Example not to define :attr as an enum backed by an
+              integer, mapping ‹"active"› to ‹0› and ‹"archived"› to ‹1› and
+              suffixing accessor methods with "_attr", but it did.
+            MESSAGE
+        end
+
+        it 'has the right description' do
+          matcher = define_enum_for(:attr).
+            with_values([:active, :archived]).
+            with_suffix
+
+          expect(matcher.description).to eq(<<~MESSAGE.strip)
+            define :attr as an enum backed by an integer with values ‹[:active, :archived]›, suffix: true
+          MESSAGE
+        end
+      end
+    end
+  end
+
+  context 'qualified with both #with_prefix and #with_suffix' do
+    context 'if the attribute was not defined with a different prefix' do
+      it 'rejects with an appropriate failure message' do
+        record = build_record_with_array_values(
+          model_name: 'Example',
+          attribute_name: :attr,
+          column_type: :integer,
+          values: [:active, :archived],
+          prefix: :foo,
+          suffix: :bar,
+        )
+
+        assertion = lambda do
+          expect(record).
+            to define_enum_for(:attr).
+            with_values([:active, :archived]).
+            with_prefix(:whatever).
+            with_suffix(:bar)
+        end
+
+        message = format_message(<<-MESSAGE)
+          Expected Example to define :attr as an enum backed by an integer,
+          mapping ‹"active"› to ‹0› and ‹"archived"› to ‹1›, prefixing
+          accessor methods with "whatever_", and suffixing accessor methods
+          with "_bar". :attr does map to these values, but the enum is
+          configured with either a different prefix or suffix, or no prefix or
+          suffix at all (we can't tell which).
+        MESSAGE
+
+        expect(&assertion).to fail_with_message(message)
+      end
+
+      context 'if the attribute was defined with a different suffix' do
         it 'rejects with an appropriate failure message' do
           record = build_record_with_array_values(
             model_name: 'Example',
@@ -706,91 +736,59 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
             expect(record).
               to define_enum_for(:attr).
               with_values([:active, :archived]).
-              with_prefix(:whatever).
-              with_suffix(:bar)
+              with_prefix(:foo).
+              with_suffix(:whatever)
           end
 
           message = format_message(<<-MESSAGE)
             Expected Example to define :attr as an enum backed by an integer,
             mapping ‹"active"› to ‹0› and ‹"archived"› to ‹1›, prefixing
-            accessor methods with "whatever_", and suffixing accessor methods
-            with "_bar". :attr does map to these values, but the enum is
-            configured with either a different prefix or suffix, or no prefix or
-            suffix at all (we can't tell which).
+            accessor methods with "foo_", and suffixing accessor methods with
+            "_whatever". :attr does map to these values, but the enum is
+            configured with either a different prefix or suffix, or no prefix
+            or suffix at all (we can't tell which).
           MESSAGE
 
           expect(&assertion).to fail_with_message(message)
         end
+      end
 
-        context 'if the attribute was defined with a different suffix' do
-          it 'rejects with an appropriate failure message' do
-            record = build_record_with_array_values(
-              model_name: 'Example',
-              attribute_name: :attr,
-              column_type: :integer,
-              values: [:active, :archived],
-              prefix: :foo,
-              suffix: :bar,
-            )
+      context 'if the attribute was defined with the same prefix and suffix' do
+        it 'matches' do
+          record = build_record_with_array_values(
+            model_name: 'Example',
+            attribute_name: :attr,
+            values: [:active, :archived],
+            prefix: :foo,
+            suffix: :bar,
+          )
 
-            assertion = lambda do
-              expect(record).
-                to define_enum_for(:attr).
-                with_values([:active, :archived]).
-                with_prefix(:foo).
-                with_suffix(:whatever)
-            end
-
-            message = format_message(<<-MESSAGE)
-              Expected Example to define :attr as an enum backed by an integer,
-              mapping ‹"active"› to ‹0› and ‹"archived"› to ‹1›, prefixing
-              accessor methods with "foo_", and suffixing accessor methods with
-              "_whatever". :attr does map to these values, but the enum is
-              configured with either a different prefix or suffix, or no prefix
-              or suffix at all (we can't tell which).
-            MESSAGE
-
-            expect(&assertion).to fail_with_message(message)
-          end
-        end
-
-        context 'if the attribute was defined with the same prefix and suffix' do
-          it 'matches' do
-            record = build_record_with_array_values(
-              model_name: 'Example',
-              attribute_name: :attr,
-              values: [:active, :archived],
-              prefix: :foo,
-              suffix: :bar,
-            )
-
-            matcher = lambda do
-              define_enum_for(:attr).
-                with_values([:active, :archived]).
-                with_prefix(:foo).
-                with_suffix(:bar)
-            end
-
-            expect(&matcher).
-              to match_against(record).
-              or_fail_with(<<-MESSAGE, wrap: true)
-                Expected Example not to define :attr as an enum backed by an
-                integer, mapping ‹"active"› to ‹0› and ‹"archived"› to ‹1›,
-                prefixing accessor methods with "foo_", and suffixing accessor
-                methods with "_bar", but it did.
-              MESSAGE
-          end
-
-          it 'has the right description' do
-            matcher = define_enum_for(:attr).
+          matcher = lambda do
+            define_enum_for(:attr).
               with_values([:active, :archived]).
               with_prefix(:foo).
               with_suffix(:bar)
-
-            expect(matcher.description).to eq(<<~MESSAGE.strip)
-              define :attr as an enum backed by an integer with values ‹[:active, :archived]›, prefix: :foo, suffix: :bar
-            MESSAGE
           end
+
+          expect(&matcher).
+            to match_against(record).
+            or_fail_with(<<-MESSAGE, wrap: true)
+              Expected Example not to define :attr as an enum backed by an
+              integer, mapping ‹"active"› to ‹0› and ‹"archived"› to ‹1›,
+              prefixing accessor methods with "foo_", and suffixing accessor
+              methods with "_bar", but it did.
+            MESSAGE
+        end
+
+        it 'has the right description' do
+          matcher = define_enum_for(:attr).
+            with_values([:active, :archived]).
+            with_prefix(:foo).
+            with_suffix(:bar)
+
+          expect(matcher.description).to eq(<<~MESSAGE.strip)
+            define :attr as an enum backed by an integer with values ‹[:active, :archived]›, prefix: :foo, suffix: :bar
+          MESSAGE
         end
       end
     end
@@ -864,11 +862,7 @@ describe Shoulda::Matchers::ActiveRecord::DefineEnumForMatcher, type: :model do
       alias_attribute attribute_alias, attribute_name
     end
 
-    if active_record_enum_supports_prefix_and_suffix?
-      model.enum(enum_name => values, _prefix: prefix, _suffix: suffix)
-    else
-      model.enum(enum_name => values)
-    end
+    model.enum(enum_name => values, _prefix: prefix, _suffix: suffix)
 
     model.new
   end

--- a/spec/unit/shoulda/matchers/active_record/have_db_index_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/have_db_index_matcher_spec.rb
@@ -1,11 +1,6 @@
 require 'unit_spec_helper'
 
 describe Shoulda::Matchers::ActiveRecord::HaveDbIndexMatcher, type: :model do
-  def self.can_test_expression_indexes?
-    active_record_supports_expression_indexes? &&
-      database_supports_expression_indexes?
-  end
-
   describe 'the matcher' do
     shared_examples 'for when the matcher is qualified' do |
       index:,
@@ -239,7 +234,7 @@ Expected the examples table to have an index on [:geocodable_id,
         end
       end
 
-      if can_test_expression_indexes?
+      if database_supports_expression_indexes?
         context 'when given an expression' do
           context 'qualified with nothing' do
             context 'when the table has the given index' do
@@ -439,7 +434,7 @@ does not.
       end
     end
 
-    if can_test_expression_indexes?
+    if database_supports_expression_indexes?
       context 'when given an expression' do
         context 'when not qualified with anything' do
           it 'returns the correct description' do

--- a/spec/unit/shoulda/matchers/active_record/have_secure_token_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/have_secure_token_matcher_spec.rb
@@ -2,176 +2,174 @@ require 'unit_spec_helper'
 
 describe Shoulda::Matchers::ActiveRecord::HaveSecureTokenMatcher,
   type: :model do
-  if active_record_supports_has_secure_token?
-    describe '#description' do
-      it 'returns the message including the name of the default column' do
-        matcher = have_secure_token
-        expect(matcher.description).
-          to eq('have :token as a secure token')
-      end
-
-      it 'returns the message including the name of a provided column' do
-        matcher = have_secure_token(:special_token)
-        expect(matcher.description).
-          to eq('have :special_token as a secure token')
-      end
+  describe '#description' do
+    it 'returns the message including the name of the default column' do
+      matcher = have_secure_token
+      expect(matcher.description).
+        to eq('have :token as a secure token')
     end
 
-    it 'matches when the subject configures has_secure_token with the db' do
-      create_table(:users) do |t|
-        t.string :token
-        t.index :token, unique: true
-      end
+    it 'returns the message including the name of a provided column' do
+      matcher = have_secure_token(:special_token)
+      expect(matcher.description).
+        to eq('have :special_token as a secure token')
+    end
+  end
 
-      valid_model = define_model_class(:User) { has_secure_token }
-
-      expect(valid_model.new).to have_secure_token
+  it 'matches when the subject configures has_secure_token with the db' do
+    create_table(:users) do |t|
+      t.string :token
+      t.index :token, unique: true
     end
 
-    it 'matches when the subject configures has_secure_token with the db for ' \
-       'a custom attribute' do
-      create_table(:users) do |t|
-        t.string :auth_token
-        t.index :auth_token, unique: true
-      end
+    valid_model = define_model_class(:User) { has_secure_token }
 
-      valid_model = define_model_class(:User) { has_secure_token(:auth_token) }
-      expect(valid_model.new).to have_secure_token(:auth_token)
+    expect(valid_model.new).to have_secure_token
+  end
+
+  it 'matches when the subject configures has_secure_token with the db for ' \
+      'a custom attribute' do
+    create_table(:users) do |t|
+      t.string :auth_token
+      t.index :auth_token, unique: true
     end
 
-    it 'does not match when missing an token index' do
-      create_table(:users) do |t|
-        t.string :token
-      end
+    valid_model = define_model_class(:User) { has_secure_token(:auth_token) }
+    expect(valid_model.new).to have_secure_token(:auth_token)
+  end
 
-      invalid_model = define_model_class(:User) { has_secure_token }
-      expected_message =
-        'Expected User to have :token as a secure token but the following ' \
-        'errors were found: missing unique index for users.token'
-
-      aggregate_failures do
-        expect(invalid_model.new).not_to have_secure_token
-        expect { expect(invalid_model.new).to have_secure_token }.
-          to fail_with_message(expected_message)
-      end
+  it 'does not match when missing an token index' do
+    create_table(:users) do |t|
+      t.string :token
     end
 
-    it 'matches when called with ignoring_check_for_db_index without db index' do
-      create_table(:users) do |t|
-        t.string :token
-      end
+    invalid_model = define_model_class(:User) { has_secure_token }
+    expected_message =
+      'Expected User to have :token as a secure token but the following ' \
+      'errors were found: missing unique index for users.token'
 
-      valid_model = define_model_class(:User) { has_secure_token }
-      expect(valid_model.new).
-        to have_secure_token.ignoring_check_for_db_index
+    aggregate_failures do
+      expect(invalid_model.new).not_to have_secure_token
+      expect { expect(invalid_model.new).to have_secure_token }.
+        to fail_with_message(expected_message)
+    end
+  end
+
+  it 'matches when called with ignoring_check_for_db_index without db index' do
+    create_table(:users) do |t|
+      t.string :token
     end
 
-    it 'does not match when missing a token column' do
-      create_table(:users)
-      invalid_model = define_model_class(:User) { has_secure_token }
+    valid_model = define_model_class(:User) { has_secure_token }
+    expect(valid_model.new).
+      to have_secure_token.ignoring_check_for_db_index
+  end
 
-      expected_message =
-        'Expected User to have :token as a secure token but the following ' \
-        'errors were found: missing expected class and instance methods, ' \
-        'missing correct column token:string, missing unique index for ' \
-        'users.token'
+  it 'does not match when missing a token column' do
+    create_table(:users)
+    invalid_model = define_model_class(:User) { has_secure_token }
 
-      aggregate_failures do
-        expect(invalid_model.new).not_to have_secure_token
-        expect { expect(invalid_model.new).to have_secure_token }.
-          to fail_with_message(expected_message)
-      end
+    expected_message =
+      'Expected User to have :token as a secure token but the following ' \
+      'errors were found: missing expected class and instance methods, ' \
+      'missing correct column token:string, missing unique index for ' \
+      'users.token'
+
+    aggregate_failures do
+      expect(invalid_model.new).not_to have_secure_token
+      expect { expect(invalid_model.new).to have_secure_token }.
+        to fail_with_message(expected_message)
+    end
+  end
+
+  it 'does not match when when lacking has_secure_token' do
+    create_table(:users) do |t|
+      t.string :token
+      t.index :token
     end
 
-    it 'does not match when when lacking has_secure_token' do
-      create_table(:users) do |t|
-        t.string :token
-        t.index :token
-      end
+    invalid_model = define_model_class(:User)
 
-      invalid_model = define_model_class(:User)
+    expected_message =
+      'Expected User to have :token as a secure token but the following ' \
+      'errors were found: missing expected class and instance methods, ' \
+      'missing unique index for users.token'
 
-      expected_message =
-        'Expected User to have :token as a secure token but the following ' \
-        'errors were found: missing expected class and instance methods, ' \
-        'missing unique index for users.token'
+    aggregate_failures do
+      expect(invalid_model.new).not_to have_secure_token
+      expect { expect(invalid_model.new).to have_secure_token }.
+        to fail_with_message(expected_message)
+    end
+  end
 
-      aggregate_failures do
-        expect(invalid_model.new).not_to have_secure_token
-        expect { expect(invalid_model.new).to have_secure_token }.
-          to fail_with_message(expected_message)
-      end
+  it 'does not match when missing an index for a custom attribute' do
+    create_table(:users) do |t|
+      t.string :auth_token
     end
 
-    it 'does not match when missing an index for a custom attribute' do
-      create_table(:users) do |t|
-        t.string :auth_token
-      end
-
-      invalid_model = define_model_class(:User) do
-        has_secure_token(:auth_token)
-      end
-
-      expected_message =
-        'Expected User to have :auth_token as a secure token but the ' \
-        'following errors were found: missing unique index for ' \
-        'users.auth_token'
-
-      aggregate_failures do
-        expect(invalid_model.new).not_to have_secure_token(:auth_token)
-        expect { expect(invalid_model.new).to have_secure_token(:auth_token) }.
-          to fail_with_message(expected_message)
-      end
+    invalid_model = define_model_class(:User) do
+      has_secure_token(:auth_token)
     end
 
-    it 'does not match when missing a column for a custom attribute' do
-      create_table(:users)
-      invalid_model = define_model_class(:User) do
-        has_secure_token(:auth_token)
-      end
+    expected_message =
+      'Expected User to have :auth_token as a secure token but the ' \
+      'following errors were found: missing unique index for ' \
+      'users.auth_token'
 
-      expected_message =
-        'Expected User to have :auth_token as a secure token but the ' \
-        'following errors were found: missing expected class and instance '  \
-        'methods, missing correct column auth_token:string, missing unique ' \
-        'index for users.auth_token'
+    aggregate_failures do
+      expect(invalid_model.new).not_to have_secure_token(:auth_token)
+      expect { expect(invalid_model.new).to have_secure_token(:auth_token) }.
+        to fail_with_message(expected_message)
+    end
+  end
 
-      aggregate_failures do
-        expect(invalid_model.new).not_to have_secure_token(:auth_token)
-        expect { expect(invalid_model.new).to have_secure_token(:auth_token) }.
-          to fail_with_message(expected_message)
-      end
+  it 'does not match when missing a column for a custom attribute' do
+    create_table(:users)
+    invalid_model = define_model_class(:User) do
+      has_secure_token(:auth_token)
     end
 
-    it 'does not match when when lacking has_secure_token for the attribute' do
-      create_table(:users) do |t|
-        t.string :auth_token
-        t.index :auth_token, unique: true
-      end
+    expected_message =
+      'Expected User to have :auth_token as a secure token but the ' \
+      'following errors were found: missing expected class and instance '  \
+      'methods, missing correct column auth_token:string, missing unique ' \
+      'index for users.auth_token'
 
-      invalid_model = define_model_class(:User)
-      expected_message =
-        'Expected User to have :auth_token as a secure token but the ' \
-        'following errors were found: missing expected class and instance ' \
-        'methods'
+    aggregate_failures do
+      expect(invalid_model.new).not_to have_secure_token(:auth_token)
+      expect { expect(invalid_model.new).to have_secure_token(:auth_token) }.
+        to fail_with_message(expected_message)
+    end
+  end
 
-      aggregate_failures do
-        expect(invalid_model.new).not_to have_secure_token(:auth_token)
-        expect { expect(invalid_model.new).to have_secure_token(:auth_token) }.
-          to fail_with_message(expected_message)
-      end
+  it 'does not match when when lacking has_secure_token for the attribute' do
+    create_table(:users) do |t|
+      t.string :auth_token
+      t.index :auth_token, unique: true
     end
 
-    it 'fails with the appropriate message when negated' do
-      create_table(:users) do |t|
-        t.string :token
-        t.index :token, unique: true
-      end
+    invalid_model = define_model_class(:User)
+    expected_message =
+      'Expected User to have :auth_token as a secure token but the ' \
+      'following errors were found: missing expected class and instance ' \
+      'methods'
 
-      valid_model = define_model_class(:User) { has_secure_token }
-
-      expect { expect(valid_model.new).not_to have_secure_token }.
-        to fail_with_message('Did not expect User to have secure token :token')
+    aggregate_failures do
+      expect(invalid_model.new).not_to have_secure_token(:auth_token)
+      expect { expect(invalid_model.new).to have_secure_token(:auth_token) }.
+        to fail_with_message(expected_message)
     end
+  end
+
+  it 'fails with the appropriate message when negated' do
+    create_table(:users) do |t|
+      t.string :token
+      t.index :token, unique: true
+    end
+
+    valid_model = define_model_class(:User) { has_secure_token }
+
+    expect { expect(valid_model.new).not_to have_secure_token }.
+      to fail_with_message('Did not expect User to have secure token :token')
   end
 end

--- a/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
@@ -852,48 +852,6 @@ within the scope of :scope1, but this could not be proved.
       end
     end
 
-    if (
-      database_supports_array_columns? &&
-      active_record_uniqueness_supports_array_columns?
-    )
-      context 'when one of the scoped attributes is a array-of-string column' do
-        include_examples 'it supports scoped attributes of a certain type',
-          column_type: :string,
-          array: true
-      end
-
-      context 'when one of the scoped attributes is an array-of-integer column' do
-        include_examples 'it supports scoped attributes of a certain type',
-          column_type: :integer,
-          array: true
-      end
-
-      context 'when one of the scoped attributes is an array-of-date column' do
-        include_examples 'it supports scoped attributes of a certain type',
-          column_type: :date,
-          array: true
-      end
-
-      context 'when one of the scoped attributes is an array-of-datetime column (using DateTime)' do
-        include_examples 'it supports scoped attributes of a certain type',
-          column_type: :datetime,
-          array: true
-      end
-
-      context 'when one of the scoped attributes is an array-of-datetime column (using Time)' do
-        include_examples 'it supports scoped attributes of a certain type',
-          column_type: :datetime,
-          value_type: :time,
-          array: true
-      end
-
-      context 'when one of the scoped attributes is an array-of-text column' do
-        include_examples 'it supports scoped attributes of a certain type',
-          column_type: :text,
-          array: true
-      end
-    end
-
     context 'when an existing record that is not the first has a nil value for the scoped attribute' do
       # This fails intermittently
       # it 'still works' do

--- a/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
@@ -854,7 +854,6 @@ within the scope of :scope1, but this could not be proved.
 
     if (
       database_supports_array_columns? &&
-      active_record_supports_array_columns? &&
       active_record_uniqueness_supports_array_columns?
     )
       context 'when one of the scoped attributes is a array-of-string column' do

--- a/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
@@ -1153,29 +1153,27 @@ long as it is not nil, but this could not be proved.
       end
     end
 
-    if active_record_supports_has_secure_password?
-      context 'when the model is declared with has_secure_password' do
-        context 'given a record whose attribute is nil' do
-          it 'accepts' do
-            model = define_model_validating_uniqueness(
-              validation_options: { allow_blank: true },
-              additional_attributes: [{ name: :password_digest, type: :string }], &:has_secure_password
-            )
-            record = build_record_from(model, attribute_name => nil)
-            expect(record).to validate_uniqueness.allow_blank
-          end
+    context 'when the model is declared with has_secure_password' do
+      context 'given a record whose attribute is nil' do
+        it 'accepts' do
+          model = define_model_validating_uniqueness(
+            validation_options: { allow_blank: true },
+            additional_attributes: [{ name: :password_digest, type: :string }], &:has_secure_password
+          )
+          record = build_record_from(model, attribute_name => nil)
+          expect(record).to validate_uniqueness.allow_blank
         end
+      end
 
-        context 'given a record whose attribute is empty' do
-          it 'accepts' do
-            model = define_model_validating_uniqueness(
-              attribute_type: :string,
-              validation_options: { allow_blank: true },
-              additional_attributes: [{ name: :password_digest, type: :string }], &:has_secure_password
-            )
-            record = build_record_from(model, attribute_name => '')
-            expect(record).to validate_uniqueness.allow_blank
-          end
+      context 'given a record whose attribute is empty' do
+        it 'accepts' do
+          model = define_model_validating_uniqueness(
+            attribute_type: :string,
+            validation_options: { allow_blank: true },
+            additional_attributes: [{ name: :password_digest, type: :string }], &:has_secure_password
+          )
+          record = build_record_from(model, attribute_name => '')
+          expect(record).to validate_uniqueness.allow_blank
         end
       end
     end


### PR DESCRIPTION
This PR is a continuation of the `Remove Rails 4.2 support` - https://github.com/thoughtbot/shoulda-matchers/pull/1422.

I'll keep this as a draft meanwhile the other PR is not merged.

I realized that we don't need some active record validations in the tests. The purpose of this PR is to remove conditionals that are no longer needed due to the current version that we support.

What do you think?