### PR TITLE
Add support for foreign_type

### DIFF
--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -482,7 +482,7 @@ module Shoulda
       # Use `with_foreign_type` to test usage of the `:foreign_type` option.
       #
       #     class Hotel < ActiveRecord::Base
-      #       has_many :visitors, foreign_key: 'facility_type'
+      #       has_many :visitors, foreign_key: 'facility_type', as: :location
       #     end
       #
       #     # RSpec
@@ -771,7 +771,7 @@ module Shoulda
       # Use `with_foreign_type` to test usage of the `:foreign_type` option.
       #
       #     class Hotel < ActiveRecord::Base
-      #       has_one :special_guest, foreign_type: 'facility_type'
+      #       has_one :special_guest, foreign_type: 'facility_type', as: :location
       #     end
       #
       #     # RSpec

--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -1581,10 +1581,10 @@ module Shoulda
 
         def foreign_type
           type = if [:has_one, :has_many].include?(macro)
-            reflection.type
-          else
-            reflection.foreign_type
-          end
+                   reflection.type
+                 else
+                   reflection.foreign_type
+                 end
 
           type.to_s
         end

--- a/lib/shoulda/matchers/active_record/association_matchers/model_reflector.rb
+++ b/lib/shoulda/matchers/active_record/association_matchers/model_reflector.rb
@@ -8,6 +8,7 @@ module Shoulda
             :associated_class,
             :association_foreign_key,
             :foreign_key,
+            :foreign_type,
             :has_and_belongs_to_many_name,
             :join_table_name,
             :polymorphic?,

--- a/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -31,6 +31,17 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
       expect(Child.new).to belong_to(:parent)
     end
 
+    it 'accepts an association with an existing custom foreign key and type' do
+      define_model :parent
+      define_model :child, ancestor_id: :integer, ancestor_type: :string do
+        belongs_to :parent, polymorphic: true, foreign_key: 'ancestor_id', foreign_type: 'ancestor_type'
+      end
+
+      expect(Child.new).to belong_to(:parent).
+        with_foreign_key(:ancestor_id).
+        with_foreign_type(:ancestor_type)
+    end
+
     it 'accepts an association using an existing custom primary key' do
       define_model :parent
       define_model :child, parent_id: :integer, custom_primary_key: :integer do
@@ -1226,6 +1237,20 @@ Expected Parent to have a has_many association called children through conceptio
       expect(Parent.new).to have_many(:children)
     end
 
+    it 'accepts an association with a nonstandard reverse foreign type, using :inverse_of' do
+      define_model :visitor, location_id: :integer, facility_type: :string do
+        belongs_to :location, foreign_type: :facility_type, 
+                              inverse_of: :visitors,
+                              polymorphic: true
+      end
+
+      define_model :hotel do
+        has_many :visitors, inverse_of: :location, foreign_type: :facility_type, as: :location
+      end
+
+      expect(Hotel.new).to have_many(:visitors).with_foreign_type(:facility_type)
+    end
+
     it 'rejects an association with a nonstandard reverse foreign key, if :inverse_of is not correct' do
       define_model :child, mother_id: :integer do
         belongs_to :mother, inverse_of: :children, class_name: :Parent
@@ -1239,14 +1264,22 @@ Expected Parent to have a has_many association called children through conceptio
     end
 
     it 'accepts an association with a nonstandard foreign key, with reverse association turned off' do
-      define_model :child, ancestor_id: :integer do
-      end
-
+      define_model :child, ancestor_id: :integer
       define_model :parent do
         has_many :children, foreign_key: :ancestor_id, inverse_of: false
       end
 
       expect(Parent.new).to have_many(:children)
+    end
+
+    it 'accepts an association with a nonstandard type, with reverse association turned off' do
+      define_model :visitor, location_id: :integer, facitility_type: :string
+
+      define_model :hotel do
+        has_many :visitors, foreign_type: :facitility_type, inverse_of: false, as: :location
+      end
+
+      expect(Hotel.new).to have_many(:visitors).with_foreign_type(:facitility_type)
     end
 
     def having_many_children(options = {})
@@ -1298,6 +1331,21 @@ Expected Parent to have a has_many association called children through conceptio
         has_one :detail, foreign_key: :detailed_person_id
       end
       expect(Person.new).to have_one(:detail).with_foreign_key(:detailed_person_id)
+    end
+
+    it 'accepts an association with an existing custom foreign type' do
+      define_model :profile, user_id: :integer, related_user_type: :string
+
+      define_model :admin do
+        has_one :profile, foreign_type: :related_user_type, as: :user
+      end
+
+      define_model :moderator do
+        has_one :profile, foreign_type: :related_user_type, as: :user
+      end
+
+      expect(Admin.new).to have_one(:profile).with_foreign_type(:related_user_type)
+      expect(Moderator.new).to have_one(:profile).with_foreign_type(:related_user_type)
     end
 
     it 'accepts an association using an existing custom primary key' do

--- a/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -1239,7 +1239,7 @@ Expected Parent to have a has_many association called children through conceptio
 
     it 'accepts an association with a nonstandard reverse foreign type, using :inverse_of' do
       define_model :visitor, location_id: :integer, facility_type: :string do
-        belongs_to :location, foreign_type: :facility_type, 
+        belongs_to :location, foreign_type: :facility_type,
                               inverse_of: :visitors,
                               polymorphic: true
       end


### PR DESCRIPTION
Allows to create tests checking set foreign_type

```ruby
class Visitor < ActiveRecord::Base
  belongs_to :location, foreign_type: :facility_type, polymorphic: true
end

class Hotel < Location
  has_many :visitors, inverse_of: :location, foreign_type: :facility_type, as: :location
end

class PrisonCell < Location
  has_one :visitor, inverse_of: :location, foreign_type: :facility_type, as: :location
end
```

```ruby
expect(Visitor.new).to belong_to(:location).with_foreign_type(:facility_type)
expect(Hotel.new).to have_many(:visitors).with_foreign_type(:facility_type)
expect(PrisonCell.new).to have_one(:visitor).with_foreign_type(:facility_type)
```