### PR TITLE
Add #ignoring_check_for_db_column to HaveSecureTokenMatcher

### DIFF
--- a/lib/shoulda/matchers/active_record/have_secure_token_matcher.rb
+++ b/lib/shoulda/matchers/active_record/have_secure_token_matcher.rb
@@ -23,6 +23,25 @@ module Shoulda
       #
       # #### Qualifiers
       #
+      # ##### ignoring_check_for_db_column
+      #
+      # By default, this matcher tests that a token column is present.
+      # Use `ignoring_check_for_db_column` if this is not the case.
+      #
+      #     class User < ActiveRecord
+      #       has_secure_token :auth_token
+      #     end
+      #
+      #     # RSpec
+      #     RSpec.describe User, type: :model do
+      #       it { should have_secure_token(:auth_token).ignoring_check_for_db_column }
+      #     end
+      #
+      #     # Minitest (Shoulda)
+      #     class UserTest < ActiveSupport::TestCase
+      #       should have_secure_token(:auth_token).ignoring_check_for_db_column
+      #     end
+      #
       # ##### ignoring_check_for_db_index
       #
       # By default, this matcher tests that an index is defined on your token
@@ -81,6 +100,12 @@ module Shoulda
           @errors.empty?
         end
 
+        def ignoring_check_for_db_column
+          @options[:ignore_check_for_db_column] = true
+          ignoring_check_for_db_index
+          self
+        end
+
         def ignoring_check_for_db_index
           @options[:ignore_check_for_db_index] = true
           self
@@ -93,7 +118,7 @@ module Shoulda
           if !has_expected_instance_methods?
             @errors << 'missing expected class and instance methods'
           end
-          if !has_expected_db_column?
+          if !@options[:ignore_check_for_db_column] && !has_expected_db_column?
             @errors << "missing correct column #{token_attribute}:string"
           end
           if !@options[:ignore_check_for_db_index] && !has_expected_db_index?

--- a/spec/unit/shoulda/matchers/active_record/have_secure_token_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/have_secure_token_matcher_spec.rb
@@ -54,6 +54,18 @@ describe Shoulda::Matchers::ActiveRecord::HaveSecureTokenMatcher,
         to fail_with_message(expected_message)
     end
   end
+  
+  it 'matches when called with ignoring_check_for_db_column without db column' do
+    create_table(:users) do |t|
+    end
+
+    valid_model = define_model_class(:User) do
+      attr_accessor :token
+      has_secure_token
+    end
+    expect(valid_model.new).
+      to have_secure_token.ignoring_check_for_db_column
+  end
 
   it 'matches when called with ignoring_check_for_db_index without db index' do
     create_table(:users) do |t|


### PR DESCRIPTION
In some cases a check for the token column may be omitted.
For example if `has_secure_token` and `has_secure_password(:token)` are used in combination.