### PR TITLE
renew deprecated methods

### DIFF
--- a/lib/shoulda/matchers/active_model/helpers.rb
+++ b/lib/shoulda/matchers/active_model/helpers.rb
@@ -8,7 +8,7 @@ module Shoulda
         end
 
         def format_validation_errors(errors)
-          list_items = errors.attribute_names.map do |attribute|
+          list_items = errors.to_hash.keys.map do |attribute|
             messages = errors[attribute]
             "* #{attribute}: #{messages}"
           end

--- a/lib/shoulda/matchers/active_model/helpers.rb
+++ b/lib/shoulda/matchers/active_model/helpers.rb
@@ -8,7 +8,7 @@ module Shoulda
         end
 
         def format_validation_errors(errors)
-          list_items = errors.keys.map do |attribute|
+          list_items = errors.attribute_names.map do |attribute|
             messages = errors[attribute]
             "* #{attribute}: #{messages}"
           end

--- a/spec/unit/shoulda/matchers/active_model/disallow_value_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/disallow_value_matcher_spec.rb
@@ -73,7 +73,7 @@ describe Shoulda::Matchers::ActiveModel::DisallowValueMatcher, type: :model do
 
         def custom_validation # rubocop:disable Lint/NestedMethodDefinition
           if self[:attr] != 'good value'
-            errors[:attr2] << 'some message'
+            errors.add :attr2, 'some message'
           end
         end
       end.new


### PR DESCRIPTION
Thank you for providing a nice gem.

In shoulda-matchers@v5.0.0.rc1, still there were deprecated methods for Rails6.1 in a helper method and an unit test, which have been renewed.