### PR TITLE
Flatten expected_join_table_columns to allow composite primary keys on HABTM 

### DIFF
--- a/lib/shoulda/matchers/active_record/association_matchers/join_table_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matchers/join_table_matcher.rb
@@ -75,7 +75,7 @@ module Shoulda
           end
 
           def expected_join_table_columns
-            [foreign_key, association_foreign_key]
+            [foreign_key, association_foreign_key].flatten
           end
 
           def actual_join_table_columns


### PR DESCRIPTION
I've run into issues using `have_and_belong_to_many` matcher when using it against a relationship using composite primary keys (utilising `composite_primary_keys/composite_primary_keys` gem).

If I'm not mistaken the problem occurs because the `expected_join_table_columns` returns an array of arrays when using in conjunction with composite primary keys.

My solution here was just to flatten the return value so the keys are again in a one dimensional array. I've run it against my own code and it works, but to be honest I did not take the time to run it against existing specs to check if that code would introduce any regression.

I would appreciate if you could check and consider this PR for integration. I'm currently a little bit busy with work and private life, so I can not promise to put in a lot of time to fix any issues if necessary, but I will try to do whatever I can in my available time to support if this fix is considered helpful.