### PR TITLE
Bump version to 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 5.0.0 - 2021-07-09
 
 ### Bug fixes
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Start by including `shoulda-matchers` in your Gemfile:
 
 ```ruby
 group :test do
-  gem 'shoulda-matchers', '~> 4.0'
+  gem 'shoulda-matchers', '~> 5.0'
 end
 ```
 

--- a/lib/shoulda/matchers/version.rb
+++ b/lib/shoulda/matchers/version.rb
@@ -1,6 +1,6 @@
 module Shoulda
   module Matchers
     # @private
-    VERSION = '5.0.0.rc1'.freeze
+    VERSION = '5.0.0'.freeze
   end
 end


### PR DESCRIPTION
### Bug fixes

* Replace `in?`, method from ActiveSupport, with `include?` to prevent exception "undefined method `in?`" on non-Rails app. ([#1405])

[#1405]: https://github.com/thoughtbot/shoulda-matchers/pull/1405

### Features

* Add support for Rails 6.1. No new Rails 6.1 features are supported, but only
  existing features that broke with the upgrade. ([#1418])

* Add support for RVM (Ruby Version Manager) to setting up local environment. ([#1424])

* Add support for alias in matcher define_enum. ([#1419])

* Add support for Ruby 3.0. ([#1406], [#1427])

[#1406]: https://github.com/thoughtbot/shoulda-matchers/pull/1406
[#1418]: https://github.com/thoughtbot/shoulda-matchers/pull/1418
[#1419]: https://github.com/thoughtbot/shoulda-matchers/pull/1419
[#1424]: https://github.com/thoughtbot/shoulda-matchers/pull/1424
[#1427]: https://github.com/thoughtbot/shoulda-matchers/pull/1427

### Improvements

* Remove deprecated warnings emitted on Rails 6.1 in ActiveModel errors. ([#1444])

[#1444]: https://github.com/thoughtbot/shoulda-matchers/pull/1444