### PR TITLE
Install ActiveStorage migrations

### DIFF
--- a/spec/support/unit/rails_application.rb
+++ b/spec/support/unit/rails_application.rb
@@ -26,6 +26,7 @@ module UnitTests
     def load
       load_environment
 
+      add_active_storage_migration
       add_action_text_migration if rails_version >= 6.0
 
       run_migrations
@@ -147,6 +148,12 @@ end
     def add_action_text_migration
       fs.within_project do
         run_command! 'bundle exec rake action_text:install:migrations'
+      end
+    end
+
+    def add_active_storage_migration
+      fs.within_project do
+        run_command! 'bundle exec rake active_storage:install:migrations'
       end
     end
 

--- a/spec/unit/shoulda/matchers/active_record/have_attached_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/have_attached_matcher_spec.rb
@@ -1,35 +1,6 @@
 require 'unit_spec_helper'
 
 describe Shoulda::Matchers::ActiveRecord::HaveAttachedMatcher, type: :model do
-  before do
-    create_table :active_storage_blobs do |t|
-      t.string :key, null: false
-      t.string :filename, null: false
-      t.string :content_type
-      t.text :metadata
-      t.bigint :byte_size, null: false
-      t.string :checksum, null: false
-      t.datetime :created_at, null: false
-
-      t.index [:key], unique: true
-    end
-
-    create_table :active_storage_attachments do |t|
-      t.string :name, null: false
-      t.references :record, null: false, polymorphic: true, index: false
-      t.references :blob, null: false
-
-      t.datetime :created_at, null: false
-
-      t.index [:record_type, :record_id, :name, :blob_id],
-        name: 'index_active_storage_attachments_uniqueness', unique: true
-
-      # The original rails migration has a foreign key.
-      # Since this messes up the clearing of the database, it's removed here.
-      # t.foreign_key :active_storage_blobs, column: :blob_id
-    end
-  end
-
   describe 'have_one_attached' do
     describe '#description' do
       it 'returns the message with the name of the association' do


### PR DESCRIPTION
Suggestion: instead of creating the table manually, use the command 'bundle exec rake active_storage: install: migrations'.