### PR TITLE
Fix the undefined method error for non rails project due to use of many? method.

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
@@ -355,7 +355,7 @@ EOT
             description = "validate that :#{@attribute}"
 
             description <<
-              if @array.many?
+              if @array.count > 1
                 " is either #{inspected_array}"
               else
                 " is #{inspected_array}"

--- a/spec/acceptance/active_model_integration_spec.rb
+++ b/spec/acceptance/active_model_integration_spec.rb
@@ -1,13 +1,35 @@
 require 'acceptance_spec_helper'
 
 describe 'shoulda-matchers integrates with an ActiveModel project' do
-  specify 'and loads without errors' do
+
+  before do
     create_active_model_project
 
-    add_shoulda_matchers_to_project(
-      test_frameworks: [:rspec],
-      libraries: [:active_model],
-    )
+    write_file 'lib/user.rb', <<-FILE
+      require 'active_model'
+
+      class User
+        include ActiveModel::Validations
+        attr_accessor :gender
+
+        validates :gender, inclusion: { in: %w(male female) }
+      end
+    FILE
+
+    write_file 'spec/user_spec.rb', <<-FILE
+      require 'spec_helper'
+      require 'user'
+      include Shoulda::Matchers::ActiveModel
+
+      describe User do
+        context 'when gender is valid' do
+          it { is_expected.to validate_inclusion_of(:gender).in_array(%w(male female)) }
+        end
+        context 'when gender is invalid' do
+          it { is_expected.to validate_inclusion_of(:gender).in_array(%w(transgender female)) }
+        end
+      end
+    FILE
 
     write_file 'load_dependencies.rb', <<-FILE
       require 'active_model'
@@ -17,7 +39,43 @@ describe 'shoulda-matchers integrates with an ActiveModel project' do
       puts "Loaded all dependencies without errors"
     FILE
 
-    result = run_command_within_bundle('ruby load_dependencies.rb')
-    expect(result).to have_output('Loaded all dependencies without errors')
+    updating_bundle do
+      add_rspec_to_project
+      add_shoulda_matchers_to_project(
+        manually: true,
+        with_configuration: false,
+      )
+
+      write_file 'spec/spec_helper.rb', <<-FILE
+        require 'active_model'
+        require 'shoulda-matchers'
+
+        Shoulda::Matchers.configure do |config|
+          config.integrate do |with|
+            with.test_framework :rspec
+
+            with.library :active_model
+          end
+        end
+      FILE
+    end
   end
+
+  context 'when using active model library' do
+
+    it 'and loads without errors' do
+      result = run_command_within_bundle('ruby load_dependencies.rb')
+      expect(result).to have_output('Loaded all dependencies without errors')
+    end
+
+    it 'allows use of inclusion matcher from active model library' do
+      result = run_rspec_tests('spec/user_spec.rb')
+      expect(result).to have_output('2 examples, 1 failure')
+
+      expect(result).to have_output(
+        'gender: ["is not included in the list"]',
+      )
+    end
+  end
+
 end

--- a/spec/acceptance/active_model_integration_spec.rb
+++ b/spec/acceptance/active_model_integration_spec.rb
@@ -1,7 +1,6 @@
 require 'acceptance_spec_helper'
 
 describe 'shoulda-matchers integrates with an ActiveModel project' do
-
   before do
     create_active_model_project
 
@@ -77,5 +76,4 @@ describe 'shoulda-matchers integrates with an ActiveModel project' do
       )
     end
   end
-
 end

--- a/spec/acceptance/active_model_integration_spec.rb
+++ b/spec/acceptance/active_model_integration_spec.rb
@@ -62,16 +62,16 @@ describe 'shoulda-matchers integrates with an ActiveModel project' do
   end
 
   context 'when using active model library' do
-
     it 'and loads without errors' do
       result = run_command_within_bundle('ruby load_dependencies.rb')
+
       expect(result).to have_output('Loaded all dependencies without errors')
     end
 
     it 'allows use of inclusion matcher from active model library' do
       result = run_rspec_tests('spec/user_spec.rb')
-      expect(result).to have_output('2 examples, 1 failure')
 
+      expect(result).to have_output('2 examples, 1 failure')
       expect(result).to have_output(
         'gender: ["is not included in the list"]',
       )


### PR DESCRIPTION
**Why?**

For non rails project when we try to implement test for inclusion validation, it throws following error:
```
NoMethodError:
       undefined method `many?' for ["video_transcoding"]:Array
       Did you mean?  any?

```

Screenshot for same:

<img width="1507" alt="image" src="https://user-images.githubusercontent.com/26363461/130441233-bb2d6591-e955-4340-8a0f-abd40f6b8945.png">

**Reason:**

The method 'many?' is defined for Rails's ActiveRecord Relation collection, for plain ruby array it gives error.

I also tried this to verify the same:

In rails console (project where we are using rails)

<img width="338" alt="image" src="https://user-images.githubusercontent.com/26363461/130441523-6fcce81b-4a9b-4601-9960-c16a0a9d65fa.png">

In IRB 
<img width="715" alt="image" src="https://user-images.githubusercontent.com/26363461/130441626-210c969e-940b-4b17-ab0d-4065de622cf4.png">

Test execution:

<pre>
➜  shoulda-matchers git:(fix/error-raised-by-ar-relation-method_many) ✗ bundle exec appraisal rails_6_0 rspec spec/acceptance/active_model_integration_spec.rb
>> BUNDLE_GEMFILE=/Users/nitinsingh/projects/gems/shoulda-matchers/gemfiles/rails_6_0.gemfile bundle exec rspec spec/acceptance/active_model_integration_spec.rb

Randomized with seed 5287

shoulda-matchers integrates with an ActiveModel project
  when using active model library
    and loads without errors
    allows use of inclusion matcher from active model library

Finished in 4.47 seconds (files took 0.3926 seconds to load)
2 examples, 0 failures

Randomized with seed 5287
</pre>

