### PR TITLE
Use bundler v2 in development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'appraisal', '2.2.0'
-gem 'bundler', '~> 1.1'
+gem 'bundler', '~> 2.0'
 gem 'pry'
 gem 'pry-byebug'
 gem 'rake', '13.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ PLATFORMS
 
 DEPENDENCIES
   appraisal (= 2.2.0)
-  bundler (~> 1.1)
+  bundler (~> 2.0)
   fssm
   pry
   pry-byebug
@@ -100,4 +100,4 @@ DEPENDENCIES
   zeus
 
 BUNDLED WITH
-   1.17.3
+   2.2.22

--- a/bin/setup
+++ b/bin/setup
@@ -8,8 +8,6 @@ set -euo pipefail
 # section. You may also delete this section altogether if your project doesn't
 # need a custom setup.
 
-USE_BUNDLER_1=1
-
 provision-project() {
   banner "Installing Appraisals"
   bundle exec appraisal install
@@ -187,8 +185,6 @@ setup() {
 # --- RUBY ---------------------------------------------------------------------
 
 provision-ruby() {
-  USE_BUNDLER_1=0
-
   if [[ -f .tool-versions ]]; then
     REQUIRED_RUBY_VERSION=$(cat .tool-versions | grep '^ruby ' | head -n 1 | sed -Ee 's/^ruby (.+)$/\1/')
   elif [[ -f .ruby-version ]]; then
@@ -265,11 +261,7 @@ has-bundler() {
 ensure-project-ruby-dependencies-installed() {
   banner 'Installing Ruby dependencies'
 
-  if [[ $USE_BUNDLER_1 -eq 1 ]] && (! has-bundler || ! [[ $(bundle -v) =~ '^Bundler version 1\.' ]]); then
-    gem install bundler:'~> 1.0'
-  elif ! has-bundler; then
-    gem install bundler
-  fi
+  gem install bundler
 
   bundle check || bundle install
 }

--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "appraisal", "2.2.0"
-gem "bundler", "~> 1.1"
+gem "bundler", "~> 2.0"
 gem "pry"
 gem "pry-byebug"
 gem "rake", "13.0.1"

--- a/gemfiles/rails_5_2.gemfile.lock
+++ b/gemfiles/rails_5_2.gemfile.lock
@@ -248,7 +248,7 @@ DEPENDENCIES
   appraisal (= 2.2.0)
   bcrypt (~> 3.1.7)
   bootsnap (>= 1.1.0)
-  bundler (~> 1.1)
+  bundler (~> 2.0)
   capybara (~> 3.1.1)
   chromedriver-helper
   fssm
@@ -281,4 +281,4 @@ DEPENDENCIES
   zeus
 
 BUNDLED WITH
-   1.17.3
+   2.2.22

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "appraisal", "2.2.0"
-gem "bundler", "~> 1.1"
+gem "bundler", "~> 2.0"
 gem "pry"
 gem "pry-byebug"
 gem "rake", "13.0.1"

--- a/gemfiles/rails_6_0.gemfile.lock
+++ b/gemfiles/rails_6_0.gemfile.lock
@@ -264,7 +264,7 @@ DEPENDENCIES
   appraisal (= 2.2.0)
   bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.2)
-  bundler (~> 1.1)
+  bundler (~> 2.0)
   capybara (>= 2.15)
   fssm
   jbuilder (~> 2.7)
@@ -297,4 +297,4 @@ DEPENDENCIES
   zeus
 
 BUNDLED WITH
-   1.17.3
+   2.2.22

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "appraisal", "2.2.0"
-gem "bundler", "~> 1.1"
+gem "bundler", "~> 2.0"
 gem "pry"
 gem "pry-byebug"
 gem "rake", "13.0.1"

--- a/gemfiles/rails_6_1.gemfile.lock
+++ b/gemfiles/rails_6_1.gemfile.lock
@@ -269,7 +269,7 @@ DEPENDENCIES
   appraisal (= 2.2.0)
   bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.2)
-  bundler (~> 1.1)
+  bundler (~> 2.0)
   capybara (>= 2.15)
   fssm
   jbuilder (~> 2.7)
@@ -303,4 +303,4 @@ DEPENDENCIES
   zeus
 
 BUNDLED WITH
-   1.17.3
+   2.2.22


### PR DESCRIPTION
Prior to this commit, the `Gemfile.lock` enforced the use of
Bundler v1.17.3 which was released in 2014.

On Ruby 3, this triggers the following deprecation warning:

```
/home/user/.rvm/gems/ruby-3.0.2@shoulda-matchers/gems/bundler-1.17.3/lib/bundler/shared_helpers.rb:118: warning: Pathname#untaint is deprecated and will be removed in Ruby 3.2.
```

Since the gem itself in v5.0.0 requires at least Ruby v2.6,
it seems fair to require a recent version of Bundler v2,
which in turn runs of every Ruby v2.3 or later.