### PR TITLE
Add array option support for have db column matcher

### DIFF
--- a/lib/shoulda/matchers/active_record/have_db_column_matcher.rb
+++ b/lib/shoulda/matchers/active_record/have_db_column_matcher.rb
@@ -52,7 +52,7 @@ module Shoulda
       #
       # Use `with_options` to assert that a column has been defined with
       # certain options (`:precision`, `:limit`, `:default`, `:null`, `:scale`,
-      # or `:primary`).
+      # `:primary` or `:array`).
       #
       #     class CreatePhones < ActiveRecord::Migration
       #       def change
@@ -84,7 +84,7 @@ module Shoulda
 
       # @private
       class HaveDbColumnMatcher
-        OPTIONS = %i(precision limit default null scale primary).freeze
+        OPTIONS = %i(precision limit default null scale primary array).freeze
 
         def initialize(column)
           @column = column
@@ -115,7 +115,8 @@ module Shoulda
             correct_default? &&
             correct_null? &&
             correct_scale? &&
-            correct_primary?
+            correct_primary? &&
+            correct_array?
         end
 
         def failure_message
@@ -253,6 +254,23 @@ module Shoulda
                 'that is not primary, but should be'
               else
                 'that is primary, but should not be'
+              end
+            false
+          end
+        end
+
+        def correct_array?
+          return true unless @options.key?(:array)
+
+          if matched_column.array? == @options[:array]
+            true
+          else
+            @missing = "#{model_class} has a db column named #{@column} "
+            @missing <<
+              if @options[:primary]
+                'that is not array, but should be'
+              else
+                'that is array, but should not be'
               end
             false
           end

--- a/spec/unit/shoulda/matchers/active_record/have_db_column_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/have_db_column_matcher_spec.rb
@@ -98,6 +98,20 @@ describe Shoulda::Matchers::ActiveRecord::HaveDbColumnMatcher, type: :model do
     end
   end
 
+  if database_supports_array_columns?
+    context 'with array option' do
+      it 'accepts a column that is array' do
+        expect(with_table(:tags, :string, array: true)).
+          to have_db_column(:tags).with_options(array: true)
+      end
+
+      it 'rejects a column that is not array' do
+        expect(with_table(:whatever, :string, array: false)).
+          not_to have_db_column(:whatever).with_options(array: true)
+      end
+    end
+  end
+
   context 'with invalid argument option' do
     it 'raises an error with the unknown options' do
       expect {


### PR DESCRIPTION
This pull request adds `:array` option support for `have_db_column` matcher.

Rails starting from 4.0 support array columns for postgresql and other databases.

`shoulda matchers` prior to 4.5.0 just ignored so it was passible to write
`expect(...).to have_db_column(:tags).with_options(array: true)`. Check was not actually performed.

`shoulda-matchers` staring from 4.5.0 caused those specs to fail.

