### PR TITLE
CI: Use bundler-cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 3.0.2
-          - 2.7.4
-          - 2.6.8
+          - '3.0'
+          - 2.7
+          - 2.6
         appraisal:
           - rails_6_1
           - rails_6_0
@@ -38,7 +38,7 @@ jobs:
           - sqlite3
           - postgresql
         exclude:
-          - { ruby: 3.0.2, appraisal: rails_5_2 }
+          - { ruby: '3.0', appraisal: rails_5_2 }
     env:
       DATABASE_ADAPTER: ${{ matrix.adapter }}
       BUNDLE_GEMFILE: gemfiles/${{ matrix.appraisal }}.gemfile
@@ -49,12 +49,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: v1-rubygems-local-${{ runner.os }}-${{ matrix.ruby }}-${{ hashFiles(format('gemfiles/{0}.gemfile.lock', matrix.appraisal)) }}
-      - name: Install dependencies
-        run: bundle install --jobs=3 --retry=3
+          bundler-cache: true # 'bundle install' and cache
       - name: Run Unit Tests
         run: bundle exec rake spec:unit --trace
       - name: Run Acceptance Tests


### PR DESCRIPTION
This PR uses the `bundler-cache` feature of the Ruby-maintained Action `ruby/setup-ruby`.

[See `ruby/setup-ruby` parameters declaration](https://github.com/ruby/setup-ruby/blob/master/action.yml) for more information.