### PR TITLE
Fix bootsnap removal

### DIFF
--- a/spec/support/unit/rails_application.rb
+++ b/spec/support/unit/rails_application.rb
@@ -130,7 +130,7 @@ end
       # Zeus anyhow)
       fs.comment_lines_matching(
         'config/boot.rb',
-        %r{\Arequire 'bootsnap/setup'},
+        %r{\Arequire ("|')bootsnap/setup("|')},
       )
     end
 


### PR DESCRIPTION
As I was trying to run the tests on Ruby 3.1, I've noticed some errors involving bootsnap, even when it's supposed to be commented automatically.

The `UnitTest::RailsApplication#remove_bootsnap` method looks for a line with single quotes. However, [since Rails 6.1](https://railsdiff.org/6.0.4.4/6.1.4.4#diff-3cda23b4db46f4304ea7df756bcefdf304bcd055), the config files use double quotes, and bootsnap is not removed.