### PR TITLE
Update references from master to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Test
 on:
   push:
     branches:
-      - master
+      - main
     paths-ignore:
       - '**.md'
   pull_request:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ contributions in a timely manner. Once we look at your pull request, we may give
 you feedback. For instance, we may suggest some changes to make to your code to
 fit within the project style or discuss alternate ways of addressing the issue
 in question. Assuming we're happy with everything, we'll then bring your changes
-into master. Now you're a contributor!
+into main. Now you're a contributor!
 
 ---
 
@@ -171,7 +171,7 @@ bundle exec rake
   guide] was a wonderful piece on this topic when it came out and we still find
   it to be helpful even today.
 * Squash "WIP" commits and remove merge commits by rebasing your branch against
-  `master`. We try to keep our commit history as clean as possible.
+  `main`. We try to keep our commit history as clean as possible.
 
 [Tim Pope's guide]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -48,7 +48,7 @@ patrons happy. We do this by:
 
 ## Workflow
 
-We generally follow [GitHub Flow]. The `master` branch is the main line, and all
+We generally follow [GitHub Flow]. The `main` branch is the main line, and all
 branches are cut from and get merged back into this branch. Generally, the
 workflow is as follows:
 
@@ -154,7 +154,7 @@ That's it!
 
 ## Updating the changelog
 
-After every user-facing change makes it into master, we make a note of it in the
+After every user-facing change makes it into main, we make a note of it in the
 changelog, kept in `CHANGELOG.md`. The changelog is sorted in reverse order by
 release version, with the topmost version as the next release (tagged as
 "(Unreleased)").

--- a/shoulda-matchers.gemspec
+++ b/shoulda-matchers.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
 
   s.metadata = {
     'bug_tracker_uri' => 'https://github.com/thoughtbot/shoulda-matchers/issues',
-    'changelog_uri' => 'https://github.com/thoughtbot/shoulda-matchers/blob/master/CHANGELOG.md',
+    'changelog_uri' => 'https://github.com/thoughtbot/shoulda-matchers/blob/main/CHANGELOG.md',
     'documentation_uri' => 'https://matchers.shoulda.io/docs',
     'homepage_uri' => 'https://matchers.shoulda.io',
     'source_code_uri' => 'https://github.com/thoughtbot/shoulda-matchers',


### PR DESCRIPTION
The `master` branch has been renamed to `main` on version 5.1.0 of the gem, but there are still a few references to `master`:
- On CONTRIBUTING.md and MAINTAINING.md documentation files
- On the changelog URL used by rubygems.org
- On the Github Actions settings file