### PR TITLE
Add support for text columns for secure matchers

### DIFF
--- a/lib/shoulda/matchers/active_record/have_secure_token_matcher.rb
+++ b/lib/shoulda/matchers/active_record/have_secure_token_matcher.rb
@@ -110,7 +110,7 @@ module Shoulda
         end
 
         def has_expected_db_column?
-          matcher = HaveDbColumnMatcher.new(token_attribute).of_type(:string)
+          matcher = HaveDbColumnMatcher.new(token_attribute).of_type(:string) || HaveDbColumnMatcher.new(token_attribute).of_type(:text)
           matcher.matches?(@subject)
         end
 

--- a/spec/unit/shoulda/matchers/active_record/have_secure_token_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/have_secure_token_matcher_spec.rb
@@ -27,6 +27,17 @@ describe Shoulda::Matchers::ActiveRecord::HaveSecureTokenMatcher,
     expect(valid_model.new).to have_secure_token
   end
 
+  it 'matches when the subject configures has_secure_token with the db using a text datatype' do
+    create_table(:users) do |t|
+      t.string :token
+      t.index :text, unique: true
+    end
+
+    valid_model = define_model_class(:User) { has_secure_token }
+
+    expect(valid_model.new).to have_secure_token
+  end
+
   it 'matches when the subject configures has_secure_token with the db for ' \
       'a custom attribute' do
     create_table(:users) do |t|


### PR DESCRIPTION
## Issue

Currently, using the `text` datatype for the `has_secure_token` functionality is supported in Rails, but when used alongside shoulda-matchers it fails as the datatype must be `string`.

On codebases that use postgresql, there's no difference between using `text` or `string` and in most cases it makes sense to use `text`.

## Proposed solution

Add support for `text` datatypes when using the `have_secure_token` matcher.