### PR TITLE
Switch from deprecated Bundler.with_clean_env to Bundler.with_original_env

### DIFF
--- a/spec/support/acceptance/helpers/command_helpers.rb
+++ b/spec/support/acceptance/helpers/command_helpers.rb
@@ -23,7 +23,7 @@ module AcceptanceTests
     def run_command_isolated_from_bundle(*args)
       run_command(*args) do |runner|
         runner.around_command do |run_command|
-          Bundler.with_clean_env(&run_command)
+          Bundler.with_original_env(&run_command)
         end
 
         yield runner if block_given?


### PR DESCRIPTION

Noticed this at the bottom of [this action output](https://github.com/thoughtbot/shoulda-matchers/runs/5012675348?check_suite_focus=true#step:8:338) on https://github.com/Gusto/zensa/pull/762

```
[DEPRECATED] `Bundler.with_clean_env` has been deprecated in favor of `Bundler.with_unbundled_env`. If you instead want the environment before bundler was originally loaded, use `Bundler.with_original_env` (called at /home/runner/work/shoulda-matchers/shoulda-matchers/spec/support/acceptance/helpers/command_helpers.rb:26)
```