### PR TITLE
Using local gems should be enough for testing

### DIFF
--- a/spec/support/acceptance/helpers/step_helpers.rb
+++ b/spec/support/acceptance/helpers/step_helpers.rb
@@ -116,7 +116,7 @@ module AcceptanceTests
 
     def add_rspec_rails_to_project!
       add_gem 'rspec-rails', rspec_rails_version
-      run_command_within_bundle!('bundle install --binstubs') if rails_gt_6_0?
+      run_command_within_bundle!('bundle install --local --binstubs') if rails_gt_6_0?
       run_command_within_bundle!('rails g rspec:install')
       remove_from_file '.rspec', '--warnings'
     end


### PR DESCRIPTION
I think that `--local` should be always preferred and it is already used on other places. Which also leads me to think that the code abuses `run_command_within_bundle!` for purposes it was not intended to be used and `install_gems` should be used instead. But that does not used the `--binstubs` option OTOH. But that might be the preferred solution anyway. Not sure. I could have try that :thinking: 