### PR TITLE
Add support for ActiveModel::Error in Rails 7

### DIFF
--- a/lib/shoulda/matchers/active_model/helpers.rb
+++ b/lib/shoulda/matchers/active_model/helpers.rb
@@ -8,7 +8,7 @@ module Shoulda
         end
 
         def format_validation_errors(errors)
-          list_items = errors.to_hash.keys.map do |attribute|
+          list_items = errors.messages.keys.map do |attribute|
             messages = errors[attribute]
             "* #{attribute}: #{messages}"
           end


### PR DESCRIPTION
#### Problem
The purpose of this PR is to enable the use of shoulda-matchers with Rails 7. There is a problem when `format_validation_errors` execute `errors.keys`. Because, `errors.keys` don't existis in Rails 7. We can check that [here](https://api.rubyonrails.org/classes/ActiveModel/Errors.html).

#### Soluction
I added `errors.messages` for return a hash with errors and their values ​​so we can use `.keys` in the hash

#### Error print
![image](https://user-images.githubusercontent.com/39440032/188214046-d69aabc2-6675-4cab-8e7e-444ab7bc41d2.png)

#### Versions
Ruby: 3.1.2
Rails: 7.0.3.1
