### PR TITLE
Bump version to 5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changelog
 
-## Unreleased
-
+## 5.2.0 - 2022-09-15
 
 ### Features
 

--- a/lib/shoulda/matchers/version.rb
+++ b/lib/shoulda/matchers/version.rb
@@ -1,6 +1,6 @@
 module Shoulda
   module Matchers
     # @private
-    VERSION = '5.1.0'.freeze
+    VERSION = '5.2.0'.freeze
   end
 end


### PR DESCRIPTION
### Features

* Add without_scopes method to enum matcher. ([#1453])

* Add support for Ruby 3.1. ([#1474])

* Add allow_blank method to validate_presence_of matcher. ([#1499])

* Add support for Rails 7.0. No new Rails 7.0 features are supported, but only
  existing features that broke with the upgrade. ([#1506])

[#1453]: https://github.com/thoughtbot/shoulda-matchers/pull/1453
[#1474]: https://github.com/thoughtbot/shoulda-matchers/pull/1474
[#1499]: https://github.com/thoughtbot/shoulda-matchers/pull/1499
[#1506]: https://github.com/thoughtbot/shoulda-matchers/pull/1506