### PR TITLE
Fix typo: arbitary -> arbitrary

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_absence_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_absence_of_matcher.rb
@@ -108,7 +108,7 @@ module Shoulda
               obj
             end
           elsif array_column?
-            ['an arbitary value']
+            ['an arbitrary value']
           elsif enum_column?
             enum_values.first
           else


### PR DESCRIPTION
This pull request just fixes a typo that I found while reading the code. Thank you.