### PR TITLE
Support :uuid column type for validate_absence_of matcher

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_absence_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_absence_of_matcher.rb
@@ -118,7 +118,7 @@ module Shoulda
             when :datetime, :time, :timestamp then Time.current
             when :date then Date.new
             when :binary then '0'
-            when :uuid then SecureRandom.uuid  
+            when :uuid then SecureRandom.uuid
             else 'an arbitrary value'
             end
           end

--- a/lib/shoulda/matchers/active_model/validate_absence_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_absence_of_matcher.rb
@@ -118,6 +118,7 @@ module Shoulda
             when :datetime, :time, :timestamp then Time.current
             when :date then Date.new
             when :binary then '0'
+            when :uuid then SecureRandom.uuid  
             else 'an arbitrary value'
             end
           end

--- a/spec/unit/shoulda/matchers/active_model/validate_absence_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_absence_of_matcher_spec.rb
@@ -14,7 +14,7 @@ describe Shoulda::Matchers::ActiveModel::ValidateAbsenceOfMatcher, type: :model 
         :time,
         :date,
         :binary,
-        :uuid
+        :uuid,
       ]
     end
 

--- a/spec/unit/shoulda/matchers/active_model/validate_absence_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_absence_of_matcher_spec.rb
@@ -14,6 +14,7 @@ describe Shoulda::Matchers::ActiveModel::ValidateAbsenceOfMatcher, type: :model 
         :time,
         :date,
         :binary,
+        :uuid
       ]
     end
 


### PR DESCRIPTION
Hello, 

I run into a case where I needed to make sure that an `uuid` column was empty but could not use `validate_absence_of` matcher. 

It tried to set the column with "an arbitrary value" which is not a valid uuid value.

This Pull Requests attempts to fix the situation. 

