### PR TITLE
Remove Ruby 2.6 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
           - 3.1.3
           - 3.0.5
           - 2.7.7
-          - 2.6.10
         appraisal:
           - rails_7_0
           - rails_6_1
@@ -48,7 +47,6 @@ jobs:
           - { ruby: 3.0.5, appraisal: rails_5_2 }
           - { ruby: 3.0.5, appraisal: rails_7_0 }
           - { ruby: 2.7.7, appraisal: rails_7_0 }
-          - { ruby: 2.6.10, appraisal: rails_7_0 }
     env:
       DATABASE_ADAPTER: ${{ matrix.adapter }}
       BUNDLE_GEMFILE: gemfiles/${{ matrix.appraisal }}.gemfile

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
   - rubocop-rails
 AllCops:
   NewCops: disable
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
   Exclude:
     - 'gemfiles/*'
 Bundler/OrderedGems:

--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ machine, understanding the codebase, and creating a good pull request.
 
 ## Compatibility
 
-Shoulda Matchers is tested and supported against Ruby 2.6+, Rails
+Shoulda Matchers is tested and supported against Ruby 2.7+, Rails
 5.2+, RSpec 3.x, and Minitest 5.x.
 
 - For Ruby < 2.4 and Rails < 4.1 compatibility, please use [v3.1.3][v3.1.3].

--- a/shoulda-matchers.gemspec
+++ b/shoulda-matchers.gemspec
@@ -36,6 +36,6 @@ Gem::Specification.new do |s|
     'shoulda-matchers.gemspec']
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 2.6.0'
+  s.required_ruby_version = '>= 2.7.0'
   s.add_dependency('activesupport', '>= 5.2.0')
 end


### PR DESCRIPTION
Removes support for Ruby 2.6 due to EOL.

Referent to #1511 