### PR TITLE
fix: confusing error message from validate_inclusion_of matcher

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
@@ -3,6 +3,8 @@ require 'date'
 
 module Shoulda
   module Matchers
+    class ExampleClass; end
+
     module ActiveModel
       # The `validate_inclusion_of` matcher tests usage of the
       # `validates_inclusion_of` validation, asserting that an attribute can
@@ -269,7 +271,7 @@ module Shoulda
       # @private
       class ValidateInclusionOfMatcher < ValidationMatcher
         BLANK_VALUES = ['', ' ', "\n", "\r", "\t", "\f"].freeze
-        ARBITRARY_OUTSIDE_STRING = 'shoulda-matchers test string'.freeze
+        ARBITRARY_OUTSIDE_STRING = Shoulda::Matchers::ExampleClass.name
         ARBITRARY_OUTSIDE_INTEGER = 123456789
         ARBITRARY_OUTSIDE_DECIMAL = BigDecimal('0.123456789')
         ARBITRARY_OUTSIDE_DATE = Date.jd(9999999)


### PR DESCRIPTION
All the credits go to [christhomson](https://github.com/christhomson). I can't thank you enough for pointing me in the right direction.

Close https://github.com/thoughtbot/shoulda-matchers/issues/1433

What do you think, @mcmire?

About the issue: https://github.com/rails/rails/pull/42124. Rails now throws an error when the class doesn't exist. To fix this it was necessary to update 'shoulda-matchers test string' to a class name as you can see in this PR.