### PR TITLE
Change GitHub workflow badge route

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [version-badge]: https://img.shields.io/gem/v/shoulda-matchers.svg
 [rubygems]: https://rubygems.org/gems/shoulda-matchers
-[github-actions-badge]: https://img.shields.io/github/workflow/status/thoughtbot/shoulda-matchers/Test
+[github-actions-badge]: https://img.shields.io/github/actions/workflow/status/thoughtbot/shoulda-matchers/ci.yml?branch=main
 [github-actions]: https://github.com/thoughtbot/shoulda-matchers/actions
 [downloads-total]: https://img.shields.io/gem/dt/shoulda-matchers.svg
 [downloads-badge]: https://img.shields.io/gem/dtv/shoulda-matchers.svg


### PR DESCRIPTION
Ref: badges/shields#8671

### Before

<img width="899" alt="image" src="https://user-images.githubusercontent.com/556268/219977102-d40ca4bd-5693-458d-85e6-4ec4cec5c5c2.png">

### After

<img width="900" alt="image" src="https://user-images.githubusercontent.com/556268/219977114-64473605-48d8-491f-ab6d-b79ecfe9bad5.png">
