### PR TITLE
Improve `have_db_index` to better handle columns with multiple indexes

### DIFF
--- a/lib/shoulda/matchers/active_record/have_db_index_matcher.rb
+++ b/lib/shoulda/matchers/active_record/have_db_index_matcher.rb
@@ -208,18 +208,17 @@ module Shoulda
         end
 
         def sorted_indexes
-          indexes = actual_indexes
-
           if qualifiers.include?(:unique)
-            indexes.sort_by! do |index|
+            # return indexes with unique matching the qualifier first
+            unsorted_indexes.sort_by do |index|
               index.unique == qualifiers[:unique] ? 0 : 1
             end
+          else
+            unsorted_indexes
           end
-
-          indexes
         end
 
-        def actual_indexes
+        def unsorted_indexes
           model.connection.indexes(table_name)
         end
 

--- a/lib/shoulda/matchers/active_record/have_db_index_matcher.rb
+++ b/lib/shoulda/matchers/active_record/have_db_index_matcher.rb
@@ -197,14 +197,26 @@ module Shoulda
         def matched_index
           @_matched_index ||=
             if expected_columns.one?
-              actual_indexes.detect do |index|
+              sorted_indexes.detect do |index|
                 Array.wrap(index.columns) == expected_columns
               end
             else
-              actual_indexes.detect do |index|
+              sorted_indexes.detect do |index|
                 index.columns == expected_columns
               end
             end
+        end
+
+        def sorted_indexes
+          indexes = actual_indexes
+
+          if qualifiers.include?(:unique)
+            indexes.sort_by! do |index|
+              index.unique == qualifiers[:unique] ? 0 : 1
+            end
+          end
+
+          indexes
         end
 
         def actual_indexes

--- a/spec/unit/shoulda/matchers/active_record/have_db_index_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/have_db_index_matcher_spec.rb
@@ -155,6 +155,36 @@ Expected the examples table to have an index on :name, but it does not.
             unique: true,
             qualifier_args: [],
           )
+
+          context 'when there are multiple possible matching columns' do
+            let(:model) do
+              define_model(
+                'Employee',
+                { ssn: :string },
+                parent_class: DevelopmentRecord,
+                customize_table: -> (table) {
+                  table.index(:ssn, name: 'aaa', unique: false)
+                  table.index(:ssn, name: 'bbb', unique: true)
+                  table.index(:ssn, name: 'ccc', unique: false)
+                }
+              )
+            end
+
+            it 'matches in the positive' do
+              expect(model.new).to have_db_index(:ssn).unique
+            end
+
+            it 'does not match in the negative' do
+              assertion = lambda do
+                expect(model.new).not_to have_db_index(:ssn).unique
+              end
+
+              expect(&assertion).to fail_with_message(<<-MESSAGE)
+Expected the employees table not to have a unique index on :ssn, but it
+does.
+              MESSAGE
+            end
+          end
         end
 
         context 'when qualified with unique: true' do

--- a/spec/unit/shoulda/matchers/active_record/have_db_index_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/have_db_index_matcher_spec.rb
@@ -166,7 +166,7 @@ Expected the examples table to have an index on :name, but it does not.
                   table.index(:ssn, name: 'aaa', unique: false)
                   table.index(:ssn, name: 'bbb', unique: true)
                   table.index(:ssn, name: 'ccc', unique: false)
-                }
+                },
               )
             end
 


### PR DESCRIPTION
The `have_db_index` matcher currently matches on the first index that has the matching column names. But when used with the `unique` qualifier that *can* result in the "wrong" index being matched causing the test to fail. 

For example, if a column had multiple indexes.. one unique BTree index, and another non-unique partial or GIN index. Using the `unique` qualifier fail because the non-unique index was identified as the `matched_index`.

It would appear that the order returned by `actual_indexes` will be database specific (say by index name) or possibly pseudo-random??

This change applies a "pre sort" of the indexes prior to finding the matching one if the unique qualifier is specified to give the match the best chance of being the "correct" one.

Note that this does of course complicate things if additional qualifiers were to be added because then sort order precedence would need to be considered.