### PR TITLE
Create against method in allow_value matcher

### DIFF
--- a/lib/shoulda/matchers/active_model/allow_value_matcher.rb
+++ b/lib/shoulda/matchers/active_model/allow_value_matcher.rb
@@ -169,6 +169,36 @@ module Shoulda
       #         on(:create)
       #     end
       #
+      # ##### against
+      #
+      # Use `against` if the validation is on an attribute
+      # other than the attribute being validated:
+      #
+      #     class UserProfile
+      #       include ActiveModel::Model
+      #       attr_accessor :website_url
+      #
+      #       alias_attribute :url, :website_url
+      #
+      #       validates_format_of :url, with: URI.regexp
+      #     end
+      #
+      #     # RSpec
+      #     RSpec.describe UserProfile, type: :model do
+      #       it do
+      #         should allow_value('https://foo.com').
+      #           for(:website_url).
+      #           against(:url)
+      #       end
+      #     end
+      #
+      #     # Minitest (Shoulda)
+      #     class UserProfileTest < ActiveSupport::TestCase
+      #       should allow_value('https://foo.com').
+      #         for(:website_url).
+      #         against(:url)
+      #     end
+      #
       # ##### with_message
       #
       # Use `with_message` if you are using a custom validation message.
@@ -345,6 +375,12 @@ module Shoulda
           if context.present?
             @context = context
           end
+
+          self
+        end
+
+        def against(attribute)
+          @attribute_to_check_message_against = attribute if attribute.present?
 
           self
         end

--- a/spec/unit/shoulda/matchers/active_model/allow_value_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/allow_value_matcher_spec.rb
@@ -366,6 +366,18 @@ involving other attributes:
       end
     end
 
+    context 'when the attribute that receives the validation error is provided' do
+      context 'given a valid value' do
+        it 'accepts' do
+          builder = builder_for_record_with_different_error_attribute
+          expect(builder.record).
+            to allow_value(builder.valid_value).
+            for(builder.attribute_to_validate).
+            against(builder.attribute_that_receives_error)
+        end
+      end
+    end
+
     context 'when the validation error message was provided directly' do
       context 'given a valid value' do
         it 'accepts' do


### PR DESCRIPTION
This PR closes #1460 

Create `against` method in allow_value matcher for when validation is on an attribute other than the attribute being validated.