### PR TITLE
Add timestamptz to the dummy value case statement

### DIFF
--- a/lib/shoulda/matchers/util.rb
+++ b/lib/shoulda/matchers/util.rb
@@ -94,7 +94,7 @@ module Shoulda
             0
           when :date
             Date.new(2100, 1, 1)
-          when :datetime, :timestamp
+          when :datetime, :timestamp, :timestamptz
             DateTime.new(2100, 1, 1)
           when :time
             Time.new(2000, 1, 1)

--- a/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
@@ -829,6 +829,16 @@ within the scope of :scope1, but this could not be proved.
         column_type: :datetime
     end
 
+    context 'when one of the scoped attributes is a timestamp column (using DateTime)' do
+      include_context 'it supports scoped attributes of a certain type',
+        column_type: :timestamp
+    end
+
+    context 'when one of the scoped attributes is a timestamp with time zone column (using DateTime)' do
+      include_context 'it supports scoped attributes of a certain type',
+        column_type: :timestamptz
+    end
+
     context 'when one of the scoped attributes is a time column (using Time)' do
       include_context 'it supports scoped attributes of a certain type',
         column_type: :time


### PR DESCRIPTION
Ran into an exception when upgrading to Rails 7.0.4.2 and a column of type `timestamptz`.

```
     Failure/Error:
       is_expected.to validate_uniqueness_of(:amount).
         scoped_to(:column1, :column2, :column3, :date_time_column).
         with_message('must be unique')
     
     NoMethodError:
       undefined method `getutc' for nil:NilClass
```

After tracing, 'dummy value' was observed as being sent into this function, when then resulted in `time` being nil:
https://github.com/rails/rails/blob/v7.0.4.2/activerecord/lib/active_record/connection_adapters/postgresql/oid/timestamp_with_time_zone.rb#L122

