### PR TITLE
Fix: false positive of validate_presence_of

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
@@ -245,7 +245,8 @@ validation for you? Instead of using `validate_presence_of`, try
         end
 
         def allows_original_or_typecast_value?(value)
-          allows_value_of(value, @expected_message)
+          @expected_message == :blank ? allows_value_of(value, nil) : allows_value_of(value, @expected_message)
+          # allows_value_of(value, @expected_message)
         end
 
         def disallows_and_double_checks_value_of!(value)


### PR DESCRIPTION
Referent to #1302 

When your model has `validate_presence_of` with a custom message:
```rb
class Article < ApplicationRecord
  validates_presence_of :owner, message: 'this is wrong, it needs the owner'
end
```
it shouldn't pass, but it does

```rb
    it { should_not validate_presence_of(:owner) }
```

However, this spec `spec/unit/shoulda/matchers/active_model/validate_presence_of_matcher_spec.rb` is failing in lines 554, 605, and 694. 

I was checking with `pry-rails` and I saw that the matcher is passing through:
https://github.com/thoughtbot/shoulda-matchers/blob/195153cf42239935062f10f29a148d9d40032ca2/lib/shoulda/matchers/active_model/allow_value_matcher.rb#L405

But it should pass through:
https://github.com/thoughtbot/shoulda-matchers/blob/195153cf42239935062f10f29a148d9d40032ca2/lib/shoulda/matchers/active_model/allow_value_matcher.rb#L432

Unfortunately, I have not found out why. @VSPPedro @mcmire do you have any idea what might be going on?