### PR TITLE
FIx: Indifference to I18n errors.format translation

### DIFF
--- a/lib/shoulda/matchers/active_model/allow_value_matcher.rb
+++ b/lib/shoulda/matchers/active_model/allow_value_matcher.rb
@@ -612,7 +612,7 @@ pass, or do something else entirely.
 
         def default_expected_message
           if expects_strict?
-            "#{human_attribute_name} #{default_attribute_message}"
+            I18n.t(:"errors.format", attribute: human_attribute_name, message: default_attribute_message)
           else
             default_attribute_message
           end


### PR DESCRIPTION
Fixes #1492 

I didn't find anything related to internationalization tests :thinking:, also both `spec/unit/shoulda/matchers/active_model/allow_value_matcher_spec.rb` and `spec/unit/shoulda/matchers/active_model/validate_presence_of_matcher_spec.rb` passed without errors.

@VSPPedro @mcmire do you have any suggestions on how to test this case, or is this enough?