### PR TITLE
Remove Ruby 2.7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,6 @@ jobs:
           - 3.2.1
           - 3.1.3
           - 3.0.5
-          - 2.7.7
         appraisal:
           - rails_7_0
           - rails_6_1
@@ -46,7 +45,6 @@ jobs:
           - { ruby: 3.1.3, appraisal: rails_5_2 }
           - { ruby: 3.0.5, appraisal: rails_5_2 }
           - { ruby: 3.0.5, appraisal: rails_7_0 }
-          - { ruby: 2.7.7, appraisal: rails_7_0 }
     env:
       DATABASE_ADAPTER: ${{ matrix.adapter }}
       BUNDLE_GEMFILE: gemfiles/${{ matrix.appraisal }}.gemfile

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
   - rubocop-rails
 AllCops:
   NewCops: disable
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   Exclude:
     - 'gemfiles/*'
 Bundler/OrderedGems:

--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ machine, understanding the codebase, and creating a good pull request.
 
 ## Compatibility
 
-Shoulda Matchers is tested and supported against Ruby 2.7+, Rails
+Shoulda Matchers is tested and supported against Ruby 3.0+, Rails
 5.2+, RSpec 3.x, and Minitest 5.x.
 
 - For Ruby < 2.4 and Rails < 4.1 compatibility, please use [v3.1.3][v3.1.3].

--- a/lib/shoulda/matchers/util/word_wrap.rb
+++ b/lib/shoulda/matchers/util/word_wrap.rb
@@ -41,7 +41,7 @@ module Shoulda
 
     # @private
     class Text < ::String
-      LIST_ITEM_REGEXP = /\A((?:[a-z0-9]+(?:\)|\.)|\*) )/.freeze
+      LIST_ITEM_REGEXP = /\A((?:[a-z0-9]+(?:\)|\.)|\*) )/
 
       def indented?
         self =~ /\A +/

--- a/shoulda-matchers.gemspec
+++ b/shoulda-matchers.gemspec
@@ -36,6 +36,6 @@ Gem::Specification.new do |s|
     'shoulda-matchers.gemspec']
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 2.7.0'
+  s.required_ruby_version = '>= 3.0.5'
   s.add_dependency('activesupport', '>= 5.2.0')
 end


### PR DESCRIPTION
Removes support for Ruby 2.6 due to [EOL](https://www.ruby-lang.org/en/downloads/branches/).

I also checked that Rails 6.0.x will hit EOL on June 1st, 2023. If you guys want to, I can remove it in this PR, or create a new one :)