### PR TITLE
Fix broken thoughtbot logo on README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,7 +503,7 @@ redistributed under the terms specified in the [LICENSE](LICENSE) file.
 
 ![thoughtbot][thoughtbot-logo]
 
-[thoughtbot-logo]: https://presskit.thoughtbot.com/images/thoughtbot-logo-for-readmes.svg
+[thoughtbot-logo]: https://thoughtbot.com/brand_assets/93:44.svg
 
 The names and logos for thoughtbot are trademarks of thoughtbot, inc.
 


### PR DESCRIPTION
The previous thoughtbot logo link is broken. Replace it with another link used other thoughtbot repositories.

Before:
![Screenshot 2023-04-05 at 10 21 06](https://user-images.githubusercontent.com/14362964/230093145-5f189377-2cfc-4671-b515-d33872dd11e0.png)

After:
