### PR TITLE
Fixed multiline strings indentation

### DIFF
--- a/custom_plan.rb
+++ b/custom_plan.rb
@@ -5,18 +5,18 @@ require_relative 'spec/support/tests/current_bundle'
 class CouldNotBootZeusError < StandardError
   def self.create(underlying_error:)
     new(<<-MESSAGE)
-Couldn't boot Zeus.
+      Couldn't boot Zeus.
 
-Bundler tried to load a gem that has already been loaded (but the
-versions are different).
+      Bundler tried to load a gem that has already been loaded (but the
+      versions are different).
 
-Note that Appraisal requires Rake, and so you'll want to make sure that
-the Gemfile is pointing to the same version of Rake that you have
-installed locally.
+      Note that Appraisal requires Rake, and so you'll want to make sure that
+      the Gemfile is pointing to the same version of Rake that you have
+      installed locally.
 
-The original message is as follows:
+      The original message is as follows:
 
-#{underlying_error.message}
+      #{underlying_error.message}
     MESSAGE
   end
 end

--- a/lib/shoulda/matchers/action_controller/set_flash_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/set_flash_matcher.rb
@@ -207,18 +207,18 @@ module Shoulda
         class QualifierOrderError < StandardError
           def message
             <<-MESSAGE.strip
-Using `set_flash` with the `now` qualifier and specifying `now` after other
-qualifiers is no longer allowed.
+              Using `set_flash` with the `now` qualifier and specifying `now` after other
+              qualifiers is no longer allowed.
 
-You'll want to use `now` immediately after `set_flash`. For instance:
+              You'll want to use `now` immediately after `set_flash`. For instance:
 
-    # Valid
-    should set_flash.now[:foo]
-    should set_flash.now[:foo].to('bar')
+                  # Valid
+                  should set_flash.now[:foo]
+                  should set_flash.now[:foo].to('bar')
 
-    # Invalid
-    should set_flash[:foo].now
-    should set_flash[:foo].to('bar').now
+                  # Invalid
+                  should set_flash[:foo].now
+                  should set_flash[:foo].to('bar').now
             MESSAGE
           end
         end

--- a/lib/shoulda/matchers/active_model/allow_value_matcher.rb
+++ b/lib/shoulda/matchers/active_model/allow_value_matcher.rb
@@ -573,11 +573,11 @@ module Shoulda
 
         def default_attribute_changed_value_message
           <<-MESSAGE.strip
-As indicated in the message above, :#{result.attribute_setter.attribute_name}
-seems to be changing certain values as they are set, and this could have
-something to do with why this test is failing. If you've overridden the writer
-method for this attribute, then you may need to change it to make this test
-pass, or do something else entirely.
+            As indicated in the message above, :#{result.attribute_setter.attribute_name}
+            seems to be changing certain values as they are set, and this could have
+            something to do with why this test is failing. If you've overridden the writer
+            method for this attribute, then you may need to change it to make this test
+            pass, or do something else entirely.
           MESSAGE
         end
 

--- a/lib/shoulda/matchers/active_model/allow_value_matcher/attribute_changed_value_error.rb
+++ b/lib/shoulda/matchers/active_model/allow_value_matcher/attribute_changed_value_error.rb
@@ -9,29 +9,29 @@ module Shoulda
 
           def message
             Shoulda::Matchers.word_wrap <<-MESSAGE
-The #{matcher_name} matcher attempted to set :#{attribute_name} on
-#{model.name} to #{value_written.inspect}, but when the attribute was
-read back, it had stored #{value_read.inspect} instead.
+              The #{matcher_name} matcher attempted to set :#{attribute_name} on
+              #{model.name} to #{value_written.inspect}, but when the attribute was
+              read back, it had stored #{value_read.inspect} instead.
 
-This creates a problem because it means that the model is behaving in a
-way that is interfering with the test -- there's a mismatch between the
-test that you wrote and test that we actually ran.
+              This creates a problem because it means that the model is behaving in a
+              way that is interfering with the test -- there's a mismatch between the
+              test that you wrote and test that we actually ran.
 
-There are a couple of reasons why this could be happening:
+              There are a couple of reasons why this could be happening:
 
-* ActiveRecord is typecasting the incoming value.
-* The writer method for :#{attribute_name} has been overridden so that
-  incoming values are changed in some way.
+              * ActiveRecord is typecasting the incoming value.
+              * The writer method for :#{attribute_name} has been overridden so that
+                incoming values are changed in some way.
 
-If this exception makes sense to you and you wish to bypass it, try
-adding the `ignoring_interference_by_writer` qualifier onto the end of
-your matcher. If the test still does not pass after that, then you may
-need to do something different.
+              If this exception makes sense to you and you wish to bypass it, try
+              adding the `ignoring_interference_by_writer` qualifier onto the end of
+              your matcher. If the test still does not pass after that, then you may
+              need to do something different.
 
-If you need help, feel free to ask a question on the shoulda-matchers
-issues list:
+              If you need help, feel free to ask a question on the shoulda-matchers
+              issues list:
 
-https://github.com/thoughtbot/shoulda-matchers/issues
+              https://github.com/thoughtbot/shoulda-matchers/issues
             MESSAGE
           end
 

--- a/lib/shoulda/matchers/active_model/allow_value_matcher/attribute_does_not_exist_error.rb
+++ b/lib/shoulda/matchers/active_model/allow_value_matcher/attribute_does_not_exist_error.rb
@@ -8,8 +8,8 @@ module Shoulda
 
           def message
             Shoulda::Matchers.word_wrap <<-MESSAGE
-The matcher attempted to set :#{attribute_name} on the #{model.name} to
-#{value.inspect}, but that attribute does not exist.
+              The matcher attempted to set :#{attribute_name} on the #{model.name} to
+              #{value.inspect}, but that attribute does not exist.
             MESSAGE
           end
 

--- a/lib/shoulda/matchers/active_model/errors.rb
+++ b/lib/shoulda/matchers/active_model/errors.rb
@@ -14,9 +14,9 @@ module Shoulda
 
         def message
           <<-EOT.strip
-You have specified that your model's #{attribute} should ensure inclusion of nil.
-However, #{attribute} is a boolean column which does not allow null values.
-Hence, this test will fail and there is no way to make it pass.
+            You have specified that your model's #{attribute} should ensure inclusion of nil.
+            However, #{attribute} is a boolean column which does not allow null values.
+            Hence, this test will fail and there is no way to make it pass.
           EOT
         end
       end
@@ -31,9 +31,9 @@ Hence, this test will fail and there is no way to make it pass.
 
         def message
           <<-EOT.strip
-The validation failed because your #{model_name} model declares `has_secure_password`, and
-`validate_presence_of` was called on a #{record_name} which has `password` already set to a value.
-Please use a #{record_name} with an empty `password` instead.
+            The validation failed because your #{model_name} model declares `has_secure_password`, and
+            `validate_presence_of` was called on a #{record_name} which has `password` already set to a value.
+            Please use a #{record_name} with an empty `password` instead.
           EOT
         end
 

--- a/lib/shoulda/matchers/active_model/qualifiers/ignore_interference_by_writer.rb
+++ b/lib/shoulda/matchers/active_model/qualifiers/ignore_interference_by_writer.rb
@@ -75,15 +75,15 @@ module Shoulda
 
           def invalid_argument_error(invalid_argument)
             ArgumentError.new(<<-ERROR)
-Unknown argument: #{invalid_argument.inspect}.
+              Unknown argument: #{invalid_argument.inspect}.
 
-ignoring_interference_by_writer takes one of three arguments:
+              ignoring_interference_by_writer takes one of three arguments:
 
-* A symbol, either :never or :always.
-* A boolean, either true (which means always) or false (which means
-  never).
-* A hash with a single key, :when, and a single value, which is either
-  the name of a method or a Proc.
+              * A symbol, either :never or :always.
+              * A boolean, either true (which means always) or false (which means
+                never).
+              * A hash with a single key, :when, and a single value, which is either
+                the name of a method or a Proc.
             ERROR
           end
 

--- a/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb
@@ -212,13 +212,13 @@ module Shoulda
           if should_add_footnote_about_belongs_to?
             message << "\n\n"
             message << Shoulda::Matchers.word_wrap(<<-MESSAGE.strip, indent: 2)
-You're getting this error because #{reason_for_existing_presence_validation}.
-*This* presence validation doesn't use "can't be blank", the usual validation
-message, but "must exist" instead.
+              You're getting this error because #{reason_for_existing_presence_validation}.
+              *This* presence validation doesn't use "can't be blank", the usual validation
+              message, but "must exist" instead.
 
-With that said, did you know that the `belong_to` matcher can test this
-validation for you? Instead of using `validate_presence_of`, try
-#{suggestions_for_belongs_to}
+              With that said, did you know that the `belong_to` matcher can test this
+              validation for you? Instead of using `validate_presence_of`, try
+              #{suggestions_for_belongs_to}
             MESSAGE
           end
 

--- a/lib/shoulda/matchers/active_record/have_attached_matcher.rb
+++ b/lib/shoulda/matchers/active_record/have_attached_matcher.rb
@@ -66,14 +66,14 @@ module Shoulda
 
         def failure_message
           <<-MESSAGE
-Expected #{expectation}, but this could not be proved.
-  #{@failure}
+            Expected #{expectation}, but this could not be proved.
+            #{@failure}
           MESSAGE
         end
 
         def failure_message_when_negated
           <<-MESSAGE
-Did not expect #{expectation}, but it does.
+            Did not expect #{expectation}, but it does.
           MESSAGE
         end
 

--- a/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
+++ b/lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb
@@ -979,16 +979,16 @@ module Shoulda
 
         def attribute_changed_value_message
           <<-MESSAGE.strip
-As indicated in the message above,
-:#{last_attribute_setter_used_on_new_record.attribute_name} seems to be
-changing certain values as they are set, and this could have something
-to do with why this test is failing. If you or something else has
-overridden the writer method for this attribute to normalize values by
-changing their case in any way (for instance, ensuring that the
-attribute is always downcased), then try adding
-`ignoring_case_sensitivity` onto the end of the uniqueness matcher.
-Otherwise, you may need to write the test yourself, or do something
-different altogether.
+            As indicated in the message above,
+            :#{last_attribute_setter_used_on_new_record.attribute_name} seems to be
+            changing certain values as they are set, and this could have something
+            to do with why this test is failing. If you or something else has
+            overridden the writer method for this attribute to normalize values by
+            changing their case in any way (for instance, ensuring that the
+            attribute is always downcased), then try adding
+            `ignoring_case_sensitivity` onto the end of the uniqueness matcher.
+            Otherwise, you may need to write the test yourself, or do something
+            different altogether.
           MESSAGE
         end
 
@@ -1129,16 +1129,16 @@ https://matchers.shoulda.io/docs/v#{Shoulda::Matchers::VERSION}/file.NonCaseSwap
 
           def message
             <<-MESSAGE.strip
-validate_uniqueness_of works by matching a new record against an
-existing record. If there is no existing record, it will create one
-using the record you provide.
+              validate_uniqueness_of works by matching a new record against an
+              existing record. If there is no existing record, it will create one
+              using the record you provide.
 
-While doing this, the following error was raised:
+              While doing this, the following error was raised:
 
-#{Shoulda::Matchers::Util.indent(underlying_exception.message, 2)}
+              #{Shoulda::Matchers::Util.indent(underlying_exception.message, 2)}
 
-The best way to fix this is to provide the matcher with a record where
-any required attributes are filled in with valid values beforehand.
+              The best way to fix this is to provide the matcher with a record where
+              any required attributes are filled in with valid values beforehand.
             MESSAGE
           end
         end

--- a/lib/shoulda/matchers/integrations/test_frameworks/missing_test_framework.rb
+++ b/lib/shoulda/matchers/integrations/test_frameworks/missing_test_framework.rb
@@ -8,18 +8,18 @@ module Shoulda
 
           def validate!
             raise TestFrameworkNotConfigured, <<-EOT
-You need to set a test framework. Please add the following to your
-test helper:
+              You need to set a test framework. Please add the following to your
+              test helper:
 
-Shoulda::Matchers.configure do |config|
-  config.integrate do |with|
-    # Choose one:
-    with.test_framework :rspec
-    with.test_framework :minitest    # or, :minitest_5
-    with.test_framework :minitest_4
-    with.test_framework :test_unit
-  end
-end
+              Shoulda::Matchers.configure do |config|
+                config.integrate do |with|
+                  # Choose one:
+                  with.test_framework :rspec
+                  with.test_framework :minitest    # or, :minitest_5
+                  with.test_framework :minitest_4
+                  with.test_framework :test_unit
+                end
+              end
             EOT
           end
 

--- a/spec/support/tests/command_runner.rb
+++ b/spec/support/tests/command_runner.rb
@@ -109,9 +109,9 @@ module Tests
 
     def fail!
       raise <<-MESSAGE
-Command #{formatted_command.inspect} exited with status #{exit_status}.
-Output:
-#{divider('START') + output + divider('END')}
+        Command #{formatted_command.inspect} exited with status #{exit_status}.
+        Output:
+        #{divider('START') + output + divider('END')}
       MESSAGE
     end
 

--- a/spec/support/unit/helpers/validation_matcher_scenario_helpers.rb
+++ b/spec/support/unit/helpers/validation_matcher_scenario_helpers.rb
@@ -34,9 +34,9 @@ module UnitTests
     def matcher_name
       validation_matcher_scenario_args.fetch(:matcher_name) do
         raise KeyNotFoundError.new(<<-MESSAGE)
-Please implement #validation_matcher_scenario_args in your example
-group, in such a way that it returns a hash that contains a
-:matcher_name key.
+          Please implement #validation_matcher_scenario_args in your example
+          group, in such a way that it returns a hash that contains a
+          :matcher_name key.
         MESSAGE
       end
     end

--- a/spec/support/unit/matchers/match_against.rb
+++ b/spec/support/unit/matchers/match_against.rb
@@ -57,11 +57,11 @@ module UnitTests
           matcher_fails_in_negative?
         else
           @failure_message = <<-MESSAGE
-Expected the matcher to match in the positive, but it failed with this message:
+            Expected the matcher to match in the positive, but it failed with this message:
 
-#{DIVIDER}
-#{positive_matcher.failure_message}
-#{DIVIDER}
+            #{DIVIDER}
+            #{positive_matcher.failure_message}
+            #{DIVIDER}
           MESSAGE
           false
         end
@@ -84,11 +84,11 @@ Expected the matcher to match in the positive, but it failed with this message:
             !negative_matcher.does_not_match?(object)
           )
             @failure_message_when_negated = <<-MESSAGE
-Expected the matcher to match in the negative, but it failed with this message:
+              Expected the matcher to match in the negative, but it failed with this message:
 
-#{DIVIDER}
-#{negative_matcher.failure_message_when_negated}
-#{DIVIDER}
+              #{DIVIDER}
+              #{negative_matcher.failure_message_when_negated}
+              #{DIVIDER}
             MESSAGE
             false
           else
@@ -127,22 +127,22 @@ Expected the matcher to match in the negative, but it failed with this message:
               negative_matcher.failure_message_when_negated.strip,
             )
             @failure_message = <<-MESSAGE
-Expected the negative version of the matcher not to match and for the failure
-message to be:
+              Expected the negative version of the matcher not to match and for the failure
+              message to be:
 
-#{DIVIDER}
-#{expected_message.chomp}
-#{DIVIDER}
+              #{DIVIDER}
+              #{expected_message.chomp}
+              #{DIVIDER}
 
-However, it was:
+              However, it was:
 
-#{DIVIDER}
-#{negative_matcher.failure_message_when_negated}
-#{DIVIDER}
+              #{DIVIDER}
+              #{negative_matcher.failure_message_when_negated}
+              #{DIVIDER}
 
-Diff:
+              Diff:
 
-#{Shoulda::Matchers::Util.indent(diff_result, 2)}
+              #{Shoulda::Matchers::Util.indent(diff_result, 2)}
             MESSAGE
             false
           end
@@ -177,22 +177,22 @@ Diff:
               positive_matcher.failure_message.strip,
             )
             @failure_message_when_negated = <<-MESSAGE
-Expected the positive version of the matcher not to match and for the failure
-message to be:
+              Expected the positive version of the matcher not to match and for the failure
+              message to be:
 
-#{DIVIDER}
-#{expected_message.chomp}
-#{DIVIDER}
+              #{DIVIDER}
+              #{expected_message.chomp}
+              #{DIVIDER}
 
-However, it was:
+              However, it was:
 
-#{DIVIDER}
-#{positive_matcher.failure_message}
-#{DIVIDER}
+              #{DIVIDER}
+              #{positive_matcher.failure_message}
+              #{DIVIDER}
 
-Diff:
+              Diff:
 
-#{Shoulda::Matchers::Util.indent(diff_result, 2)}
+              #{Shoulda::Matchers::Util.indent(diff_result, 2)}
             MESSAGE
             false
           end

--- a/spec/support/unit/rails_application.rb
+++ b/spec/support/unit/rails_application.rb
@@ -102,9 +102,9 @@ module UnitTests
       # https://stackoverflow.com/questions/20361428/rails-i18n-validation-deprecation-warning
       fs.transform('config/application.rb') do |lines|
         lines.insert(-3, <<-EOT)
-if I18n.respond_to?(:enforce_available_locales=)
-  I18n.enforce_available_locales = false
-end
+          if I18n.respond_to?(:enforce_available_locales=)
+            I18n.enforce_available_locales = false
+          end
         EOT
       end
     end
@@ -123,10 +123,10 @@ end
       # connection will be routed to this database.
       path = 'app/models/production_record.rb'
       fs.write(path, <<-TEXT)
-class ProductionRecord < ActiveRecord::Base
-  self.abstract_class = true
-  establish_connection :production
-end
+        class ProductionRecord < ActiveRecord::Base
+          self.abstract_class = true
+          establish_connection :production
+        end
       TEXT
     end
 
@@ -139,9 +139,9 @@ end
       #   expect(with_index_on(:age2, parent_class: ProductionRecord)).to have_db_index(:age2)
       path = 'app/models/development_record.rb'
       fs.write(path, <<-TEXT)
-class DevelopmentRecord < ActiveRecord::Base
-  self.abstract_class = true
-end
+        class DevelopmentRecord < ActiveRecord::Base
+          self.abstract_class = true
+        end
       TEXT
     end
 
@@ -160,9 +160,9 @@ end
     def add_initializer_for_time_zone_aware_types
       path = 'config/initializers/configure_time_zone_aware_types.rb'
       fs.write(path, <<-TEXT)
-Rails.application.configure do
-  config.active_record.time_zone_aware_types = [:datetime, :time]
-end
+        Rails.application.configure do
+          config.active_record.time_zone_aware_types = [:datetime, :time]
+        end
       TEXT
     end
 

--- a/spec/support/unit/validation_matcher_scenario.rb
+++ b/spec/support/unit/validation_matcher_scenario.rb
@@ -10,8 +10,8 @@ module UnitTests
 
       @specified_model_creator = @arguments.delete(:model_creator) do
         raise KeyError.new(<<-MESSAGE)
-:model_creator is missing. You can either provide it as an option or as
-a method.
+          :model_creator is missing. You can either provide it as an option or as
+          a method.
         MESSAGE
       end
 

--- a/spec/unit/shoulda/matchers/active_model/allow_value_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/allow_value_matcher_spec.rb
@@ -80,8 +80,8 @@ describe Shoulda::Matchers::ActiveModel::AllowValueMatcher, type: :model do
           end
 
           message = <<-MESSAGE
-After setting :attr to ‹"abcde"›, the matcher expected the Example to be
-invalid, but it was valid instead.
+            After setting :attr to ‹"abcde"›, the matcher expected the Example to be
+            invalid, but it was valid instead.
           MESSAGE
 
           expect(&assertion).to fail_with_message(message)
@@ -105,8 +105,8 @@ invalid, but it was valid instead.
           end
 
           message = <<-MESSAGE
-After setting :attr to ‹"abcde"›, the matcher expected the Example to be
-invalid, but it was valid instead.
+            After setting :attr to ‹"abcde"›, the matcher expected the Example to be
+            invalid, but it was valid instead.
           MESSAGE
 
           expect(&assertion).to fail_with_message(message)
@@ -123,10 +123,10 @@ invalid, but it was valid instead.
           end
 
           message = <<-MESSAGE
-After setting :attr to ‹"xyz"›, the matcher expected the Example to be
-valid, but it was invalid instead, producing these validation errors:
+            After setting :attr to ‹"xyz"›, the matcher expected the Example to be
+            valid, but it was invalid instead, producing these validation errors:
 
-* attr: ["is invalid"]
+            * attr: ["is invalid"]
           MESSAGE
 
           expect(&assertion).to fail_with_message(message)
@@ -152,10 +152,10 @@ valid, but it was invalid instead, producing these validation errors:
           end
 
           message = <<-MESSAGE
-After setting :attr to ‹"xyz"›, the matcher expected the Example to be
-valid, but it was invalid instead, producing these validation errors:
+            After setting :attr to ‹"xyz"›, the matcher expected the Example to be
+            valid, but it was invalid instead, producing these validation errors:
 
-* attr: ["is invalid"]
+            * attr: ["is invalid"]
           MESSAGE
 
           expect(&assertion).to fail_with_message(message)
@@ -183,10 +183,10 @@ valid, but it was invalid instead, producing these validation errors:
           end
 
           message = <<-MESSAGE
-After setting :attr to ‹"xyz"›, the matcher expected the Example to be
-valid, but it was invalid instead, producing these validation errors:
+            After setting :attr to ‹"xyz"›, the matcher expected the Example to be
+            valid, but it was invalid instead, producing these validation errors:
 
-* attr: ["is invalid"]
+            * attr: ["is invalid"]
           MESSAGE
 
           expect(&assertion).to fail_with_message(message)
@@ -203,8 +203,8 @@ valid, but it was invalid instead, producing these validation errors:
           end
 
           message = <<-MESSAGE
-After setting :attr to ‹"abc"›, the matcher expected the Example to be
-invalid, but it was valid instead.
+            After setting :attr to ‹"abc"›, the matcher expected the Example to be
+            invalid, but it was valid instead.
           MESSAGE
 
           expect(&assertion).to fail_with_message(message)
@@ -223,10 +223,10 @@ invalid, but it was valid instead.
           end
 
           message = <<-MESSAGE
-After setting :attr to ‹"xyz"›, the matcher expected the Example to be
-valid, but it was invalid instead, producing these validation errors:
+            After setting :attr to ‹"xyz"›, the matcher expected the Example to be
+            valid, but it was invalid instead, producing these validation errors:
 
-* attr: ["is invalid"]
+            * attr: ["is invalid"]
           MESSAGE
 
           expect(&assertion).to fail_with_message(message)
@@ -243,8 +243,8 @@ valid, but it was invalid instead, producing these validation errors:
           end
 
           message = <<-MESSAGE
-After setting :attr to ‹"abc"›, the matcher expected the Example to be
-invalid, but it was valid instead.
+            After setting :attr to ‹"abc"›, the matcher expected the Example to be
+            invalid, but it was valid instead.
           MESSAGE
 
           expect(&assertion).to fail_with_message(message)
@@ -261,10 +261,10 @@ invalid, but it was valid instead.
 
     it 'rejects a bad value with an appropriate failure message' do
       message = <<-MESSAGE
-After setting :attr to ‹"xyz"›, the matcher expected the Example to be
-valid, but it was invalid instead, producing these validation errors:
+        After setting :attr to ‹"xyz"›, the matcher expected the Example to be
+        valid, but it was invalid instead, producing these validation errors:
 
-* attr: ["bad value"]
+        * attr: ["bad value"]
       MESSAGE
 
       assertion = lambda do
@@ -278,12 +278,12 @@ valid, but it was invalid instead, producing these validation errors:
     context 'when the custom messages do not match' do
       it 'rejects with an appropriate failure message' do
         message = <<-MESSAGE
-After setting :attr to ‹"xyz"›, the matcher expected the Example to be
-invalid and to produce a validation error matching ‹/different/› on
-:attr. The record was indeed invalid, but it produced these validation
-errors instead:
+          After setting :attr to ‹"xyz"›, the matcher expected the Example to be
+          invalid and to produce a validation error matching ‹/different/› on
+          :attr. The record was indeed invalid, but it produced these validation
+          errors instead:
 
-* attr: ["bad value"]
+          * attr: ["bad value"]
         MESSAGE
 
         assertion = lambda do
@@ -337,12 +337,12 @@ errors instead:
           end
 
           message = <<-MESSAGE
-After setting :attr to ‹"xyz"›, the matcher expected the Example to be
-invalid and to produce the validation error "must be greater than 2" on
-:attr. The record was indeed invalid, but it produced these validation
-errors instead:
+            After setting :attr to ‹"xyz"›, the matcher expected the Example to be
+            invalid and to produce the validation error "must be greater than 2" on
+            :attr. The record was indeed invalid, but it produced these validation
+            errors instead:
 
-* attr: ["some other error"]
+            * attr: ["some other error"]
           MESSAGE
 
           expect(&assertion).to fail_with_message(message)
@@ -400,12 +400,12 @@ errors instead:
             end
 
             message = <<-MESSAGE
-After setting :#{builder.attribute_to_validate} to ‹"#{invalid_value}"›, the
-matcher expected the #{builder.model.name} to be invalid and to produce the validation
-error "some error" on :#{builder.attribute_that_receives_error}. The record was
-indeed invalid, but it produced these validation errors instead:
+              After setting :#{builder.attribute_to_validate} to ‹"#{invalid_value}"›, the
+              matcher expected the #{builder.model.name} to be invalid and to produce the validation
+              error "some error" on :#{builder.attribute_that_receives_error}. The record was
+              indeed invalid, but it produced these validation errors instead:
 
-* #{builder.attribute_that_receives_error}: ["a different error"]
+              * #{builder.attribute_that_receives_error}: ["a different error"]
             MESSAGE
 
             expect(&assertion).to fail_with_message(message)
@@ -495,8 +495,8 @@ indeed invalid, but it produced these validation errors instead:
 
     it 'does not match given good values along with bad values' do
       message = <<-MESSAGE.strip_heredoc
-After setting :attr to ‹"12345"›, the matcher expected the Example to be
-invalid, but it was valid instead.
+        After setting :attr to ‹"12345"›, the matcher expected the Example to be
+        invalid, but it was valid instead.
       MESSAGE
 
       assertion = lambda do
@@ -508,8 +508,8 @@ invalid, but it was valid instead.
 
     it 'does not match given bad values along with good values' do
       message = <<-MESSAGE.strip_heredoc
-After setting :attr to ‹"12345"›, the matcher expected the Example to be
-invalid, but it was valid instead.
+        After setting :attr to ‹"12345"›, the matcher expected the Example to be
+        invalid, but it was valid instead.
       MESSAGE
 
       assertion = lambda do
@@ -542,9 +542,9 @@ invalid, but it was valid instead.
       context 'when qualified with strict' do
         it 'rejects a bad value, providing the correct failure message' do
           message = <<-MESSAGE.strip_heredoc
-After setting :attr to ‹"xyz"›, the matcher expected the Example to be
-valid, but it was invalid instead, raising a validation exception with
-the message "Attr is invalid".
+            After setting :attr to ‹"xyz"›, the matcher expected the Example to be
+            valid, but it was invalid instead, raising a validation exception with
+            the message "Attr is invalid".
           MESSAGE
 
           assertion = lambda do
@@ -558,10 +558,10 @@ the message "Attr is invalid".
         context 'qualified with a custom message' do
           it 'rejects a bad value when the failure messages do not match' do
             message = <<-MESSAGE.strip_heredoc
-After setting :attr to ‹"xyz"›, the matcher expected the Example to be
-invalid and to raise a validation exception with message matching
-‹/abc/›. The record was indeed invalid, but the exception message was
-"Attr is invalid" instead.
+              After setting :attr to ‹"xyz"›, the matcher expected the Example to be
+              invalid and to raise a validation exception with message matching
+              ‹/abc/›. The record was indeed invalid, but the exception message was
+              "Attr is invalid" instead.
             MESSAGE
 
             assertion = lambda do
@@ -605,17 +605,17 @@ invalid and to raise a validation exception with message matching
           end
 
           message = <<-MESSAGE.strip
-After setting :name to ‹"anything"› -- which was read back as ‹nil› --
-the matcher expected the Example to be valid, but it was invalid
-instead, producing these validation errors:
+            After setting :name to ‹"anything"› -- which was read back as ‹nil› --
+            the matcher expected the Example to be valid, but it was invalid
+            instead, producing these validation errors:
 
-* name: ["can't be blank"]
+            * name: ["can't be blank"]
 
-As indicated in the message above, :name seems to be changing certain
-values as they are set, and this could have something to do with why
-this test is failing. If you've overridden the writer method for this
-attribute, then you may need to change it to make this test pass, or do
-something else entirely.
+            As indicated in the message above, :name seems to be changing certain
+            values as they are set, and this could have something to do with why
+            this test is failing. If you've overridden the writer method for this
+            attribute, then you may need to change it to make this test pass, or do
+            something else entirely.
           MESSAGE
 
           expect(&assertion).to fail_with_message(message)
@@ -659,17 +659,17 @@ something else entirely.
           end
 
           message = <<-MESSAGE.strip
-After setting :name to ‹nil› -- which was read back as ‹"some name"› --
-the matcher expected the Example to be valid, but it was invalid
-instead, producing these validation errors:
+            After setting :name to ‹nil› -- which was read back as ‹"some name"› --
+            the matcher expected the Example to be valid, but it was invalid
+            instead, producing these validation errors:
 
-* name: ["must be blank"]
+            * name: ["must be blank"]
 
-As indicated in the message above, :name seems to be changing certain
-values as they are set, and this could have something to do with why
-this test is failing. If you've overridden the writer method for this
-attribute, then you may need to change it to make this test pass, or do
-something else entirely.
+            As indicated in the message above, :name seems to be changing certain
+            values as they are set, and this could have something to do with why
+            this test is failing. If you've overridden the writer method for this
+            attribute, then you may need to change it to make this test pass, or do
+            something else entirely.
           MESSAGE
 
           expect(&assertion).to fail_with_message(message)
@@ -709,17 +709,17 @@ something else entirely.
           end
 
           message = <<-MESSAGE.strip
-After setting :name to ‹"another name"› -- which was read back as
-‹"constant name"› -- the matcher expected the Example to be valid, but
-it was invalid instead, producing these validation errors:
+            After setting :name to ‹"another name"› -- which was read back as
+            ‹"constant name"› -- the matcher expected the Example to be valid, but
+            it was invalid instead, producing these validation errors:
 
-* name: ["is invalid"]
+            * name: ["is invalid"]
 
-As indicated in the message above, :name seems to be changing certain
-values as they are set, and this could have something to do with why
-this test is failing. If you've overridden the writer method for this
-attribute, then you may need to change it to make this test pass, or do
-something else entirely.
+            As indicated in the message above, :name seems to be changing certain
+            values as they are set, and this could have something to do with why
+            this test is failing. If you've overridden the writer method for this
+            attribute, then you may need to change it to make this test pass, or do
+            something else entirely.
           MESSAGE
 
           expect(&assertion).to fail_with_message(message)
@@ -738,8 +738,8 @@ something else entirely.
         end
 
         message = <<-MESSAGE.rstrip
-The matcher attempted to set :nonexistent on the Example to "foo", but
-that attribute does not exist.
+          The matcher attempted to set :nonexistent on the Example to "foo", but
+          that attribute does not exist.
         MESSAGE
 
         expect(&assertion).to raise_error(
@@ -758,8 +758,8 @@ that attribute does not exist.
         end
 
         message = <<-MESSAGE.rstrip
-The matcher attempted to set :nonexistent on the Example to "foo", but
-that attribute does not exist.
+          The matcher attempted to set :nonexistent on the Example to "foo", but
+          that attribute does not exist.
         MESSAGE
 
         expect(&assertion).to raise_error(
@@ -785,8 +785,8 @@ that attribute does not exist.
           end
 
           message = <<-MESSAGE.rstrip
-The matcher attempted to set :nonexistent on the Example to "some
-value", but that attribute does not exist.
+            The matcher attempted to set :nonexistent on the Example to "some
+            value", but that attribute does not exist.
           MESSAGE
 
           expect(&assertion).to raise_error(
@@ -811,8 +811,8 @@ value", but that attribute does not exist.
           end
 
           message = <<-MESSAGE.rstrip
-The matcher attempted to set :nonexistent on the Example to "some
-value", but that attribute does not exist.
+            The matcher attempted to set :nonexistent on the Example to "some
+            value", but that attribute does not exist.
           MESSAGE
 
           expect(&assertion).to raise_error(

--- a/spec/unit/shoulda/matchers/active_model/validate_absence_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_absence_of_matcher_spec.rb
@@ -109,13 +109,13 @@ describe Shoulda::Matchers::ActiveModel::ValidateAbsenceOfMatcher, type: :model 
           end
 
           message = <<-MESSAGE
-Expected Example not to validate that :attr is empty/falsy, but this
-could not be proved.
-  After setting :attr to ‹"an arbitrary value"›, the matcher expected
-  the Example to be valid, but it was invalid instead, producing these
-  validation errors:
+            Expected Example not to validate that :attr is empty/falsy, but this
+            could not be proved.
+              After setting :attr to ‹"an arbitrary value"›, the matcher expected
+              the Example to be valid, but it was invalid instead, producing these
+              validation errors:
 
-  * attr: ["must be blank"]
+              * attr: ["must be blank"]
           MESSAGE
 
           expect(&assertion).to fail_with_message(message)
@@ -132,10 +132,10 @@ could not be proved.
         record = define_model(:example, attr: :string).new
 
         message = <<-MESSAGE
-Expected Example to validate that :attr is empty/falsy, but this could
-not be proved.
-  After setting :attr to ‹"an arbitrary value"›, the matcher expected
-  the Example to be invalid, but it was valid instead.
+          Expected Example to validate that :attr is empty/falsy, but this could
+          not be proved.
+            After setting :attr to ‹"an arbitrary value"›, the matcher expected
+            the Example to be invalid, but it was valid instead.
         MESSAGE
 
         assertion = lambda do
@@ -172,10 +172,10 @@ not be proved.
     context 'an ActiveModel class without an absence validation' do
       it 'rejects with the correct failure message' do
         message = <<-MESSAGE
-Expected Example to validate that :attr is empty/falsy, but this could
-not be proved.
-  After setting :attr to ‹"an arbitrary value"›, the matcher expected
-  the Example to be invalid, but it was valid instead.
+          Expected Example to validate that :attr is empty/falsy, but this could
+          not be proved.
+            After setting :attr to ‹"an arbitrary value"›, the matcher expected
+            the Example to be invalid, but it was valid instead.
         MESSAGE
 
         assertion = lambda do
@@ -237,10 +237,10 @@ not be proved.
         model = having_and_belonging_to_many(:children, absence: false)
 
         message = <<-MESSAGE
-Expected Parent to validate that :children is empty/falsy, but this
-could not be proved.
-  After setting :children to ‹[#<Child id: nil>]›, the matcher expected
-  the Parent to be invalid, but it was valid instead.
+          Expected Parent to validate that :children is empty/falsy, but this
+          could not be proved.
+            After setting :children to ‹[#<Child id: nil>]›, the matcher expected
+            the Parent to be invalid, but it was valid instead.
         MESSAGE
 
         assertion = lambda do

--- a/spec/unit/shoulda/matchers/active_model/validate_acceptance_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_acceptance_of_matcher_spec.rb
@@ -21,16 +21,16 @@ describe Shoulda::Matchers::ActiveModel::ValidateAcceptanceOfMatcher, type: :mod
           attribute_name: :attr,
           changing_values_with: :always_nil,
           expected_message: <<-MESSAGE.strip,
-Expected Example to validate that :attr has been set to "1", but this
-could not be proved.
-  After setting :attr to ‹false› -- which was read back as ‹nil› -- the
-  matcher expected the Example to be invalid, but it was valid instead.
+            Expected Example to validate that :attr has been set to "1", but this
+            could not be proved.
+              After setting :attr to ‹false› -- which was read back as ‹nil› -- the
+              matcher expected the Example to be invalid, but it was valid instead.
 
-  As indicated in the message above, :attr seems to be changing certain
-  values as they are set, and this could have something to do with why
-  this test is failing. If you've overridden the writer method for this
-  attribute, then you may need to change it to make this test pass, or
-  do something else entirely.
+              As indicated in the message above, :attr seems to be changing certain
+              values as they are set, and this could have something to do with why
+              this test is failing. If you've overridden the writer method for this
+              attribute, then you may need to change it to make this test pass, or
+              do something else entirely.
           MESSAGE
         },
       },
@@ -43,12 +43,12 @@ could not be proved.
       end
 
       message = <<-MESSAGE
-Expected Example not to validate that :attr has been set to "1", but
-this could not be proved.
-  After setting :attr to ‹false›, the matcher expected the Example to be
-  valid, but it was invalid instead, producing these validation errors:
+        Expected Example not to validate that :attr has been set to "1", but
+        this could not be proved.
+          After setting :attr to ‹false›, the matcher expected the Example to be
+          valid, but it was invalid instead, producing these validation errors:
 
-  * attr: ["must be accepted"]
+          * attr: ["must be accepted"]
       MESSAGE
 
       expect(&assertion).to fail_with_message(message)

--- a/spec/unit/shoulda/matchers/active_model/validate_confirmation_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_confirmation_of_matcher_spec.rb
@@ -36,20 +36,20 @@ describe Shoulda::Matchers::ActiveModel::ValidateConfirmationOfMatcher, type: :m
           attribute_name: :password,
           changing_values_with: :next_value,
           expected_message: <<-MESSAGE.strip,
-Expected Example to validate that :password_confirmation matches
-:password, but this could not be proved.
-  After setting :password_confirmation to ‹"same value"›, then setting
-  :password to ‹"same value"› -- which was read back as ‹"same valuf"›
-  -- the matcher expected the Example to be valid, but it was invalid
-  instead, producing these validation errors:
+            Expected Example to validate that :password_confirmation matches
+            :password, but this could not be proved.
+              After setting :password_confirmation to ‹"same value"›, then setting
+              :password to ‹"same value"› -- which was read back as ‹"same valuf"›
+              -- the matcher expected the Example to be valid, but it was invalid
+              instead, producing these validation errors:
 
-  * password_confirmation: ["doesn't match Password"]
+              * password_confirmation: ["doesn't match Password"]
 
-  As indicated in the message above, :password seems to be changing
-  certain values as they are set, and this could have something to do
-  with why this test is failing. If you've overridden the writer method
-  for this attribute, then you may need to change it to make this test
-  pass, or do something else entirely.
+              As indicated in the message above, :password seems to be changing
+              certain values as they are set, and this could have something to do
+              with why this test is failing. If you've overridden the writer method
+              for this attribute, then you may need to change it to make this test
+              pass, or do something else entirely.
           MESSAGE
         },
       },
@@ -69,11 +69,11 @@ Expected Example to validate that :password_confirmation matches
       end
 
       message = <<-MESSAGE
-Expected Example not to validate that :password_confirmation matches
-:password, but this could not be proved.
-  After setting :password_confirmation to ‹nil›, then setting :password
-  to ‹"any value"›, the matcher expected the Example to be invalid, but
-  it was valid instead.
+        Expected Example not to validate that :password_confirmation matches
+        :password, but this could not be proved.
+          After setting :password_confirmation to ‹nil›, then setting :password
+          to ‹"any value"›, the matcher expected the Example to be invalid, but
+          it was valid instead.
       MESSAGE
 
       expect(&assertion).to fail_with_message(message)
@@ -89,8 +89,8 @@ Expected Example not to validate that :password_confirmation matches
       end
 
       message = <<-MESSAGE.rstrip
-The matcher attempted to set :attribute_to_confirm_confirmation on the
-Example to "some value", but that attribute does not exist.
+        The matcher attempted to set :attribute_to_confirm_confirmation on the
+        Example to "some value", but that attribute does not exist.
       MESSAGE
 
       expect(&assertion).to raise_error(
@@ -109,8 +109,8 @@ Example to "some value", but that attribute does not exist.
       end
 
       message = <<-MESSAGE.rstrip
-The matcher attempted to set :attribute_to_confirm on the Example to
-"different value", but that attribute does not exist.
+        The matcher attempted to set :attribute_to_confirm on the Example to
+        "different value", but that attribute does not exist.
       MESSAGE
 
       expect(&assertion).to raise_error(
@@ -131,11 +131,11 @@ The matcher attempted to set :attribute_to_confirm on the Example to
       end
 
       message = <<-MESSAGE
-Expected Example to validate that :attribute_to_confirm_confirmation
-matches :attribute_to_confirm, but this could not be proved.
-  After setting :attribute_to_confirm_confirmation to ‹"some value"›,
-  then setting :attribute_to_confirm to ‹"different value"›, the matcher
-  expected the Example to be invalid, but it was valid instead.
+        Expected Example to validate that :attribute_to_confirm_confirmation
+        matches :attribute_to_confirm, but this could not be proved.
+          After setting :attribute_to_confirm_confirmation to ‹"some value"›,
+          then setting :attribute_to_confirm to ‹"different value"›, the matcher
+          expected the Example to be invalid, but it was valid instead.
       MESSAGE
 
       expect(&assertion).to fail_with_message(message)

--- a/spec/unit/shoulda/matchers/active_model/validate_exclusion_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_exclusion_of_matcher_spec.rb
@@ -40,19 +40,19 @@ describe Shoulda::Matchers::ActiveModel::ValidateExclusionOfMatcher, type: :mode
           attribute_name: :attr,
           changing_values_with: :next_value,
           expected_message: <<-MESSAGE.strip,
-Expected Example to validate that :attr lies outside the range ‹2› to
-‹5›, but this could not be proved.
-  After setting :attr to ‹1› -- which was read back as ‹2› -- the
-  matcher expected the Example to be valid, but it was invalid instead,
-  producing these validation errors:
+            Expected Example to validate that :attr lies outside the range ‹2› to
+            ‹5›, but this could not be proved.
+              After setting :attr to ‹1› -- which was read back as ‹2› -- the
+              matcher expected the Example to be valid, but it was invalid instead,
+              producing these validation errors:
 
-  * attr: ["is reserved"]
+              * attr: ["is reserved"]
 
-  As indicated in the message above, :attr seems to be changing certain
-  values as they are set, and this could have something to do with why
-  this test is failing. If you've overridden the writer method for this
-  attribute, then you may need to change it to make this test pass, or
-  do something else entirely.
+              As indicated in the message above, :attr seems to be changing certain
+              values as they are set, and this could have something to do with why
+              this test is failing. If you've overridden the writer method for this
+              attribute, then you may need to change it to make this test pass, or
+              do something else entirely.
           MESSAGE
         },
       },
@@ -74,10 +74,10 @@ Expected Example to validate that :attr lies outside the range ‹2› to
       end
 
       message = <<-MESSAGE
-Expected Example not to validate that :attr lies outside the range ‹2›
-to ‹5›, but this could not be proved.
-  After setting :attr to ‹6›, the matcher expected the Example to be
-  invalid, but it was valid instead.
+        Expected Example not to validate that :attr lies outside the range ‹2›
+        to ‹5›, but this could not be proved.
+          After setting :attr to ‹6›, the matcher expected the Example to be
+          invalid, but it was valid instead.
       MESSAGE
 
       expect(&assertion).to fail_with_message(message)
@@ -192,17 +192,17 @@ to ‹5›, but this could not be proved.
           attribute_name: :attr,
           changing_values_with: :next_value,
           expected_message: <<-MESSAGE.strip,
-Expected Example to validate that :attr is neither ‹"one"› nor ‹"two"›,
-but this could not be proved.
-  After setting :attr to ‹"one"› -- which was read back as ‹"onf"› --
-  the matcher expected the Example to be invalid, but it was valid
-  instead.
+            Expected Example to validate that :attr is neither ‹"one"› nor ‹"two"›,
+            but this could not be proved.
+              After setting :attr to ‹"one"› -- which was read back as ‹"onf"› --
+              the matcher expected the Example to be invalid, but it was valid
+              instead.
 
-  As indicated in the message above, :attr seems to be changing certain
-  values as they are set, and this could have something to do with why
-  this test is failing. If you've overridden the writer method for this
-  attribute, then you may need to change it to make this test pass, or
-  do something else entirely.
+              As indicated in the message above, :attr seems to be changing certain
+              values as they are set, and this could have something to do with why
+              this test is failing. If you've overridden the writer method for this
+              attribute, then you may need to change it to make this test pass, or
+              do something else entirely.
           MESSAGE
         },
       },
@@ -224,12 +224,12 @@ but this could not be proved.
       end
 
       message = <<-MESSAGE
-Expected Example not to validate that :attr is neither ‹"one"› nor
-‹"two"›, but this could not be proved.
-  After setting :attr to ‹"two"›, the matcher expected the Example to be
-  valid, but it was invalid instead, producing these validation errors:
+        Expected Example not to validate that :attr is neither ‹"one"› nor
+        ‹"two"›, but this could not be proved.
+          After setting :attr to ‹"two"›, the matcher expected the Example to be
+          valid, but it was invalid instead, producing these validation errors:
 
-  * attr: ["is reserved"]
+          * attr: ["is reserved"]
       MESSAGE
 
       expect(&assertion).to fail_with_message(message)

--- a/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb
@@ -420,11 +420,11 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
           attribute_name: :attr,
           changing_values_with: :next_value,
           expected_message_includes: <<-MESSAGE.strip,
-  As indicated in the message above, :attr seems to be changing certain
-  values as they are set, and this could have something to do with why
-  this test is failing. If you've overridden the writer method for this
-  attribute, then you may need to change it to make this test pass, or
-  do something else entirely.
+            As indicated in the message above, :attr seems to be changing certain
+            values as they are set, and this could have something to do with why
+            this test is failing. If you've overridden the writer method for this
+            attribute, then you may need to change it to make this test pass, or
+            do something else entirely.
           MESSAGE
         },
       },
@@ -597,11 +597,11 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
           attribute_name: :attr,
           changing_values_with: :next_value,
           expected_message_includes: <<-MESSAGE.strip,
-  As indicated in the message above, :attr seems to be changing certain
-  values as they are set, and this could have something to do with why
-  this test is failing. If you've overridden the writer method for this
-  attribute, then you may need to change it to make this test pass, or
-  do something else entirely.
+            As indicated in the message above, :attr seems to be changing certain
+            values as they are set, and this could have something to do with why
+            this test is failing. If you've overridden the writer method for this
+            attribute, then you may need to change it to make this test pass, or
+            do something else entirely.
           MESSAGE
         },
       },
@@ -909,11 +909,11 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
         define_model(:low)
 
         expected_message = <<-MESSAGE.strip
-Expected Issue to validate that :severity_type is either ‹"Low"›,
-‹"Medium"›, or ‹"High"›, but this could not be proved.
-  After setting :severity_type to ‹"Shoulda::Matchers::ExampleClass"›,
-  the matcher expected the Issue to be invalid, but it was valid
-  instead.
+          Expected Issue to validate that :severity_type is either ‹"Low"›,
+          ‹"Medium"›, or ‹"High"›, but this could not be proved.
+            After setting :severity_type to ‹"Shoulda::Matchers::ExampleClass"›,
+            the matcher expected the Issue to be invalid, but it was valid
+            instead.
         MESSAGE
 
         expect { validate_inclusion_of(:severity_type).in_array(%w(Low Medium High)) }.

--- a/spec/unit/shoulda/matchers/active_model/validate_length_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_length_of_matcher_spec.rb
@@ -33,17 +33,17 @@ describe Shoulda::Matchers::ActiveModel::ValidateLengthOfMatcher, type: :model d
           attribute_name: :attr,
           changing_values_with: :add_character,
           expected_message: <<-MESSAGE.strip,
-Expected Example to validate that the length of :attr is at least 4, but
-this could not be proved.
-  After setting :attr to ‹"xxx"› -- which was read back as ‹"xxxa"› --
-  the matcher expected the Example to be invalid, but it was valid
-  instead.
+            Expected Example to validate that the length of :attr is at least 4, but
+            this could not be proved.
+              After setting :attr to ‹"xxx"› -- which was read back as ‹"xxxa"› --
+              the matcher expected the Example to be invalid, but it was valid
+              instead.
 
-  As indicated in the message above, :attr seems to be changing certain
-  values as they are set, and this could have something to do with why
-  this test is failing. If you've overridden the writer method for this
-  attribute, then you may need to change it to make this test pass, or
-  do something else entirely.
+              As indicated in the message above, :attr seems to be changing certain
+              values as they are set, and this could have something to do with why
+              this test is failing. If you've overridden the writer method for this
+              attribute, then you may need to change it to make this test pass, or
+              do something else entirely.
           MESSAGE
         },
       },
@@ -64,10 +64,10 @@ this could not be proved.
       end
 
       message = <<-MESSAGE
-Expected Example not to validate that the length of :attr is at least 4,
-but this could not be proved.
-  After setting :attr to ‹"xxxx"›, the matcher expected the Example to
-  be invalid, but it was valid instead.
+        Expected Example not to validate that the length of :attr is at least 4,
+        but this could not be proved.
+          After setting :attr to ‹"xxxx"›, the matcher expected the Example to
+          be invalid, but it was valid instead.
       MESSAGE
 
       expect(&assertion).to fail_with_message(message)
@@ -113,17 +113,17 @@ but this could not be proved.
           attribute_name: :attr,
           changing_values_with: :remove_character,
           expected_message: <<-MESSAGE.strip,
-Expected Example to validate that the length of :attr is at most 4, but
-this could not be proved.
-  After setting :attr to ‹"xxxxx"› -- which was read back as ‹"xxxx"› --
-  the matcher expected the Example to be invalid, but it was valid
-  instead.
+            Expected Example to validate that the length of :attr is at most 4, but
+            this could not be proved.
+              After setting :attr to ‹"xxxxx"› -- which was read back as ‹"xxxx"› --
+              the matcher expected the Example to be invalid, but it was valid
+              instead.
 
-  As indicated in the message above, :attr seems to be changing certain
-  values as they are set, and this could have something to do with why
-  this test is failing. If you've overridden the writer method for this
-  attribute, then you may need to change it to make this test pass, or
-  do something else entirely.
+              As indicated in the message above, :attr seems to be changing certain
+              values as they are set, and this could have something to do with why
+              this test is failing. If you've overridden the writer method for this
+              attribute, then you may need to change it to make this test pass, or
+              do something else entirely.
           MESSAGE
         },
       },
@@ -170,17 +170,17 @@ this could not be proved.
           attribute_name: :attr,
           changing_values_with: :add_character,
           expected_message: <<-MESSAGE.strip,
-Expected Example to validate that the length of :attr is 4, but this
-could not be proved.
-  After setting :attr to ‹"xxx"› -- which was read back as ‹"xxxa"› --
-  the matcher expected the Example to be invalid, but it was valid
-  instead.
+            Expected Example to validate that the length of :attr is 4, but this
+            could not be proved.
+              After setting :attr to ‹"xxx"› -- which was read back as ‹"xxxa"› --
+              the matcher expected the Example to be invalid, but it was valid
+              instead.
 
-  As indicated in the message above, :attr seems to be changing certain
-  values as they are set, and this could have something to do with why
-  this test is failing. If you've overridden the writer method for this
-  attribute, then you may need to change it to make this test pass, or
-  do something else entirely.
+              As indicated in the message above, :attr seems to be changing certain
+              values as they are set, and this could have something to do with why
+              this test is failing. If you've overridden the writer method for this
+              attribute, then you may need to change it to make this test pass, or
+              do something else entirely.
           MESSAGE
         },
       },
@@ -301,12 +301,12 @@ could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that the length of :attr is at least 1, but
-this could not be proved.
-  After setting :attr to ‹nil›, the matcher expected the Example to be
-  valid, but it was invalid instead, producing these validation errors:
+          Expected Example to validate that the length of :attr is at least 1, but
+          this could not be proved.
+            After setting :attr to ‹nil›, the matcher expected the Example to be
+            valid, but it was invalid instead, producing these validation errors:
 
-  * attr: ["is too short (minimum is 1 character)"]
+            * attr: ["is too short (minimum is 1 character)"]
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -357,12 +357,12 @@ this could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that the length of :attr is at least 1, but
-this could not be proved.
-  After setting :attr to ‹""›, the matcher expected the Example to be
-  valid, but it was invalid instead, producing these validation errors:
+          Expected Example to validate that the length of :attr is at least 1, but
+          this could not be proved.
+            After setting :attr to ‹""›, the matcher expected the Example to be
+            valid, but it was invalid instead, producing these validation errors:
 
-  * attr: ["is too short (minimum is 1 character)"]
+            * attr: ["is too short (minimum is 1 character)"]
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)

--- a/spec/unit/shoulda/matchers/active_model/validate_numericality_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_numericality_of_matcher_spec.rb
@@ -153,16 +153,16 @@ describe Shoulda::Matchers::ActiveModel::ValidateNumericalityOfMatcher, type: :m
             attribute_name: :attr,
             changing_values_with: :numeric_value,
             expected_message: <<-MESSAGE.strip,
-Expected Example to validate that :attr looks like a number, but this
-could not be proved.
-  After setting :attr to ‹"abcd"› -- which was read back as ‹"1"› -- the
-  matcher expected the Example to be invalid, but it was valid instead.
+              Expected Example to validate that :attr looks like a number, but this
+              could not be proved.
+                After setting :attr to ‹"abcd"› -- which was read back as ‹"1"› -- the
+                matcher expected the Example to be invalid, but it was valid instead.
 
-  As indicated in the message above, :attr seems to be changing certain
-  values as they are set, and this could have something to do with why
-  this test is failing. If you've overridden the writer method for this
-  attribute, then you may need to change it to make this test pass, or
-  do something else entirely.
+                As indicated in the message above, :attr seems to be changing certain
+                values as they are set, and this could have something to do with why
+                this test is failing. If you've overridden the writer method for this
+                attribute, then you may need to change it to make this test pass, or
+                do something else entirely.
             MESSAGE
           },
         },
@@ -213,13 +213,13 @@ could not be proved.
           end
 
           message = <<-MESSAGE
-Expected Example not to validate that :attr looks like a number, but
-this could not be proved.
-  After setting :attr to ‹"abcd"›, the matcher expected the Example to
-  be valid, but it was invalid instead, producing these validation
-  errors:
+            Expected Example not to validate that :attr looks like a number, but
+            this could not be proved.
+              After setting :attr to ‹"abcd"›, the matcher expected the Example to
+              be valid, but it was invalid instead, producing these validation
+              errors:
 
-  * attr: ["is not a number"]
+              * attr: ["is not a number"]
           MESSAGE
 
           expect(&assertion).to fail_with_message(message)
@@ -234,10 +234,10 @@ this could not be proved.
         assertion = -> { expect(record).to validate_numericality }
 
         message = <<-MESSAGE
-Expected Example to validate that :attr looks like a number, but this
-could not be proved.
-  After setting :attr to ‹"abcd"›, the matcher expected the Example to
-  be invalid, but it was valid instead.
+          Expected Example to validate that :attr looks like a number, but this
+          could not be proved.
+            After setting :attr to ‹"abcd"›, the matcher expected the Example to
+            be invalid, but it was valid instead.
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -263,20 +263,20 @@ could not be proved.
             attribute_name: :attr,
             changing_values_with: :next_value_or_non_numeric_value,
             expected_message: <<-MESSAGE.strip,
-Expected Example to validate that :attr looks like a number as long as
-it is not nil, but this could not be proved.
-  In checking that Example allows :attr to be ‹nil›, after setting :attr
-  to ‹nil› -- which was read back as ‹"a"› -- the matcher expected the
-  Example to be valid, but it was invalid instead, producing these
-  validation errors:
+              Expected Example to validate that :attr looks like a number as long as
+              it is not nil, but this could not be proved.
+                In checking that Example allows :attr to be ‹nil›, after setting :attr
+                to ‹nil› -- which was read back as ‹"a"› -- the matcher expected the
+                Example to be valid, but it was invalid instead, producing these
+                validation errors:
 
-  * attr: ["is not a number"]
+                * attr: ["is not a number"]
 
-  As indicated in the message above, :attr seems to be changing certain
-  values as they are set, and this could have something to do with why
-  this test is failing. If you've overridden the writer method for this
-  attribute, then you may need to change it to make this test pass, or
-  do something else entirely.
+                As indicated in the message above, :attr seems to be changing certain
+                values as they are set, and this could have something to do with why
+                this test is failing. If you've overridden the writer method for this
+                attribute, then you may need to change it to make this test pass, or
+                do something else entirely.
             MESSAGE
           },
         },
@@ -300,13 +300,13 @@ it is not nil, but this could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr looks like a number as long as
-it is not nil, but this could not be proved.
-  In checking that Example allows :attr to be ‹nil›, after setting :attr
-  to ‹nil›, the matcher expected the Example to be valid, but it was
-  invalid instead, producing these validation errors:
+          Expected Example to validate that :attr looks like a number as long as
+          it is not nil, but this could not be proved.
+            In checking that Example allows :attr to be ‹nil›, after setting :attr
+            to ‹nil›, the matcher expected the Example to be valid, but it was
+            invalid instead, producing these validation errors:
 
-  * attr: ["is not a number"]
+            * attr: ["is not a number"]
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -349,16 +349,16 @@ this could not be proved.
             attribute_name: :attr,
             changing_values_with: :numeric_value,
             expected_message: <<-MESSAGE.strip,
-Expected Example to validate that :attr looks like an integer, but this
-could not be proved.
-  After setting :attr to ‹"0.1"› -- which was read back as ‹"1"› -- the
-  matcher expected the Example to be invalid, but it was valid instead.
+              Expected Example to validate that :attr looks like an integer, but this
+              could not be proved.
+                After setting :attr to ‹"0.1"› -- which was read back as ‹"1"› -- the
+                matcher expected the Example to be invalid, but it was valid instead.
 
-  As indicated in the message above, :attr seems to be changing certain
-  values as they are set, and this could have something to do with why
-  this test is failing. If you've overridden the writer method for this
-  attribute, then you may need to change it to make this test pass, or
-  do something else entirely.
+                As indicated in the message above, :attr seems to be changing certain
+                values as they are set, and this could have something to do with why
+                this test is failing. If you've overridden the writer method for this
+                attribute, then you may need to change it to make this test pass, or
+                do something else entirely.
             MESSAGE
           },
         },
@@ -382,10 +382,10 @@ could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr looks like an integer, but this
-could not be proved.
-  After setting :attr to ‹"0.1"›, the matcher expected the Example to be
-  invalid, but it was valid instead.
+          Expected Example to validate that :attr looks like an integer, but this
+          could not be proved.
+            After setting :attr to ‹"0.1"›, the matcher expected the Example to be
+            invalid, but it was valid instead.
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -428,16 +428,16 @@ but this could not be proved.
             attribute_name: :attr,
             changing_values_with: :next_value,
             expected_message: <<-MESSAGE.strip,
-Expected Example to validate that :attr looks like an odd number, but
-this could not be proved.
-  After setting :attr to ‹"2"› -- which was read back as ‹"3"› -- the
-  matcher expected the Example to be invalid, but it was valid instead.
+              Expected Example to validate that :attr looks like an odd number, but
+              this could not be proved.
+                After setting :attr to ‹"2"› -- which was read back as ‹"3"› -- the
+                matcher expected the Example to be invalid, but it was valid instead.
 
-  As indicated in the message above, :attr seems to be changing certain
-  values as they are set, and this could have something to do with why
-  this test is failing. If you've overridden the writer method for this
-  attribute, then you may need to change it to make this test pass, or
-  do something else entirely.
+                As indicated in the message above, :attr seems to be changing certain
+                values as they are set, and this could have something to do with why
+                this test is failing. If you've overridden the writer method for this
+                attribute, then you may need to change it to make this test pass, or
+                do something else entirely.
             MESSAGE
           },
         },
@@ -503,10 +503,10 @@ this could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr looks like an odd number, but
-this could not be proved.
-  After setting :attr to ‹"2"›, the matcher expected the Example to be
-  invalid, but it was valid instead.
+          Expected Example to validate that :attr looks like an odd number, but
+          this could not be proved.
+            After setting :attr to ‹"2"›, the matcher expected the Example to be
+            invalid, but it was valid instead.
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -549,16 +549,16 @@ but this could not be proved.
             attribute_name: :attr,
             changing_values_with: :next_value,
             expected_message: <<-MESSAGE.strip,
-Expected Example to validate that :attr looks like an even number, but
-this could not be proved.
-  After setting :attr to ‹"1"› -- which was read back as ‹"2"› -- the
-  matcher expected the Example to be invalid, but it was valid instead.
+              Expected Example to validate that :attr looks like an even number, but
+              this could not be proved.
+                After setting :attr to ‹"1"› -- which was read back as ‹"2"› -- the
+                matcher expected the Example to be invalid, but it was valid instead.
 
-  As indicated in the message above, :attr seems to be changing certain
-  values as they are set, and this could have something to do with why
-  this test is failing. If you've overridden the writer method for this
-  attribute, then you may need to change it to make this test pass, or
-  do something else entirely.
+                As indicated in the message above, :attr seems to be changing certain
+                values as they are set, and this could have something to do with why
+                this test is failing. If you've overridden the writer method for this
+                attribute, then you may need to change it to make this test pass, or
+                do something else entirely.
             MESSAGE
           },
         },
@@ -624,10 +624,10 @@ this could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr looks like an even number, but
-this could not be proved.
-  After setting :attr to ‹"1"›, the matcher expected the Example to be
-  invalid, but it was valid instead.
+          Expected Example to validate that :attr looks like an even number, but
+          this could not be proved.
+            After setting :attr to ‹"1"›, the matcher expected the Example to be
+            invalid, but it was valid instead.
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -669,19 +669,19 @@ than or equal to 18, but this could not be proved.
             attribute_name: :attr,
             changing_values_with: :next_value,
             expected_message: <<-MESSAGE.strip,
-Expected Example to validate that :attr looks like a number less than or
-equal to 18, but this could not be proved.
-  After setting :attr to ‹"18"› -- which was read back as ‹"19"› -- the
-  matcher expected the Example to be valid, but it was invalid instead,
-  producing these validation errors:
+              Expected Example to validate that :attr looks like a number less than or
+              equal to 18, but this could not be proved.
+                After setting :attr to ‹"18"› -- which was read back as ‹"19"› -- the
+                matcher expected the Example to be valid, but it was invalid instead,
+                producing these validation errors:
 
-  * attr: ["must be less than or equal to 18"]
+                * attr: ["must be less than or equal to 18"]
 
-  As indicated in the message above, :attr seems to be changing certain
-  values as they are set, and this could have something to do with why
-  this test is failing. If you've overridden the writer method for this
-  attribute, then you may need to change it to make this test pass, or
-  do something else entirely.
+                As indicated in the message above, :attr seems to be changing certain
+                values as they are set, and this could have something to do with why
+                this test is failing. If you've overridden the writer method for this
+                attribute, then you may need to change it to make this test pass, or
+                do something else entirely.
             MESSAGE
           },
         },
@@ -749,10 +749,10 @@ equal to 18, but this could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr looks like a number less than or
-equal to 18, but this could not be proved.
-  After setting :attr to ‹"19"›, the matcher expected the Example to be
-  invalid, but it was valid instead.
+          Expected Example to validate that :attr looks like a number less than or
+          equal to 18, but this could not be proved.
+            After setting :attr to ‹"19"›, the matcher expected the Example to be
+            invalid, but it was valid instead.
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -777,13 +777,13 @@ equal to 18, but this could not be proved.
         end
 
         expect(&assertion).to fail_with_message(<<~MESSAGE)
-Expected Example not to validate that :attr looks like a number less
-than 18, but this could not be proved.
-  After setting :attr to ‹"abcd"›, the matcher expected the Example to
-  be valid, but it was invalid instead, producing these validation
-  errors:
+          Expected Example not to validate that :attr looks like a number less
+          than 18, but this could not be proved.
+            After setting :attr to ‹"abcd"›, the matcher expected the Example to
+            be valid, but it was invalid instead, producing these validation
+            errors:
 
-  * attr: ["is not a number"]
+            * attr: ["is not a number"]
         MESSAGE
       end
 
@@ -795,19 +795,19 @@ than 18, but this could not be proved.
             attribute_name: :attr,
             changing_values_with: :next_value,
             expected_message: <<-MESSAGE.strip,
-Expected Example to validate that :attr looks like a number less than
-18, but this could not be proved.
-  After setting :attr to ‹"17"› -- which was read back as ‹"18"› -- the
-  matcher expected the Example to be valid, but it was invalid instead,
-  producing these validation errors:
+              Expected Example to validate that :attr looks like a number less than
+              18, but this could not be proved.
+                After setting :attr to ‹"17"› -- which was read back as ‹"18"› -- the
+                matcher expected the Example to be valid, but it was invalid instead,
+                producing these validation errors:
 
-  * attr: ["must be less than 18"]
+                * attr: ["must be less than 18"]
 
-  As indicated in the message above, :attr seems to be changing certain
-  values as they are set, and this could have something to do with why
-  this test is failing. If you've overridden the writer method for this
-  attribute, then you may need to change it to make this test pass, or
-  do something else entirely.
+                As indicated in the message above, :attr seems to be changing certain
+                values as they are set, and this could have something to do with why
+                this test is failing. If you've overridden the writer method for this
+                attribute, then you may need to change it to make this test pass, or
+                do something else entirely.
             MESSAGE
           },
         },
@@ -873,10 +873,10 @@ Expected Example to validate that :attr looks like a number less than
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr looks like a number less than
-18, but this could not be proved.
-  After setting :attr to ‹"19"›, the matcher expected the Example to be
-  invalid, but it was valid instead.
+          Expected Example to validate that :attr looks like a number less than
+          18, but this could not be proved.
+            After setting :attr to ‹"19"›, the matcher expected the Example to be
+            invalid, but it was valid instead.
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -899,13 +899,13 @@ Expected Example to validate that :attr looks like a number less than
         end
 
         expect(&assertion).to fail_with_message(<<~MESSAGE)
-Expected Example not to validate that :attr looks like a number equal to
-18, but this could not be proved.
-  After setting :attr to ‹"abcd"›, the matcher expected the Example to
-  be valid, but it was invalid instead, producing these validation
-  errors:
+          Expected Example not to validate that :attr looks like a number equal to
+          18, but this could not be proved.
+            After setting :attr to ‹"abcd"›, the matcher expected the Example to
+            be valid, but it was invalid instead, producing these validation
+            errors:
 
-  * attr: ["is not a number"]
+            * attr: ["is not a number"]
         MESSAGE
       end
 
@@ -917,19 +917,19 @@ Expected Example not to validate that :attr looks like a number equal to
             attribute_name: :attr,
             changing_values_with: :next_value,
             expected_message: <<-MESSAGE.strip,
-Expected Example to validate that :attr looks like a number equal to 18,
-but this could not be proved.
-  After setting :attr to ‹"18"› -- which was read back as ‹"19"› -- the
-  matcher expected the Example to be valid, but it was invalid instead,
-  producing these validation errors:
+              Expected Example to validate that :attr looks like a number equal to 18,
+              but this could not be proved.
+                After setting :attr to ‹"18"› -- which was read back as ‹"19"› -- the
+                matcher expected the Example to be valid, but it was invalid instead,
+                producing these validation errors:
 
-  * attr: ["must be equal to 18"]
+                * attr: ["must be equal to 18"]
 
-  As indicated in the message above, :attr seems to be changing certain
-  values as they are set, and this could have something to do with why
-  this test is failing. If you've overridden the writer method for this
-  attribute, then you may need to change it to make this test pass, or
-  do something else entirely.
+                As indicated in the message above, :attr seems to be changing certain
+                values as they are set, and this could have something to do with why
+                this test is failing. If you've overridden the writer method for this
+                attribute, then you may need to change it to make this test pass, or
+                do something else entirely.
             MESSAGE
           },
         },
@@ -995,10 +995,10 @@ but this could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr looks like a number equal to 18,
-but this could not be proved.
-  After setting :attr to ‹"19"›, the matcher expected the Example to be
-  invalid, but it was valid instead.
+          Expected Example to validate that :attr looks like a number equal to 18,
+          but this could not be proved.
+            After setting :attr to ‹"19"›, the matcher expected the Example to be
+            invalid, but it was valid instead.
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -1021,13 +1021,13 @@ but this could not be proved.
         end
 
         expect(&assertion).to fail_with_message(<<~MESSAGE)
-Expected Example not to validate that :attr looks like a number other
-than 18, but this could not be proved.
-  After setting :attr to ‹"abcd"›, the matcher expected the Example to
-  be valid, but it was invalid instead, producing these validation
-  errors:
+          Expected Example not to validate that :attr looks like a number other
+          than 18, but this could not be proved.
+            After setting :attr to ‹"abcd"›, the matcher expected the Example to
+            be valid, but it was invalid instead, producing these validation
+            errors:
 
-  * attr: ["is not a number"]
+            * attr: ["is not a number"]
         MESSAGE
       end
 
@@ -1039,16 +1039,16 @@ than 18, but this could not be proved.
             attribute_name: :attr,
             changing_values_with: :next_value,
             expected_message: <<-MESSAGE.strip,
-Expected Example to validate that :attr looks like a number other than
-18, but this could not be proved.
-  After setting :attr to ‹"18"› -- which was read back as ‹"19"› -- the
-  matcher expected the Example to be invalid, but it was valid instead.
+              Expected Example to validate that :attr looks like a number other than
+              18, but this could not be proved.
+                After setting :attr to ‹"18"› -- which was read back as ‹"19"› -- the
+                matcher expected the Example to be invalid, but it was valid instead.
 
-  As indicated in the message above, :attr seems to be changing certain
-  values as they are set, and this could have something to do with why
-  this test is failing. If you've overridden the writer method for this
-  attribute, then you may need to change it to make this test pass, or
-  do something else entirely.
+                As indicated in the message above, :attr seems to be changing certain
+                values as they are set, and this could have something to do with why
+                this test is failing. If you've overridden the writer method for this
+                attribute, then you may need to change it to make this test pass, or
+                do something else entirely.
             MESSAGE
           },
         },
@@ -1114,10 +1114,10 @@ Expected Example to validate that :attr looks like a number other than
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr looks like a number other than
-18, but this could not be proved.
-  After setting :attr to ‹"18"›, the matcher expected the Example to be
-  invalid, but it was valid instead.
+          Expected Example to validate that :attr looks like a number other than
+          18, but this could not be proved.
+            After setting :attr to ‹"18"›, the matcher expected the Example to be
+            invalid, but it was valid instead.
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -1147,13 +1147,13 @@ Expected Example to validate that :attr looks like a number other than
         end
 
         expect(&assertion).to fail_with_message(<<~MESSAGE)
-Expected Example not to validate that :attr looks like a number greater
-than or equal to 18, but this could not be proved.
-  After setting :attr to ‹"abcd"›, the matcher expected the Example to
-  be valid, but it was invalid instead, producing these validation
-  errors:
+          Expected Example not to validate that :attr looks like a number greater
+          than or equal to 18, but this could not be proved.
+            After setting :attr to ‹"abcd"›, the matcher expected the Example to
+            be valid, but it was invalid instead, producing these validation
+            errors:
 
-  * attr: ["is not a number"]
+            * attr: ["is not a number"]
         MESSAGE
       end
 
@@ -1165,16 +1165,16 @@ than or equal to 18, but this could not be proved.
             attribute_name: :attr,
             changing_values_with: :next_value,
             expected_message: <<-MESSAGE.strip,
-Expected Example to validate that :attr looks like a number greater than
-or equal to 18, but this could not be proved.
-  After setting :attr to ‹"17"› -- which was read back as ‹"18"› -- the
-  matcher expected the Example to be invalid, but it was valid instead.
+              Expected Example to validate that :attr looks like a number greater than
+              or equal to 18, but this could not be proved.
+                After setting :attr to ‹"17"› -- which was read back as ‹"18"› -- the
+                matcher expected the Example to be invalid, but it was valid instead.
 
-  As indicated in the message above, :attr seems to be changing certain
-  values as they are set, and this could have something to do with why
-  this test is failing. If you've overridden the writer method for this
-  attribute, then you may need to change it to make this test pass, or
-  do something else entirely.
+                As indicated in the message above, :attr seems to be changing certain
+                values as they are set, and this could have something to do with why
+                this test is failing. If you've overridden the writer method for this
+                attribute, then you may need to change it to make this test pass, or
+                do something else entirely.
             MESSAGE
           },
         },
@@ -1250,10 +1250,10 @@ or equal to 18, but this could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr looks like a number greater than
-or equal to 18, but this could not be proved.
-  After setting :attr to ‹"17"›, the matcher expected the Example to be
-  invalid, but it was valid instead.
+          Expected Example to validate that :attr looks like a number greater than
+          or equal to 18, but this could not be proved.
+            After setting :attr to ‹"17"›, the matcher expected the Example to be
+            invalid, but it was valid instead.
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -1279,13 +1279,13 @@ or equal to 18, but this could not be proved.
         end
 
         expect(&assertion).to fail_with_message(<<~MESSAGE)
-Expected Example not to validate that :attr looks like a number greater
-than 18, but this could not be proved.
-  After setting :attr to ‹"abcd"›, the matcher expected the Example to
-  be valid, but it was invalid instead, producing these validation
-  errors:
+          Expected Example not to validate that :attr looks like a number greater
+          than 18, but this could not be proved.
+            After setting :attr to ‹"abcd"›, the matcher expected the Example to
+            be valid, but it was invalid instead, producing these validation
+            errors:
 
-  * attr: ["is not a number"]
+            * attr: ["is not a number"]
         MESSAGE
       end
 
@@ -1297,16 +1297,16 @@ than 18, but this could not be proved.
             attribute_name: :attr,
             changing_values_with: :next_value,
             expected_message: <<-MESSAGE.strip,
-Expected Example to validate that :attr looks like a number greater than
-18, but this could not be proved.
-  After setting :attr to ‹"18"› -- which was read back as ‹"19"› -- the
-  matcher expected the Example to be invalid, but it was valid instead.
+              Expected Example to validate that :attr looks like a number greater than
+              18, but this could not be proved.
+                After setting :attr to ‹"18"› -- which was read back as ‹"19"› -- the
+                matcher expected the Example to be invalid, but it was valid instead.
 
-  As indicated in the message above, :attr seems to be changing certain
-  values as they are set, and this could have something to do with why
-  this test is failing. If you've overridden the writer method for this
-  attribute, then you may need to change it to make this test pass, or
-  do something else entirely.
+                As indicated in the message above, :attr seems to be changing certain
+                values as they are set, and this could have something to do with why
+                this test is failing. If you've overridden the writer method for this
+                attribute, then you may need to change it to make this test pass, or
+                do something else entirely.
             MESSAGE
           },
         },
@@ -1378,10 +1378,10 @@ Expected Example to validate that :attr looks like a number greater than
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr looks like a number greater than
-18, but this could not be proved.
-  After setting :attr to ‹"18"›, the matcher expected the Example to be
-  invalid, but it was valid instead.
+          Expected Example to validate that :attr looks like a number greater than
+          18, but this could not be proved.
+            After setting :attr to ‹"18"›, the matcher expected the Example to be
+            invalid, but it was valid instead.
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -1406,14 +1406,14 @@ Expected Example to validate that :attr looks like a number greater than
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr looks like a number, producing a
-custom validation error on failure, but this could not be proved.
-  After setting :attr to ‹"abcd"›, the matcher expected the Example to
-  be invalid and to produce a validation error matching ‹/wrong/› on
-  :attr. The record was indeed invalid, but it produced these validation
-  errors instead:
+          Expected Example to validate that :attr looks like a number, producing a
+          custom validation error on failure, but this could not be proved.
+            After setting :attr to ‹"abcd"›, the matcher expected the Example to
+            be invalid and to produce a validation error matching ‹/wrong/› on
+            :attr. The record was indeed invalid, but it produced these validation
+            errors instead:
 
-  * attr: ["custom"]
+            * attr: ["custom"]
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -1436,10 +1436,10 @@ custom validation error on failure, but this could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr looks like a number, producing a
-custom validation error on failure, but this could not be proved.
-  After setting :attr to ‹"abcd"›, the matcher expected the Example to
-  be invalid, but it was valid instead.
+          Expected Example to validate that :attr looks like a number, producing a
+          custom validation error on failure, but this could not be proved.
+            After setting :attr to ‹"abcd"›, the matcher expected the Example to
+            be invalid, but it was valid instead.
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -1464,11 +1464,11 @@ custom validation error on failure, but this could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr looks like a number, raising a
-validation exception on failure, but this could not be proved.
-  After setting :attr to ‹"abcd"›, the matcher expected the Example to
-  be invalid and to raise a validation exception, but the record
-  produced validation errors instead.
+          Expected Example to validate that :attr looks like a number, raising a
+          validation exception on failure, but this could not be proved.
+            After setting :attr to ‹"abcd"›, the matcher expected the Example to
+            be invalid and to raise a validation exception, but the record
+            produced validation errors instead.
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -1499,10 +1499,10 @@ validation exception on failure, but this could not be proved.
       end
 
       message = <<-MESSAGE
-Expected Example to validate that :attr looks like a number, but this
-could not be proved.
-  After setting :attr to ‹"abcd"›, the matcher expected the Example to
-  be invalid, but it was valid instead.
+        Expected Example to validate that :attr looks like a number, but this
+        could not be proved.
+          After setting :attr to ‹"abcd"›, the matcher expected the Example to
+          be invalid, but it was valid instead.
       MESSAGE
 
       expect(&assertion).to fail_with_message(message)
@@ -1537,15 +1537,15 @@ could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr looks like an integer greater
-than 18, but this could not be proved.
-  In checking that Example disallows :attr from being a decimal number,
-  after setting :attr to ‹"0.1"›, the matcher expected the Example to be
-  invalid and to produce the validation error "must be an integer" on
-  :attr. The record was indeed invalid, but it produced these validation
-  errors instead:
+          Expected Example to validate that :attr looks like an integer greater
+          than 18, but this could not be proved.
+            In checking that Example disallows :attr from being a decimal number,
+            after setting :attr to ‹"0.1"›, the matcher expected the Example to be
+            invalid and to produce the validation error "must be an integer" on
+            :attr. The record was indeed invalid, but it produced these validation
+            errors instead:
 
-  * attr: ["must be greater than 18"]
+            * attr: ["must be greater than 18"]
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -1562,15 +1562,15 @@ than 18, but this could not be proved.
         end
 
         message = <<-MESSAGE.strip_heredoc
-Expected Example to validate that :attr looks like an integer greater
-than 18, but this could not be proved.
-  In checking that Example disallows :attr from being a decimal number,
-  after setting :attr to ‹"0.1"›, the matcher expected the Example to be
-  invalid and to produce the validation error "must be an integer" on
-  :attr. The record was indeed invalid, but it produced these validation
-  errors instead:
+          Expected Example to validate that :attr looks like an integer greater
+          than 18, but this could not be proved.
+            In checking that Example disallows :attr from being a decimal number,
+            after setting :attr to ‹"0.1"›, the matcher expected the Example to be
+            invalid and to produce the validation error "must be an integer" on
+            :attr. The record was indeed invalid, but it produced these validation
+            errors instead:
 
-  * attr: ["must be greater than 18"]
+            * attr: ["must be greater than 18"]
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -1590,11 +1590,11 @@ than 18, but this could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr looks like an even number
-greater than 18, but this could not be proved.
-  In checking that Example disallows :attr from being a number that is
-  not greater than 18, after setting :attr to ‹"18"›, the matcher
-  expected the Example to be invalid, but it was valid instead.
+          Expected Example to validate that :attr looks like an even number
+          greater than 18, but this could not be proved.
+            In checking that Example disallows :attr from being a number that is
+            not greater than 18, after setting :attr to ‹"18"›, the matcher
+            expected the Example to be invalid, but it was valid instead.
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -1614,15 +1614,15 @@ greater than 18, but this could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr looks like an even number
-greater than 18, but this could not be proved.
-  In checking that Example disallows :attr from being an odd number,
-  after setting :attr to ‹"1"›, the matcher expected the Example to be
-  invalid and to produce the validation error "must be even" on :attr.
-  The record was indeed invalid, but it produced these validation errors
-  instead:
+          Expected Example to validate that :attr looks like an even number
+          greater than 18, but this could not be proved.
+            In checking that Example disallows :attr from being an odd number,
+            after setting :attr to ‹"1"›, the matcher expected the Example to be
+            invalid and to produce the validation error "must be even" on :attr.
+            The record was indeed invalid, but it produced these validation errors
+            instead:
 
-  * attr: ["must be greater than 18"]
+            * attr: ["must be greater than 18"]
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -1642,11 +1642,11 @@ greater than 18, but this could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr looks like an odd number less
-than or equal to 99, but this could not be proved.
-  In checking that Example disallows :attr from being a number that is
-  not less than or equal to 99, after setting :attr to ‹"101"›, the
-  matcher expected the Example to be invalid, but it was valid instead.
+          Expected Example to validate that :attr looks like an odd number less
+          than or equal to 99, but this could not be proved.
+            In checking that Example disallows :attr from being a number that is
+            not less than or equal to 99, after setting :attr to ‹"101"›, the
+            matcher expected the Example to be invalid, but it was valid instead.
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -1668,11 +1668,11 @@ than or equal to 99, but this could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr looks like an integer greater
-than 18 and less than 99, but this could not be proved.
-  In checking that Example disallows :attr from being a number that is
-  not greater than 18, after setting :attr to ‹"18"›, the matcher
-  expected the Example to be invalid, but it was valid instead.
+          Expected Example to validate that :attr looks like an integer greater
+          than 18 and less than 99, but this could not be proved.
+            In checking that Example disallows :attr from being a number that is
+            not greater than 18, after setting :attr to ‹"18"›, the matcher
+            expected the Example to be invalid, but it was valid instead.
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -1694,15 +1694,15 @@ than 18 and less than 99, but this could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr looks like an integer greater
-than 18, but this could not be proved.
-  In checking that Example disallows :attr from being a number that is
-  not greater than 18, after setting :attr to ‹"18"›, the matcher
-  expected the Example to be invalid and to produce the validation error
-  "must be greater than 18" on :attr. The record was indeed invalid, but
-  it produced these validation errors instead:
+          Expected Example to validate that :attr looks like an integer greater
+          than 18, but this could not be proved.
+            In checking that Example disallows :attr from being a number that is
+            not greater than 18, after setting :attr to ‹"18"›, the matcher
+            expected the Example to be invalid and to produce the validation error
+            "must be greater than 18" on :attr. The record was indeed invalid, but
+            it produced these validation errors instead:
 
-  * attr: ["must be greater than 19"]
+            * attr: ["must be greater than 19"]
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -1722,11 +1722,11 @@ than 18, but this could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr looks like an integer greater
-than 18, but this could not be proved.
-  In checking that Example disallows :attr from being a number that is
-  not greater than 18, after setting :attr to ‹"18"›, the matcher
-  expected the Example to be invalid, but it was valid instead.
+          Expected Example to validate that :attr looks like an integer greater
+          than 18, but this could not be proved.
+            In checking that Example disallows :attr from being a number that is
+            not greater than 18, after setting :attr to ‹"18"›, the matcher
+            expected the Example to be invalid, but it was valid instead.
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -1746,15 +1746,15 @@ than 18, but this could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr looks like an even number
-greater than 18, but this could not be proved.
-  In checking that Example disallows :attr from being a number that is
-  not greater than 18, after setting :attr to ‹"18"›, the matcher
-  expected the Example to be invalid and to produce the validation error
-  "must be greater than 18" on :attr. The record was indeed invalid, but
-  it produced these validation errors instead:
+          Expected Example to validate that :attr looks like an even number
+          greater than 18, but this could not be proved.
+            In checking that Example disallows :attr from being a number that is
+            not greater than 18, after setting :attr to ‹"18"›, the matcher
+            expected the Example to be invalid and to produce the validation error
+            "must be greater than 18" on :attr. The record was indeed invalid, but
+            it produced these validation errors instead:
 
-  * attr: ["must be greater than 20"]
+            * attr: ["must be greater than 20"]
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -1774,11 +1774,11 @@ greater than 18, but this could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr looks like an even number
-greater than 18, but this could not be proved.
-  In checking that Example disallows :attr from being a number that is
-  not greater than 18, after setting :attr to ‹"18"›, the matcher
-  expected the Example to be invalid, but it was valid instead.
+          Expected Example to validate that :attr looks like an even number
+          greater than 18, but this could not be proved.
+            In checking that Example disallows :attr from being a number that is
+            not greater than 18, after setting :attr to ‹"18"›, the matcher
+            expected the Example to be invalid, but it was valid instead.
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -1798,11 +1798,11 @@ greater than 18, but this could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr looks like an odd number less
-than or equal to 99, but this could not be proved.
-  In checking that Example disallows :attr from being a number that is
-  not less than or equal to 99, after setting :attr to ‹"101"›, the
-  matcher expected the Example to be invalid, but it was valid instead.
+          Expected Example to validate that :attr looks like an odd number less
+          than or equal to 99, but this could not be proved.
+            In checking that Example disallows :attr from being a number that is
+            not less than or equal to 99, after setting :attr to ‹"101"›, the
+            matcher expected the Example to be invalid, but it was valid instead.
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -1822,16 +1822,16 @@ than or equal to 99, but this could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr looks like an odd number less
-than or equal to 99, but this could not be proved.
-  In checking that Example disallows :attr from being a number that is
-  not less than or equal to 99, after setting :attr to ‹"101"›, the
-  matcher expected the Example to be invalid and to produce the
-  validation error "must be less than or equal to 99" on :attr. The
-  record was indeed invalid, but it produced these validation errors
-  instead:
+          Expected Example to validate that :attr looks like an odd number less
+          than or equal to 99, but this could not be proved.
+            In checking that Example disallows :attr from being a number that is
+            not less than or equal to 99, after setting :attr to ‹"101"›, the
+            matcher expected the Example to be invalid and to produce the
+            validation error "must be less than or equal to 99" on :attr. The
+            record was indeed invalid, but it produced these validation errors
+            instead:
 
-  * attr: ["must be less than or equal to 97"]
+            * attr: ["must be less than or equal to 97"]
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -1853,15 +1853,15 @@ than or equal to 99, but this could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr looks like an integer greater
-than 18 and less than 99, but this could not be proved.
-  In checking that Example disallows :attr from being a number that is
-  not greater than 18, after setting :attr to ‹"18"›, the matcher
-  expected the Example to be invalid and to produce the validation error
-  "must be greater than 18" on :attr. The record was indeed invalid, but
-  it produced these validation errors instead:
+          Expected Example to validate that :attr looks like an integer greater
+          than 18 and less than 99, but this could not be proved.
+            In checking that Example disallows :attr from being a number that is
+            not greater than 18, after setting :attr to ‹"18"›, the matcher
+            expected the Example to be invalid and to produce the validation error
+            "must be greater than 18" on :attr. The record was indeed invalid, but
+            it produced these validation errors instead:
 
-  * attr: ["must be greater than 19"]
+            * attr: ["must be greater than 19"]
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -1883,15 +1883,15 @@ than 18 and less than 99, but this could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr looks like an integer greater
-than 18 and less than 99, but this could not be proved.
-  In checking that Example disallows :attr from being a number that is
-  not less than 99, after setting :attr to ‹"100"›, the matcher expected
-  the Example to be invalid and to produce the validation error "must be
-  less than 99" on :attr. The record was indeed invalid, but it produced
-  these validation errors instead:
+          Expected Example to validate that :attr looks like an integer greater
+          than 18 and less than 99, but this could not be proved.
+            In checking that Example disallows :attr from being a number that is
+            not less than 99, after setting :attr to ‹"100"›, the matcher expected
+            the Example to be invalid and to produce the validation error "must be
+            less than 99" on :attr. The record was indeed invalid, but it produced
+            these validation errors instead:
 
-  * attr: ["must be less than 100"]
+            * attr: ["must be less than 100"]
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -1964,16 +1964,16 @@ than 18 and less than 99, but this could not be proved.
           attribute_name: :attr,
           changing_values_with: :numeric_value,
           expected_message: <<-MESSAGE.strip,
-Expected Example to validate that :attr looks like a number, but this
-could not be proved.
-  After setting :attr to ‹"abcd"› -- which was read back as ‹"1"› -- the
-  matcher expected the Example to be invalid, but it was valid instead.
+            Expected Example to validate that :attr looks like a number, but this
+            could not be proved.
+              After setting :attr to ‹"abcd"› -- which was read back as ‹"1"› -- the
+              matcher expected the Example to be invalid, but it was valid instead.
 
-  As indicated in the message above, :attr seems to be changing certain
-  values as they are set, and this could have something to do with why
-  this test is failing. If you've overridden the writer method for this
-  attribute, then you may need to change it to make this test pass, or
-  do something else entirely.
+              As indicated in the message above, :attr seems to be changing certain
+              values as they are set, and this could have something to do with why
+              this test is failing. If you've overridden the writer method for this
+              attribute, then you may need to change it to make this test pass, or
+              do something else entirely.
           MESSAGE
         },
       },
@@ -2093,13 +2093,13 @@ could not be proved.
           end
 
           expect(&assertion).to fail_with_message(<<~MESSAGE)
-  Expected Example not to validate that :attr looks like a number from ‹1›
-  to ‹10›, but this could not be proved.
-    After setting :attr to ‹"abcd"›, the matcher expected the Example to
-    be valid, but it was invalid instead, producing these validation
-    errors:
+            Expected Example not to validate that :attr looks like a number from ‹1›
+            to ‹10›, but this could not be proved.
+              After setting :attr to ‹"abcd"›, the matcher expected the Example to
+              be valid, but it was invalid instead, producing these validation
+              errors:
 
-    * attr: ["is not a number"]
+              * attr: ["is not a number"]
           MESSAGE
         end
 
@@ -2111,19 +2111,19 @@ could not be proved.
               attribute_name: :attr,
               changing_values_with: :next_value,
               expected_message: <<-MESSAGE.strip,
-Expected Example to validate that :attr looks like a number from ‹1› to
-‹10›, but this could not be proved.
-  After setting :attr to ‹"10"› -- which was read back as ‹"11"› -- the
-  matcher expected the Example to be valid, but it was invalid instead,
-  producing these validation errors:
+                Expected Example to validate that :attr looks like a number from ‹1› to
+                ‹10›, but this could not be proved.
+                  After setting :attr to ‹"10"› -- which was read back as ‹"11"› -- the
+                  matcher expected the Example to be valid, but it was invalid instead,
+                  producing these validation errors:
 
-  * attr: ["must be in 1..10"]
+                  * attr: ["must be in 1..10"]
 
-  As indicated in the message above, :attr seems to be changing certain
-  values as they are set, and this could have something to do with why
-  this test is failing. If you've overridden the writer method for this
-  attribute, then you may need to change it to make this test pass, or
-  do something else entirely.
+                  As indicated in the message above, :attr seems to be changing certain
+                  values as they are set, and this could have something to do with why
+                  this test is failing. If you've overridden the writer method for this
+                  attribute, then you may need to change it to make this test pass, or
+                  do something else entirely.
               MESSAGE
             },
           },
@@ -2199,10 +2199,10 @@ Expected Example to validate that :attr looks like a number from ‹1› to
           end
 
           message = <<-MESSAGE
-Expected Example to validate that :attr looks like a number from ‹1› to
-‹10›, but this could not be proved.
-  After setting :attr to ‹"11"›, the matcher expected the Example to be
-  invalid, but it was valid instead.
+            Expected Example to validate that :attr looks like a number from ‹1› to
+            ‹10›, but this could not be proved.
+              After setting :attr to ‹"11"›, the matcher expected the Example to be
+              invalid, but it was valid instead.
           MESSAGE
 
           expect(&assertion).to fail_with_message(message)

--- a/spec/unit/shoulda/matchers/active_model/validate_presence_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_presence_of_matcher_spec.rb
@@ -23,17 +23,17 @@ describe Shoulda::Matchers::ActiveModel::ValidatePresenceOfMatcher, type: :model
           attribute_name: :attr,
           changing_values_with: :never_falsy,
           expected_message: <<-MESSAGE,
-Expected Example to validate that :attr cannot be empty/falsy, but this
-could not be proved.
-  After setting :attr to ‹nil› -- which was read back as ‹"dummy value"›
-  -- the matcher expected the Example to be invalid, but it was valid
-  instead.
+            Expected Example to validate that :attr cannot be empty/falsy, but this
+            could not be proved.
+              After setting :attr to ‹nil› -- which was read back as ‹"dummy value"›
+              -- the matcher expected the Example to be invalid, but it was valid
+              instead.
 
-  As indicated in the message above, :attr seems to be changing certain
-  values as they are set, and this could have something to do with why
-  this test is failing. If you've overridden the writer method for this
-  attribute, then you may need to change it to make this test pass, or
-  do something else entirely.
+              As indicated in the message above, :attr seems to be changing certain
+              values as they are set, and this could have something to do with why
+              this test is failing. If you've overridden the writer method for this
+              attribute, then you may need to change it to make this test pass, or
+              do something else entirely.
           MESSAGE
         },
       },
@@ -45,12 +45,12 @@ could not be proved.
       end
 
       message = <<-MESSAGE
-Expected Example not to validate that :attr cannot be empty/falsy, but
-this could not be proved.
-  After setting :attr to ‹nil›, the matcher expected the Example to be
-  valid, but it was invalid instead, producing these validation errors:
+        Expected Example not to validate that :attr cannot be empty/falsy, but
+        this could not be proved.
+          After setting :attr to ‹nil›, the matcher expected the Example to be
+          valid, but it was invalid instead, producing these validation errors:
 
-  * attr: ["can't be blank"]
+          * attr: ["can't be blank"]
       MESSAGE
 
       expect(&assertion).to fail_with_message(message)
@@ -179,10 +179,10 @@ this could not be proved.
         end
 
       message = <<-MESSAGE
-Expected Example to validate that :attr cannot be empty/falsy, but this
-could not be proved.
-  After setting :attr to ‹#{blank_value.inspect}›, the matcher expected the Example to be
-  invalid, but it was valid instead.
+        Expected Example to validate that :attr cannot be empty/falsy, but this
+        could not be proved.
+          After setting :attr to ‹#{blank_value.inspect}›, the matcher expected the Example to be
+          invalid, but it was valid instead.
       MESSAGE
 
       expect(&assertion).to fail_with_message(message)
@@ -209,17 +209,17 @@ could not be proved.
           attribute_name: :attr,
           changing_values_with: :never_falsy,
           expected_message: <<-MESSAGE,
-Expected Example to validate that :attr cannot be empty/falsy, but this
-could not be proved.
-  After setting :attr to ‹nil› -- which was read back as ‹"dummy value"›
-  -- the matcher expected the Example to be invalid, but it was valid
-  instead.
+            Expected Example to validate that :attr cannot be empty/falsy, but this
+            could not be proved.
+              After setting :attr to ‹nil› -- which was read back as ‹"dummy value"›
+              -- the matcher expected the Example to be invalid, but it was valid
+              instead.
 
-  As indicated in the message above, :attr seems to be changing certain
-  values as they are set, and this could have something to do with why
-  this test is failing. If you've overridden the writer method for this
-  attribute, then you may need to change it to make this test pass, or
-  do something else entirely.
+              As indicated in the message above, :attr seems to be changing certain
+              values as they are set, and this could have something to do with why
+              this test is failing. If you've overridden the writer method for this
+              attribute, then you may need to change it to make this test pass, or
+              do something else entirely.
           MESSAGE
         },
       },
@@ -285,10 +285,10 @@ could not be proved.
       end
 
       message = <<-MESSAGE
-Expected Example to validate that :attr cannot be empty/falsy, but this
-could not be proved.
-  After setting :attr to ‹nil›, the matcher expected the Example to be
-  invalid, but it was valid instead.
+        Expected Example to validate that :attr cannot be empty/falsy, but this
+        could not be proved.
+          After setting :attr to ‹nil›, the matcher expected the Example to be
+          invalid, but it was valid instead.
       MESSAGE
 
       expect(&assertion).to fail_with_message(message)
@@ -312,17 +312,17 @@ could not be proved.
             attribute_name: :attr,
             changing_values_with: :never_falsy,
             expected_message: <<-MESSAGE,
-Expected Example to validate that :attr cannot be empty/falsy, but this
-could not be proved.
-  After setting :attr to ‹nil› -- which was read back as ‹"dummy value"›
-  -- the matcher expected the Example to be invalid, but it was valid
-  instead.
+              Expected Example to validate that :attr cannot be empty/falsy, but this
+              could not be proved.
+                After setting :attr to ‹nil› -- which was read back as ‹"dummy value"›
+                -- the matcher expected the Example to be invalid, but it was valid
+                instead.
 
-  As indicated in the message above, :attr seems to be changing certain
-  values as they are set, and this could have something to do with why
-  this test is failing. If you've overridden the writer method for this
-  attribute, then you may need to change it to make this test pass, or
-  do something else entirely.
+                As indicated in the message above, :attr seems to be changing certain
+                values as they are set, and this could have something to do with why
+                this test is failing. If you've overridden the writer method for this
+                attribute, then you may need to change it to make this test pass, or
+                do something else entirely.
             MESSAGE
           },
         },
@@ -352,17 +352,17 @@ could not be proved.
             attribute_name: :attr,
             changing_values_with: :never_falsy,
             expected_message: <<-MESSAGE,
-Expected Example to validate that :attr cannot be empty/falsy, but this
-could not be proved.
-  After setting :attr to ‹nil› -- which was read back as ‹"dummy value"›
-  -- the matcher expected the Example to be invalid, but it was valid
-  instead.
+              Expected Example to validate that :attr cannot be empty/falsy, but this
+              could not be proved.
+                After setting :attr to ‹nil› -- which was read back as ‹"dummy value"›
+                -- the matcher expected the Example to be invalid, but it was valid
+                instead.
 
-  As indicated in the message above, :attr seems to be changing certain
-  values as they are set, and this could have something to do with why
-  this test is failing. If you've overridden the writer method for this
-  attribute, then you may need to change it to make this test pass, or
-  do something else entirely.
+                As indicated in the message above, :attr seems to be changing certain
+                values as they are set, and this could have something to do with why
+                this test is failing. If you've overridden the writer method for this
+                attribute, then you may need to change it to make this test pass, or
+                do something else entirely.
             MESSAGE
           },
         },
@@ -393,17 +393,17 @@ could not be proved.
           attribute_name: :attr,
           changing_values_with: :never_falsy,
           expected_message: <<-MESSAGE,
-Expected Example to validate that :attr cannot be empty/falsy, but this
-could not be proved.
-  After setting :attr to ‹nil› -- which was read back as ‹"dummy value"›
-  -- the matcher expected the Example to be invalid, but it was valid
-  instead.
+            Expected Example to validate that :attr cannot be empty/falsy, but this
+            could not be proved.
+              After setting :attr to ‹nil› -- which was read back as ‹"dummy value"›
+              -- the matcher expected the Example to be invalid, but it was valid
+              instead.
 
-  As indicated in the message above, :attr seems to be changing certain
-  values as they are set, and this could have something to do with why
-  this test is failing. If you've overridden the writer method for this
-  attribute, then you may need to change it to make this test pass, or
-  do something else entirely.
+              As indicated in the message above, :attr seems to be changing certain
+              values as they are set, and this could have something to do with why
+              this test is failing. If you've overridden the writer method for this
+              attribute, then you may need to change it to make this test pass, or
+              do something else entirely.
           MESSAGE
         },
       },
@@ -452,17 +452,17 @@ could not be proved.
           attribute_name: :attr,
           changing_values_with: :never_falsy,
           expected_message: <<-MESSAGE,
-Expected Example to validate that :attr cannot be empty/falsy, but this
-could not be proved.
-  After setting :attr to ‹nil› -- which was read back as ‹"dummy value"›
-  -- the matcher expected the Example to be invalid, but it was valid
-  instead.
+            Expected Example to validate that :attr cannot be empty/falsy, but this
+            could not be proved.
+              After setting :attr to ‹nil› -- which was read back as ‹"dummy value"›
+              -- the matcher expected the Example to be invalid, but it was valid
+              instead.
 
-  As indicated in the message above, :attr seems to be changing certain
-  values as they are set, and this could have something to do with why
-  this test is failing. If you've overridden the writer method for this
-  attribute, then you may need to change it to make this test pass, or
-  do something else entirely.
+              As indicated in the message above, :attr seems to be changing certain
+              values as they are set, and this could have something to do with why
+              this test is failing. If you've overridden the writer method for this
+              attribute, then you may need to change it to make this test pass, or
+              do something else entirely.
           MESSAGE
         },
       },
@@ -491,10 +491,10 @@ could not be proved.
       end
 
       message = <<-MESSAGE
-Expected Parent to validate that :children cannot be empty/falsy, but
-this could not be proved.
-  After setting :children to ‹[]›, the matcher expected the Parent to be
-  invalid, but it was valid instead.
+        Expected Parent to validate that :children cannot be empty/falsy, but
+        this could not be proved.
+          After setting :children to ‹[]›, the matcher expected the Parent to be
+          invalid, but it was valid instead.
       MESSAGE
 
       expect(&assertion).to fail_with_message(message)
@@ -528,10 +528,10 @@ this could not be proved.
           expect { validate_presence_of(:parent) }.
             not_to match_against(record).
             and_fail_with(<<-MESSAGE)
-Expected Child to validate that :parent cannot be empty/falsy, but this
-could not be proved.
-  After setting :parent to ‹nil›, the matcher expected the Child to be
-  invalid, but it was valid instead.
+              Expected Child to validate that :parent cannot be empty/falsy, but this
+              could not be proved.
+                After setting :parent to ‹nil›, the matcher expected the Child to be
+                invalid, but it was valid instead.
             MESSAGE
         end
       end
@@ -563,26 +563,26 @@ could not be proved.
           expect { validate_presence_of(:parent) }.
             not_to match_against(record).
             and_fail_with(<<-MESSAGE)
-Expected Child to validate that :parent cannot be empty/falsy, but this
-could not be proved.
-  After setting :parent to ‹nil›, the matcher expected the Child to be
-  invalid and to produce the validation error "can't be blank" on
-  :parent. The record was indeed invalid, but it produced these
-  validation errors instead:
+              Expected Child to validate that :parent cannot be empty/falsy, but this
+              could not be proved.
+                After setting :parent to ‹nil›, the matcher expected the Child to be
+                invalid and to produce the validation error "can't be blank" on
+                :parent. The record was indeed invalid, but it produced these
+                validation errors instead:
 
-  * parent: ["must exist"]
+                * parent: ["must exist"]
 
-  You're getting this error because you've instructed your `belongs_to`
-  association to add a presence validation to the attribute. *This*
-  presence validation doesn't use "can't be blank", the usual validation
-  message, but "must exist" instead.
+                You're getting this error because you've instructed your `belongs_to`
+                association to add a presence validation to the attribute. *This*
+                presence validation doesn't use "can't be blank", the usual validation
+                message, but "must exist" instead.
 
-  With that said, did you know that the `belong_to` matcher can test
-  this validation for you? Instead of using `validate_presence_of`, try
-  one of the following instead, depending on your use case:
+                With that said, did you know that the `belong_to` matcher can test
+                this validation for you? Instead of using `validate_presence_of`, try
+                one of the following instead, depending on your use case:
 
-      it { should belong_to(:parent).optional(false) }
-      it { should belong_to(:parent).required(true) }
+                    it { should belong_to(:parent).optional(false) }
+                    it { should belong_to(:parent).required(true) }
             MESSAGE
         end
       end
@@ -614,26 +614,26 @@ could not be proved.
           expect { validate_presence_of(:parent) }.
             not_to match_against(record).
             and_fail_with(<<-MESSAGE)
-Expected Child to validate that :parent cannot be empty/falsy, but this
-could not be proved.
-  After setting :parent to ‹nil›, the matcher expected the Child to be
-  invalid and to produce the validation error "can't be blank" on
-  :parent. The record was indeed invalid, but it produced these
-  validation errors instead:
+              Expected Child to validate that :parent cannot be empty/falsy, but this
+              could not be proved.
+                After setting :parent to ‹nil›, the matcher expected the Child to be
+                invalid and to produce the validation error "can't be blank" on
+                :parent. The record was indeed invalid, but it produced these
+                validation errors instead:
 
-  * parent: ["must exist"]
+                * parent: ["must exist"]
 
-  You're getting this error because you've instructed your `belongs_to`
-  association to add a presence validation to the attribute. *This*
-  presence validation doesn't use "can't be blank", the usual validation
-  message, but "must exist" instead.
+                You're getting this error because you've instructed your `belongs_to`
+                association to add a presence validation to the attribute. *This*
+                presence validation doesn't use "can't be blank", the usual validation
+                message, but "must exist" instead.
 
-  With that said, did you know that the `belong_to` matcher can test
-  this validation for you? Instead of using `validate_presence_of`, try
-  one of the following instead, depending on your use case:
+                With that said, did you know that the `belong_to` matcher can test
+                this validation for you? Instead of using `validate_presence_of`, try
+                one of the following instead, depending on your use case:
 
-      it { should belong_to(:parent).optional(false) }
-      it { should belong_to(:parent).required(true) }
+                    it { should belong_to(:parent).optional(false) }
+                    it { should belong_to(:parent).required(true) }
             MESSAGE
         end
       end
@@ -665,10 +665,10 @@ could not be proved.
           expect { validate_presence_of(:parent) }.
             not_to match_against(record).
             and_fail_with(<<-MESSAGE)
-Expected Child to validate that :parent cannot be empty/falsy, but this
-could not be proved.
-  After setting :parent to ‹nil›, the matcher expected the Child to be
-  invalid, but it was valid instead.
+              Expected Child to validate that :parent cannot be empty/falsy, but this
+              could not be proved.
+                After setting :parent to ‹nil›, the matcher expected the Child to be
+                invalid, but it was valid instead.
             MESSAGE
         end
       end
@@ -703,25 +703,25 @@ could not be proved.
               expect { validate_presence_of(:parent) }.
                 not_to match_against(record).
                 and_fail_with(<<-MESSAGE)
-Expected Child to validate that :parent cannot be empty/falsy, but this
-could not be proved.
-  After setting :parent to ‹nil›, the matcher expected the Child to be
-  invalid and to produce the validation error "can't be blank" on
-  :parent. The record was indeed invalid, but it produced these
-  validation errors instead:
+                  Expected Child to validate that :parent cannot be empty/falsy, but this
+                  could not be proved.
+                    After setting :parent to ‹nil›, the matcher expected the Child to be
+                    invalid and to produce the validation error "can't be blank" on
+                    :parent. The record was indeed invalid, but it produced these
+                    validation errors instead:
 
-  * parent: ["must exist"]
+                    * parent: ["must exist"]
 
-  You're getting this error because ActiveRecord is configured to add a
-  presence validation to all `belongs_to` associations, and this
-  includes yours. *This* presence validation doesn't use "can't be
-  blank", the usual validation message, but "must exist" instead.
+                    You're getting this error because ActiveRecord is configured to add a
+                    presence validation to all `belongs_to` associations, and this
+                    includes yours. *This* presence validation doesn't use "can't be
+                    blank", the usual validation message, but "must exist" instead.
 
-  With that said, did you know that the `belong_to` matcher can test
-  this validation for you? Instead of using `validate_presence_of`, try
-  the following instead:
+                    With that said, did you know that the `belong_to` matcher can test
+                    this validation for you? Instead of using `validate_presence_of`, try
+                    the following instead:
 
-      it { should belong_to(:parent) }
+                        it { should belong_to(:parent) }
                 MESSAGE
             end
           end
@@ -756,10 +756,10 @@ could not be proved.
               expect { validate_presence_of(:parent) }.
                 not_to match_against(record).
                 and_fail_with(<<-MESSAGE)
-Expected Child to validate that :parent cannot be empty/falsy, but this
-could not be proved.
-  After setting :parent to ‹nil›, the matcher expected the Child to be
-  invalid, but it was valid instead.
+                  Expected Child to validate that :parent cannot be empty/falsy, but this
+                  could not be proved.
+                    After setting :parent to ‹nil›, the matcher expected the Child to be
+                    invalid, but it was valid instead.
                 MESSAGE
             end
           end
@@ -829,11 +829,11 @@ could not be proved.
         end
 
       message = <<-MESSAGE
-Expected Example to validate that :attr cannot be empty/falsy, raising a
-validation exception on failure, but this could not be proved.
-  After setting :attr to ‹#{blank_value.inspect}›, the matcher expected the Example to be
-  invalid and to raise a validation exception, but the record produced
-  validation errors instead.
+        Expected Example to validate that :attr cannot be empty/falsy, raising a
+        validation exception on failure, but this could not be proved.
+          After setting :attr to ‹#{blank_value.inspect}›, the matcher expected the Example to be
+          invalid and to raise a validation exception, but the record produced
+          validation errors instead.
       MESSAGE
 
       expect(&assertion).to fail_with_message(message)
@@ -910,19 +910,19 @@ validation exception on failure, but this could not be proved.
 
           if active_model_supports_full_attributes_api?
             expect(&assertion).to fail_with_message(<<-MESSAGE)
-Expected Example not to validate that :attr cannot be empty/falsy, but
-this could not be proved.
-  After setting :attr to ‹""›, the matcher expected the Example to be
-  valid, but it was invalid instead, producing these validation errors:
+              Expected Example not to validate that :attr cannot be empty/falsy, but
+              this could not be proved.
+                After setting :attr to ‹""›, the matcher expected the Example to be
+                valid, but it was invalid instead, producing these validation errors:
 
-  * attr: ["can't be blank"]
+                * attr: ["can't be blank"]
             MESSAGE
           else
             expect(&assertion).to fail_with_message(<<-MESSAGE)
-Expected Example not to validate that :attr cannot be empty/falsy, but
-this could not be proved.
-  After setting :attr to ‹nil›, the matcher expected the Example to be
-  invalid, but it was valid instead.
+              Expected Example not to validate that :attr cannot be empty/falsy, but
+              this could not be proved.
+                After setting :attr to ‹nil›, the matcher expected the Example to be
+                invalid, but it was valid instead.
             MESSAGE
           end
         end
@@ -937,12 +937,12 @@ this could not be proved.
           end
 
           message = <<-MESSAGE
-Expected Example to validate that :attr cannot be empty/falsy, but this
-could not be proved.
-  After setting :attr to ‹nil›, the matcher expected the Example to be
-  valid, but it was invalid instead, producing these validation errors:
+            Expected Example to validate that :attr cannot be empty/falsy, but this
+            could not be proved.
+              After setting :attr to ‹nil›, the matcher expected the Example to be
+              valid, but it was invalid instead, producing these validation errors:
 
-  * attr: ["can't be blank"]
+              * attr: ["can't be blank"]
           MESSAGE
 
           expect(&assertion).to fail_with_message(message)
@@ -966,10 +966,10 @@ could not be proved.
           end
 
           message = <<-MESSAGE
-Expected Example to validate that :attr cannot be empty/falsy, but this
-could not be proved.
-  After setting :attr to ‹""›, the matcher expected the Example to be
-  invalid, but it was valid instead.
+            Expected Example to validate that :attr cannot be empty/falsy, but this
+            could not be proved.
+              After setting :attr to ‹""›, the matcher expected the Example to be
+              invalid, but it was valid instead.
           MESSAGE
 
           expect(&assertion).to fail_with_message(message)
@@ -995,10 +995,10 @@ could not be proved.
           end
 
           message = <<-MESSAGE
-Expected Example not to validate that :attr cannot be empty/falsy, but
-this could not be proved.
-  After setting :attr to ‹nil›, the matcher expected the Example to be
-  invalid, but it was valid instead.
+            Expected Example not to validate that :attr cannot be empty/falsy, but
+            this could not be proved.
+              After setting :attr to ‹nil›, the matcher expected the Example to be
+              invalid, but it was valid instead.
           MESSAGE
 
           expect(&assertion).to fail_with_message(message)
@@ -1021,10 +1021,10 @@ this could not be proved.
           assertion = -> { expect(record).not_to matcher.allow_blank }
 
           expect(&assertion).to fail_with_message(<<-MESSAGE)
-Expected Example not to validate that :attr cannot be empty/falsy, but
-this could not be proved.
-  After setting :attr to ‹""›, the matcher expected the Example to be
-  invalid, but it was valid instead.
+            Expected Example not to validate that :attr cannot be empty/falsy, but
+            this could not be proved.
+              After setting :attr to ‹""›, the matcher expected the Example to be
+              invalid, but it was valid instead.
           MESSAGE
         end
       end
@@ -1038,12 +1038,12 @@ this could not be proved.
           end
 
           message = <<-MESSAGE
-Expected Example to validate that :attr cannot be empty/falsy, but this
-could not be proved.
-  After setting :attr to ‹""›, the matcher expected the Example to be
-  valid, but it was invalid instead, producing these validation errors:
+            Expected Example to validate that :attr cannot be empty/falsy, but this
+            could not be proved.
+              After setting :attr to ‹""›, the matcher expected the Example to be
+              valid, but it was invalid instead, producing these validation errors:
 
-  * attr: ["can't be blank"]
+              * attr: ["can't be blank"]
           MESSAGE
 
           expect(&assertion).to fail_with_message(message)
@@ -1072,10 +1072,10 @@ could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example not to validate that :attr cannot be empty/falsy, but
-this could not be proved.
-  After setting :attr to ‹""›, the matcher expected the Example to be
-  invalid, but it was valid instead.
+          Expected Example not to validate that :attr cannot be empty/falsy, but
+          this could not be proved.
+            After setting :attr to ‹""›, the matcher expected the Example to be
+            invalid, but it was valid instead.
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)

--- a/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -783,7 +783,7 @@ describe Shoulda::Matchers::ActiveRecord::AssociationMatcher, type: :model do
       end
 
       expect { have_many(:children) }.not_to match_against(parent_class.new).and_fail_with(<<-MESSAGE)
-Expected Parent to have a has_many association called children through conceptions (Could not find the source association(s) "child" or :children in model Conception. Try 'has_many :children, :through => :conceptions, :source => <name>'. Is it one of ?)
+        Expected Parent to have a has_many association called children through conceptions (Could not find the source association(s) "child" or :children in model Conception. Try 'has_many :children, :through => :conceptions, :source => <name>'. Is it one of ?)
       MESSAGE
     end
 
@@ -1583,8 +1583,8 @@ Expected Parent to have a has_many association called children through conceptio
                   expect(&build_matcher).
                     to match_against(Person.new).
                     or_fail_with(<<-MESSAGE)
-Did not expect Person to have a has_and_belongs_to_many association called relatives
-                  MESSAGE
+                      Did not expect Person to have a has_and_belongs_to_many association called relatives
+                    MESSAGE
                 end
               end
 
@@ -1634,8 +1634,8 @@ Expected Person to have a has_and_belongs_to_many association called relatives (
                 expect(&build_matcher).
                   not_to match_against(Person.new).
                   and_fail_with(<<-MESSAGE)
-Expected Person to have a has_and_belongs_to_many association called relatives (relatives should use :family_tree for :join_table option)
-                MESSAGE
+                    Expected Person to have a has_and_belongs_to_many association called relatives (relatives should use :family_tree for :join_table option)
+                  MESSAGE
               end
             end
           end
@@ -1663,7 +1663,7 @@ Expected Person to have a has_and_belongs_to_many association called relatives (
               expect(&build_matcher).
                 not_to match_against(Person.new).
                 and_fail_with(<<-MESSAGE)
-Expected Person to have a has_and_belongs_to_many association called relatives (relatives should use :family_tree for :join_table option)
+                  Expected Person to have a has_and_belongs_to_many association called relatives (relatives should use :family_tree for :join_table option)
                 MESSAGE
             end
           end
@@ -1689,7 +1689,7 @@ Expected Person to have a has_and_belongs_to_many association called relatives (
             expect(&build_matcher).
               not_to match_against(Person.new).
               and_fail_with(<<-MESSAGE)
-Expected Person to have a has_and_belongs_to_many association called relatives (relatives should use :family_tree for :join_table option)
+                Expected Person to have a has_and_belongs_to_many association called relatives (relatives should use :family_tree for :join_table option)
               MESSAGE
           end
         end
@@ -1723,8 +1723,8 @@ Expected Person to have a has_and_belongs_to_many association called relatives (
                   expect(&build_matcher).
                     to match_against(Person.new).
                     or_fail_with(<<-MESSAGE)
-Did not expect Person to have a has_and_belongs_to_many association called relatives
-                  MESSAGE
+                      Did not expect Person to have a has_and_belongs_to_many association called relatives
+                    MESSAGE
                 end
               end
 
@@ -1749,8 +1749,8 @@ Did not expect Person to have a has_and_belongs_to_many association called relat
                   expect(&build_matcher).
                     not_to match_against(Person.new).
                     and_fail_with(<<-MESSAGE)
-Expected Person to have a has_and_belongs_to_many association called relatives (join table people_and_their_families missing columns: person_id, relative_id)
-                  MESSAGE
+                      Expected Person to have a has_and_belongs_to_many association called relatives (join table people_and_their_families missing columns: person_id, relative_id)
+                    MESSAGE
                 end
               end
             end
@@ -1774,8 +1774,8 @@ Expected Person to have a has_and_belongs_to_many association called relatives (
                 expect(&build_matcher).
                   not_to match_against(Person.new).
                   and_fail_with(<<-MESSAGE)
-Expected Person to have a has_and_belongs_to_many association called relatives (relatives should use "family_tree" for :join_table option)
-                MESSAGE
+                    Expected Person to have a has_and_belongs_to_many association called relatives (relatives should use "family_tree" for :join_table option)
+                  MESSAGE
               end
             end
           end
@@ -1803,7 +1803,7 @@ Expected Person to have a has_and_belongs_to_many association called relatives (
               expect(&build_matcher).
                 not_to match_against(Person.new).
                 and_fail_with(<<-MESSAGE)
-Expected Person to have a has_and_belongs_to_many association called relatives (relatives should use "family_tree" for :join_table option)
+                  Expected Person to have a has_and_belongs_to_many association called relatives (relatives should use "family_tree" for :join_table option)
                 MESSAGE
             end
           end
@@ -1829,7 +1829,7 @@ Expected Person to have a has_and_belongs_to_many association called relatives (
             expect(&build_matcher).
               not_to match_against(Person.new).
               and_fail_with(<<-MESSAGE)
-Expected Person to have a has_and_belongs_to_many association called relatives (relatives should use "family_tree" for :join_table option)
+                Expected Person to have a has_and_belongs_to_many association called relatives (relatives should use "family_tree" for :join_table option)
               MESSAGE
           end
         end
@@ -1859,8 +1859,8 @@ Expected Person to have a has_and_belongs_to_many association called relatives (
             expect(&build_matcher).
               to match_against(Person.new).
               or_fail_with(<<-MESSAGE)
-Did not expect Person to have a has_and_belongs_to_many association called relatives
-            MESSAGE
+                Did not expect Person to have a has_and_belongs_to_many association called relatives
+              MESSAGE
           end
         end
 
@@ -1882,8 +1882,8 @@ Did not expect Person to have a has_and_belongs_to_many association called relat
             expect(&build_matcher).
               not_to match_against(Person.new).
               and_fail_with(<<-MESSAGE)
-Expected Person to have a has_and_belongs_to_many association called relatives (join table people_and_their_families missing columns: person_id, relative_id)
-            MESSAGE
+                Expected Person to have a has_and_belongs_to_many association called relatives (join table people_and_their_families missing columns: person_id, relative_id)
+              MESSAGE
           end
         end
       end
@@ -1904,8 +1904,8 @@ Expected Person to have a has_and_belongs_to_many association called relatives (
           expect(&build_matcher).
             not_to match_against(Person.new).
             and_fail_with(<<-MESSAGE)
-Expected Person to have a has_and_belongs_to_many association called relatives (join table people_and_their_families doesn't exist)
-          MESSAGE
+              Expected Person to have a has_and_belongs_to_many association called relatives (join table people_and_their_families doesn't exist)
+            MESSAGE
         end
       end
     end

--- a/spec/unit/shoulda/matchers/active_record/have_attached_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/have_attached_matcher_spec.rb
@@ -16,8 +16,8 @@ describe Shoulda::Matchers::ActiveRecord::HaveAttachedMatcher, type: :model do
         expect { have_one_attached(:avatar) }.
           to match_against(record).
           or_fail_with(<<-MESSAGE)
-Did not expect User to have a has_one_attached called avatar, but it does.
-        MESSAGE
+            Did not expect User to have a has_one_attached called avatar, but it does.
+          MESSAGE
       end
 
       context 'and the reader attribute does not exist' do
@@ -26,9 +26,9 @@ Did not expect User to have a has_one_attached called avatar, but it does.
           expect { have_one_attached(:avatar) }.
             not_to match_against(record).
             and_fail_with(<<-MESSAGE)
-Expected User to have a has_one_attached called avatar, but this could not be proved.
-  User does not have a :avatar method.
-          MESSAGE
+              Expected User to have a has_one_attached called avatar, but this could not be proved.
+              User does not have a :avatar method.
+            MESSAGE
         end
       end
 
@@ -38,9 +38,9 @@ Expected User to have a has_one_attached called avatar, but this could not be pr
           expect { have_one_attached(:avatar) }.
             not_to match_against(record).
             and_fail_with(<<-MESSAGE)
-Expected User to have a has_one_attached called avatar, but this could not be proved.
-  User does not have a :avatar= method.
-          MESSAGE
+              Expected User to have a has_one_attached called avatar, but this could not be proved.
+              User does not have a :avatar= method.
+            MESSAGE
         end
       end
 
@@ -50,9 +50,9 @@ Expected User to have a has_one_attached called avatar, but this could not be pr
           expect { have_one_attached(:avatar) }.
             not_to match_against(record).
             and_fail_with(<<-MESSAGE)
-Expected User to have a has_one_attached called avatar, but this could not be proved.
-  Expected User to have a has_one association called avatar_attachment (no association called avatar_attachment)
-          MESSAGE
+              Expected User to have a has_one_attached called avatar, but this could not be proved.
+              Expected User to have a has_one association called avatar_attachment (no association called avatar_attachment)
+            MESSAGE
         end
       end
 
@@ -62,9 +62,9 @@ Expected User to have a has_one_attached called avatar, but this could not be pr
           expect { have_one_attached(:avatar) }.
             not_to match_against(record).
             and_fail_with(<<-MESSAGE)
-Expected User to have a has_one_attached called avatar, but this could not be proved.
-  Expected User to have a has_one association called avatar_blob through avatar_attachment (avatar_blob should resolve to ActiveStorage::Blob for class_name)
-          MESSAGE
+              Expected User to have a has_one_attached called avatar, but this could not be proved.
+              Expected User to have a has_one association called avatar_blob through avatar_attachment (avatar_blob should resolve to ActiveStorage::Blob for class_name)
+            MESSAGE
         end
       end
 
@@ -74,9 +74,9 @@ Expected User to have a has_one_attached called avatar, but this could not be pr
           expect { have_one_attached(:avatar) }.
             not_to match_against(record).
             and_fail_with <<-MESSAGE
-Expected User to have a has_one_attached called avatar, but this could not be proved.
-  User does not have a :with_attached_avatar scope.
-          MESSAGE
+              Expected User to have a has_one_attached called avatar, but this could not be proved.
+              User does not have a :with_attached_avatar scope.
+            MESSAGE
         end
       end
     end
@@ -97,8 +97,8 @@ Expected User to have a has_one_attached called avatar, but this could not be pr
         expect { have_many_attached(:avatars) }.
           to match_against(record).
           or_fail_with(<<-MESSAGE)
-Did not expect User to have a has_many_attached called avatars, but it does.
-        MESSAGE
+            Did not expect User to have a has_many_attached called avatars, but it does.
+          MESSAGE
       end
 
       context 'and the reader attribute does not exist' do
@@ -107,9 +107,9 @@ Did not expect User to have a has_many_attached called avatars, but it does.
           expect { have_many_attached(:avatars) }.
             not_to match_against(record).
             and_fail_with(<<-MESSAGE)
-Expected User to have a has_many_attached called avatars, but this could not be proved.
-  User does not have a :avatars method.
-          MESSAGE
+              Expected User to have a has_many_attached called avatars, but this could not be proved.
+              User does not have a :avatars method.
+            MESSAGE
         end
       end
 
@@ -119,9 +119,9 @@ Expected User to have a has_many_attached called avatars, but this could not be 
           expect { have_many_attached(:avatars) }.
             not_to match_against(record).
             and_fail_with(<<-MESSAGE)
-Expected User to have a has_many_attached called avatars, but this could not be proved.
-  User does not have a :avatars= method.
-          MESSAGE
+              Expected User to have a has_many_attached called avatars, but this could not be proved.
+              User does not have a :avatars= method.
+            MESSAGE
         end
       end
 
@@ -131,9 +131,9 @@ Expected User to have a has_many_attached called avatars, but this could not be 
           expect { have_many_attached(:avatars) }.
             not_to match_against(record).
             and_fail_with(<<-MESSAGE)
-Expected User to have a has_many_attached called avatars, but this could not be proved.
-  Expected User to have a has_many association called avatars_attachments (no association called avatars_attachments)
-          MESSAGE
+              Expected User to have a has_many_attached called avatars, but this could not be proved.
+              Expected User to have a has_many association called avatars_attachments (no association called avatars_attachments)
+            MESSAGE
         end
       end
 
@@ -143,9 +143,9 @@ Expected User to have a has_many_attached called avatars, but this could not be 
           expect { have_many_attached(:avatars) }.
             not_to match_against(record).
             and_fail_with(<<-MESSAGE)
-Expected User to have a has_many_attached called avatars, but this could not be proved.
-  Expected User to have a has_many association called avatars_blobs through avatars_attachments (avatars_blobs should resolve to ActiveStorage::Blob for class_name)
-          MESSAGE
+              Expected User to have a has_many_attached called avatars, but this could not be proved.
+              Expected User to have a has_many association called avatars_blobs through avatars_attachments (avatars_blobs should resolve to ActiveStorage::Blob for class_name)
+            MESSAGE
         end
       end
 
@@ -155,9 +155,9 @@ Expected User to have a has_many_attached called avatars, but this could not be 
           expect { have_many_attached(:avatars) }.
             not_to match_against(record).
             and_fail_with(<<-MESSAGE)
-Expected User to have a has_many_attached called avatars, but this could not be proved.
-  User does not have a :with_attached_avatars scope.
-          MESSAGE
+              Expected User to have a has_many_attached called avatars, but this could not be proved.
+              User does not have a :with_attached_avatars scope.
+            MESSAGE
         end
       end
     end
@@ -194,7 +194,7 @@ def record_having_one_attached(
 
     if remove_eager_loading_scope
       instance_eval <<-CODE, __FILE__, __LINE__ + 1
-undef with_attached_#{attached_name}
+        undef with_attached_#{attached_name}
       CODE
     end
   end
@@ -232,7 +232,7 @@ def record_having_many_attached(
 
     if remove_eager_loading_scope
       instance_eval <<-CODE, __FILE__, __LINE__ + 1
-undef with_attached_#{attached_name}
+        undef with_attached_#{attached_name}
       CODE
     end
   end

--- a/spec/unit/shoulda/matchers/active_record/have_db_column_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/have_db_column_matcher_spec.rb
@@ -41,7 +41,7 @@ describe Shoulda::Matchers::ActiveRecord::HaveDbColumnMatcher, type: :model do
       end
 
       message = <<-MESSAGE
-Expected Employee to have db column named superhero of sql_type #{sql_column_type} (Employee does not have a db column named superhero.)
+        Expected Employee to have db column named superhero of sql_type #{sql_column_type} (Employee does not have a db column named superhero.)
       MESSAGE
 
       expect(&assertion).to fail_with_message(message)
@@ -55,7 +55,7 @@ Expected Employee to have db column named superhero of sql_type #{sql_column_typ
       end
 
       message = <<-MESSAGE
-Expected Employee to have db column named nickname of sql_type varchar (Employee has a db column named nickname of sql type #{sql_column_type}, not varchar.)
+        Expected Employee to have db column named nickname of sql_type varchar (Employee has a db column named nickname of sql type #{sql_column_type}, not varchar.)
       MESSAGE
 
       expect(&assertion).to fail_with_message(message)

--- a/spec/unit/shoulda/matchers/active_record/have_db_index_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/have_db_index_matcher_spec.rb
@@ -44,8 +44,8 @@ describe Shoulda::Matchers::ActiveRecord::HaveDbIndexMatcher, type: :model do
             end
 
             expect(&assertion).to fail_with_message(<<-MESSAGE, wrap: true)
-Expected the examples table not to have a #{index_type} index on
-#{index.inspect}, but it does.
+              Expected the examples table not to have a #{index_type} index on
+              #{index.inspect}, but it does.
             MESSAGE
           end
         end
@@ -74,8 +74,8 @@ Expected the examples table not to have a #{index_type} index on
             end
 
             expect(&assertion).to fail_with_message(<<-MESSAGE, wrap: true)
-Expected the examples table to have an index on #{index.inspect} and for it to
-be #{index_type}. The index does exist, but it is #{inverse_description}.
+              Expected the examples table to have an index on #{index.inspect} and for it to
+              be #{index_type}. The index does exist, but it is #{inverse_description}.
             MESSAGE
           end
         end
@@ -95,8 +95,8 @@ be #{index_type}. The index does exist, but it is #{inverse_description}.
           end
 
           expect(&assertion).to fail_with_message(<<-MESSAGE, wrap: true)
-Expected the examples table to have a #{index_type} index on :#{other_index},
-but it does not.
+            Expected the examples table to have a #{index_type} index on :#{other_index},
+            but it does not.
           MESSAGE
         end
 
@@ -124,7 +124,7 @@ but it does not.
               end
 
               expect(&assertion).to fail_with_message(<<-MESSAGE)
-Expected the examples table not to have an index on :age, but it does.
+                Expected the examples table not to have an index on :age, but it does.
               MESSAGE
             end
           end
@@ -137,7 +137,7 @@ Expected the examples table not to have an index on :age, but it does.
               end
 
               expect(&assertion).to fail_with_message(<<-MESSAGE)
-Expected the examples table to have an index on :name, but it does not.
+                Expected the examples table to have an index on :name, but it does not.
               MESSAGE
             end
 
@@ -180,8 +180,8 @@ Expected the examples table to have an index on :name, but it does not.
               end
 
               expect(&assertion).to fail_with_message(<<-MESSAGE)
-Expected the employees table not to have a unique index on :ssn, but it
-does.
+                Expected the employees table not to have a unique index on :ssn, but it
+                does.
               MESSAGE
             end
           end
@@ -232,8 +232,8 @@ does.
             end
 
             expect(&assertion).to fail_with_message(<<-MESSAGE)
-Expected the examples table not to have an index on [:geocodable_id,
-:geocodable_type], but it does.
+              Expected the examples table not to have an index on [:geocodable_id,
+              :geocodable_type], but it does.
             MESSAGE
           end
         end
@@ -249,8 +249,8 @@ Expected the examples table not to have an index on [:geocodable_id,
             end
 
             expect(&assertion).to fail_with_message(<<-MESSAGE)
-Expected the examples table to have an index on [:geocodable_id,
-:geocodable_type], but it does not.
+              Expected the examples table to have an index on [:geocodable_id,
+              :geocodable_type], but it does not.
             MESSAGE
           end
 
@@ -288,8 +288,8 @@ Expected the examples table to have an index on [:geocodable_id,
                 end
 
                 expect(&assertion).to fail_with_message(<<-MESSAGE, wrap: true)
-Expected the examples table not to have an index on "lower((code)::text)", but
-it does.
+                  Expected the examples table not to have an index on "lower((code)::text)", but
+                  it does.
                 MESSAGE
               end
             end
@@ -315,8 +315,8 @@ it does.
                 end
 
                 expect(&assertion).to fail_with_message(<<-MESSAGE, wrap: true)
-Expected the examples table to have an index on "lower((code)::text)", but it
-does not.
+                  Expected the examples table to have an index on "lower((code)::text)", but it
+                  does not.
                 MESSAGE
               end
             end

--- a/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
@@ -82,11 +82,11 @@ describe Shoulda::Matchers::ActiveRecord::ValidateUniquenessOfMatcher, type: :mo
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr is case-sensitively unique
-within the scope of :scope1, :scope2, and :other, but this could not be
-proved.
-  Expected the validation to be scoped to :scope1, :scope2, and :other,
-  but it was scoped to :scope1 and :scope2 instead.
+          Expected Example to validate that :attr is case-sensitively unique
+          within the scope of :scope1, :scope2, and :other, but this could not be
+          proved.
+            Expected the validation to be scoped to :scope1, :scope2, and :other,
+            but it was scoped to :scope1 and :scope2 instead.
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -109,10 +109,10 @@ proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr is case-sensitively unique
-within the scope of :scope1, but this could not be proved.
-  Expected the validation to be scoped to :scope1, but it was scoped to
-  :scope1 and :scope2 instead.
+          Expected Example to validate that :attr is case-sensitively unique
+          within the scope of :scope1, but this could not be proved.
+            Expected the validation to be scoped to :scope1, but it was scoped to
+            :scope1 and :scope2 instead.
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -132,10 +132,10 @@ within the scope of :scope1, but this could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr is case-sensitively unique
-within the scope of :scope, but this could not be proved.
-  Expected the validation to be scoped to :scope, but it was scoped to
-  :other instead.
+          Expected Example to validate that :attr is case-sensitively unique
+          within the scope of :scope, but this could not be proved.
+            Expected the validation to be scoped to :scope, but it was scoped to
+            :other instead.
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -153,10 +153,10 @@ within the scope of :scope, but this could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr is case-sensitively unique, but
-this could not be proved.
-  Expected the validation not to be scoped to anything, but it was
-  scoped to :scope instead.
+          Expected Example to validate that :attr is case-sensitively unique, but
+          this could not be proved.
+            Expected the validation not to be scoped to anything, but it was
+            scoped to :scope instead.
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -173,10 +173,10 @@ this could not be proved.
           end
 
           message = <<-MESSAGE
-Expected Example to validate that :attr is case-sensitively unique, but
-this could not be proved.
-  Expected the validation not to be scoped to anything, but it was
-  scoped to :scope instead.
+            Expected Example to validate that :attr is case-sensitively unique, but
+            this could not be proved.
+              Expected the validation not to be scoped to anything, but it was
+              scoped to :scope instead.
           MESSAGE
 
           expect(&assertion).to fail_with_message(message)
@@ -196,9 +196,9 @@ this could not be proved.
           end
 
           message = <<-MESSAGE.strip
-Expected Example to validate that :attr is case-sensitively unique
-within the scope of :non_existent, but this could not be proved.
-  :non_existent does not seem to be an attribute on Example.
+            Expected Example to validate that :attr is case-sensitively unique
+            within the scope of :non_existent, but this could not be proved.
+              :non_existent does not seem to be an attribute on Example.
           MESSAGE
 
           expect(&assertion).to fail_with_message(message)
@@ -219,11 +219,11 @@ within the scope of :non_existent, but this could not be proved.
           end
 
           message = <<-MESSAGE.strip
-Expected Example to validate that :attr is case-sensitively unique
-within the scope of :non_existent1 and :non_existent2, but this could
-not be proved.
-  :non_existent1 and :non_existent2 do not seem to be attributes on
-  Example.
+            Expected Example to validate that :attr is case-sensitively unique
+            within the scope of :non_existent1 and :non_existent2, but this could
+            not be proved.
+              :non_existent1 and :non_existent2 do not seem to be attributes on
+              Example.
           MESSAGE
 
           expect(&assertion).to fail_with_message(message)
@@ -336,11 +336,11 @@ not be proved.
       end
 
       message = <<-MESSAGE
-Expected Example to validate that :attr is case-sensitively unique, but
-this could not be proved.
-  Given an existing Example whose :attr is ‹"value"›, after making a new
-  Example and setting its :attr to ‹"value"› as well, the matcher
-  expected the new Example to be invalid, but it was valid instead.
+        Expected Example to validate that :attr is case-sensitively unique, but
+        this could not be proved.
+          Given an existing Example whose :attr is ‹"value"›, after making a new
+          Example and setting its :attr to ‹"value"› as well, the matcher
+          expected the new Example to be invalid, but it was valid instead.
       MESSAGE
 
       expect(&assertion).to fail_with_message(message)
@@ -532,10 +532,10 @@ this could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr is case-sensitively unique
-within the scope of :other, but this could not be proved.
-  Expected the validation to be scoped to :other, but it was not scoped
-  to anything.
+          Expected Example to validate that :attr is case-sensitively unique
+          within the scope of :other, but this could not be proved.
+            Expected the validation to be scoped to :other, but it was not scoped
+            to anything.
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -555,16 +555,16 @@ within the scope of :other, but this could not be proved.
           end
 
           message = <<-MESSAGE
-Expected Example to validate that :attr is case-sensitively unique, but
-this could not be proved.
-  After taking the given Example, whose :attr is ‹"some value"›, and
-  saving it as the existing record, then making a new Example and
-  setting its :attr to ‹"some value"› as well, the matcher expected the
-  new Example to be invalid and to produce the validation error "has
-  already been taken" on :attr. The record was indeed invalid, but it
-  produced these validation errors instead:
+            Expected Example to validate that :attr is case-sensitively unique, but
+            this could not be proved.
+              After taking the given Example, whose :attr is ‹"some value"›, and
+              saving it as the existing record, then making a new Example and
+              setting its :attr to ‹"some value"› as well, the matcher expected the
+              new Example to be invalid and to produce the validation error "has
+              already been taken" on :attr. The record was indeed invalid, but it
+              produced these validation errors instead:
 
-  * attr: ["bad value"]
+              * attr: ["bad value"]
           MESSAGE
 
           expect(&assertion).to fail_with_message(message)
@@ -586,17 +586,17 @@ this could not be proved.
             end
 
             message = <<-MESSAGE
-Expected Example to validate that :attr is case-sensitively unique,
-producing a custom validation error on failure, but this could not be
-proved.
-  After taking the given Example, whose :attr is ‹"some value"›, and
-  saving it as the existing record, then making a new Example and
-  setting its :attr to ‹"some value"› as well, the matcher expected the
-  new Example to be invalid and to produce the validation error "some
-  message" on :attr. The record was indeed invalid, but it produced
-  these validation errors instead:
+              Expected Example to validate that :attr is case-sensitively unique,
+              producing a custom validation error on failure, but this could not be
+              proved.
+                After taking the given Example, whose :attr is ‹"some value"›, and
+                saving it as the existing record, then making a new Example and
+                setting its :attr to ‹"some value"› as well, the matcher expected the
+                new Example to be invalid and to produce the validation error "some
+                message" on :attr. The record was indeed invalid, but it produced
+                these validation errors instead:
 
-  * attr: ["something else entirely"]
+                * attr: ["something else entirely"]
             MESSAGE
 
             expect(&assertion).to fail_with_message(message)
@@ -630,17 +630,17 @@ proved.
             end
 
             message = <<-MESSAGE
-Expected Example to validate that :attr is case-sensitively unique,
-producing a custom validation error on failure, but this could not be
-proved.
-  After taking the given Example, whose :attr is ‹"some value"›, and
-  saving it as the existing record, then making a new Example and
-  setting its :attr to ‹"some value"› as well, the matcher expected the
-  new Example to be invalid and to produce a validation error matching
-  ‹/some message/› on :attr. The record was indeed invalid, but it
-  produced these validation errors instead:
+              Expected Example to validate that :attr is case-sensitively unique,
+              producing a custom validation error on failure, but this could not be
+              proved.
+                After taking the given Example, whose :attr is ‹"some value"›, and
+                saving it as the existing record, then making a new Example and
+                setting its :attr to ‹"some value"› as well, the matcher expected the
+                new Example to be invalid and to produce a validation error matching
+                ‹/some message/› on :attr. The record was indeed invalid, but it
+                produced these validation errors instead:
 
-  * attr: ["something else entirely"]
+                * attr: ["something else entirely"]
             MESSAGE
 
             expect(&assertion).to fail_with_message(message)
@@ -669,22 +669,22 @@ proved.
           default_value: 'some value',
           changing_values_with: :next_value,
           expected_message: <<-MESSAGE.strip,
-Expected Example to validate that :attr is case-sensitively unique, but
-this could not be proved.
-  After taking the given Example, whose :attr is ‹"some valuf"›, and
-  saving it as the existing record, then making a new Example and
-  setting its :attr to ‹"some valuf"› (read back as ‹"some valug"›) as
-  well, the matcher expected the new Example to be invalid, but it was
-  valid instead.
+            Expected Example to validate that :attr is case-sensitively unique, but
+            this could not be proved.
+              After taking the given Example, whose :attr is ‹"some valuf"›, and
+              saving it as the existing record, then making a new Example and
+              setting its :attr to ‹"some valuf"› (read back as ‹"some valug"›) as
+              well, the matcher expected the new Example to be invalid, but it was
+              valid instead.
 
-  As indicated in the message above, :attr seems to be changing certain
-  values as they are set, and this could have something to do with why
-  this test is failing. If you or something else has overridden the
-  writer method for this attribute to normalize values by changing their
-  case in any way (for instance, ensuring that the attribute is always
-  downcased), then try adding `ignoring_case_sensitivity` onto the end
-  of the uniqueness matcher. Otherwise, you may need to write the test
-  yourself, or do something different altogether.
+              As indicated in the message above, :attr seems to be changing certain
+              values as they are set, and this could have something to do with why
+              this test is failing. If you or something else has overridden the
+              writer method for this attribute to normalize values by changing their
+              case in any way (for instance, ensuring that the attribute is always
+              downcased), then try adding `ignoring_case_sensitivity` onto the end
+              of the uniqueness matcher. Otherwise, you may need to write the test
+              yourself, or do something different altogether.
 
           MESSAGE
         },
@@ -702,12 +702,12 @@ this could not be proved.
       end
 
       message = <<-MESSAGE
-Expected Example not to validate that :attr is case-sensitively unique,
-but this could not be proved.
-  After taking the given Example, setting its :attr to ‹"x"›, and saving
-  it as the existing record, then making a new Example and setting its
-  :attr to a different value, ‹"X"›, the matcher expected the new
-  Example to be invalid, but it was valid instead.
+        Expected Example not to validate that :attr is case-sensitively unique,
+        but this could not be proved.
+          After taking the given Example, setting its :attr to ‹"x"›, and saving
+          it as the existing record, then making a new Example and setting its
+          :attr to a different value, ‹"X"›, the matcher expected the new
+          Example to be invalid, but it was valid instead.
       MESSAGE
 
       expect(&assertion).to fail_with_message(message)
@@ -784,11 +784,11 @@ but this could not be proved.
             end
 
             message = <<-MESSAGE
-Expected Example to validate that :attr is case-sensitively unique
-within the scope of :scope1, :scope2, and :other, but this could not be
-proved.
-  Expected the validation to be scoped to :scope1, :scope2, and :other,
-  but it was scoped to :scope1 and :scope2 instead.
+              Expected Example to validate that :attr is case-sensitively unique
+              within the scope of :scope1, :scope2, and :other, but this could not be
+              proved.
+                Expected the validation to be scoped to :scope1, :scope2, and :other,
+                but it was scoped to :scope1 and :scope2 instead.
             MESSAGE
 
             expect(&assertion).to fail_with_message(message)
@@ -807,10 +807,10 @@ proved.
             end
 
             message = <<-MESSAGE
-Expected Example to validate that :attr is case-sensitively unique
-within the scope of :scope1, but this could not be proved.
-  Expected the validation to be scoped to :scope1, but it was scoped to
-  :scope1 and :scope2 instead.
+              Expected Example to validate that :attr is case-sensitively unique
+              within the scope of :scope1, but this could not be proved.
+                Expected the validation to be scoped to :scope1, but it was scoped to
+                :scope1 and :scope2 instead.
             MESSAGE
 
             expect(&assertion).to fail_with_message(message)
@@ -914,12 +914,12 @@ within the scope of :scope1, but this could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr is case-insensitively unique,
-but this could not be proved.
-  After taking the given Example, whose :attr is ‹"some value"›, and
-  saving it as the existing record, then making a new Example and
-  setting its :attr to a different value, ‹"SOME VALUE"›, the matcher
-  expected the new Example to be invalid, but it was valid instead.
+          Expected Example to validate that :attr is case-insensitively unique,
+          but this could not be proved.
+            After taking the given Example, whose :attr is ‹"some value"›, and
+            saving it as the existing record, then making a new Example and
+            setting its :attr to a different value, ‹"SOME VALUE"›, the matcher
+            expected the new Example to be invalid, but it was valid instead.
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -940,15 +940,15 @@ but this could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr is case-sensitively unique, but
-this could not be proved.
-  After taking the given Example, setting its :attr to ‹"dummy value"›,
-  and saving it as the existing record, then making a new Example and
-  setting its :attr to a different value, ‹"DUMMY VALUE"›, the matcher
-  expected the new Example to be valid, but it was invalid instead,
-  producing these validation errors:
+          Expected Example to validate that :attr is case-sensitively unique, but
+          this could not be proved.
+            After taking the given Example, setting its :attr to ‹"dummy value"›,
+            and saving it as the existing record, then making a new Example and
+            setting its :attr to a different value, ‹"DUMMY VALUE"›, the matcher
+            expected the new Example to be valid, but it was invalid instead,
+            producing these validation errors:
 
-  * attr: ["has already been taken"]
+            * attr: ["has already been taken"]
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -974,22 +974,22 @@ this could not be proved.
             default_value: 'some value',
             changing_values_with: :next_value,
             expected_message: <<-MESSAGE.strip,
-Expected Example to validate that :attr is case-insensitively unique,
-but this could not be proved.
-  After taking the given Example, whose :attr is ‹"some valuf"›, and
-  saving it as the existing record, then making a new Example and
-  setting its :attr to ‹"some valuf"› (read back as ‹"some valug"›) as
-  well, the matcher expected the new Example to be invalid, but it was
-  valid instead.
+              Expected Example to validate that :attr is case-insensitively unique,
+              but this could not be proved.
+                After taking the given Example, whose :attr is ‹"some valuf"›, and
+                saving it as the existing record, then making a new Example and
+                setting its :attr to ‹"some valuf"› (read back as ‹"some valug"›) as
+                well, the matcher expected the new Example to be invalid, but it was
+                valid instead.
 
-  As indicated in the message above, :attr seems to be changing certain
-  values as they are set, and this could have something to do with why
-  this test is failing. If you or something else has overridden the
-  writer method for this attribute to normalize values by changing their
-  case in any way (for instance, ensuring that the attribute is always
-  downcased), then try adding `ignoring_case_sensitivity` onto the end
-  of the uniqueness matcher. Otherwise, you may need to write the test
-  yourself, or do something different altogether.
+                As indicated in the message above, :attr seems to be changing certain
+                values as they are set, and this could have something to do with why
+                this test is failing. If you or something else has overridden the
+                writer method for this attribute to normalize values by changing their
+                case in any way (for instance, ensuring that the attribute is always
+                downcased), then try adding `ignoring_case_sensitivity` onto the end
+                of the uniqueness matcher. Otherwise, you may need to write the test
+                yourself, or do something different altogether.
             MESSAGE
           },
         },
@@ -1038,14 +1038,14 @@ but this could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr is case-sensitively unique as
-long as it is not nil, but this could not be proved.
-  After taking the given Example, setting its :attr to ‹nil›, and saving
-  it as the existing record, then making a new Example and setting its
-  :attr to ‹nil› as well, the matcher expected the new Example to be
-  valid, but it was invalid instead, producing these validation errors:
+          Expected Example to validate that :attr is case-sensitively unique as
+          long as it is not nil, but this could not be proved.
+            After taking the given Example, setting its :attr to ‹nil›, and saving
+            it as the existing record, then making a new Example and setting its
+            :attr to ‹nil› as well, the matcher expected the new Example to be
+            valid, but it was invalid instead, producing these validation errors:
 
-  * attr: ["has already been taken"]
+            * attr: ["has already been taken"]
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -1062,14 +1062,14 @@ long as it is not nil, but this could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr is case-sensitively unique as
-long as it is not nil, but this could not be proved.
-  Given an existing Example, after setting its :attr to ‹nil›, then
-  making a new Example and setting its :attr to ‹nil› as well, the
-  matcher expected the new Example to be valid, but it was invalid
-  instead, producing these validation errors:
+          Expected Example to validate that :attr is case-sensitively unique as
+          long as it is not nil, but this could not be proved.
+            Given an existing Example, after setting its :attr to ‹nil›, then
+            making a new Example and setting its :attr to ‹nil› as well, the
+            matcher expected the new Example to be valid, but it was invalid
+            instead, producing these validation errors:
 
-  * attr: ["has already been taken"]
+            * attr: ["has already been taken"]
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -1157,14 +1157,14 @@ long as it is not nil, but this could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr is case-sensitively unique as
-long as it is not blank, but this could not be proved.
-  After taking the given Example, setting its :attr to ‹""›, and saving
-  it as the existing record, then making a new Example and setting its
-  :attr to ‹""› as well, the matcher expected the new Example to be
-  valid, but it was invalid instead, producing these validation errors:
+          Expected Example to validate that :attr is case-sensitively unique as
+          long as it is not blank, but this could not be proved.
+            After taking the given Example, setting its :attr to ‹""›, and saving
+            it as the existing record, then making a new Example and setting its
+            :attr to ‹""› as well, the matcher expected the new Example to be
+            valid, but it was invalid instead, producing these validation errors:
 
-  * attr: ["has already been taken"]
+            * attr: ["has already been taken"]
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -1181,14 +1181,14 @@ long as it is not blank, but this could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr is case-sensitively unique as
-long as it is not blank, but this could not be proved.
-  Given an existing Example, after setting its :attr to ‹""›, then
-  making a new Example and setting its :attr to ‹""› as well, the
-  matcher expected the new Example to be valid, but it was invalid
-  instead, producing these validation errors:
+          Expected Example to validate that :attr is case-sensitively unique as
+          long as it is not blank, but this could not be proved.
+            Given an existing Example, after setting its :attr to ‹""›, then
+            making a new Example and setting its :attr to ‹""› as well, the
+            matcher expected the new Example to be valid, but it was invalid
+            instead, producing these validation errors:
 
-  * attr: ["has already been taken"]
+            * attr: ["has already been taken"]
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -1207,14 +1207,14 @@ long as it is not blank, but this could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr is case-sensitively unique as
-long as it is not blank, but this could not be proved.
-  After taking the given Example, setting its :attr to ‹""›, and saving
-  it as the existing record, then making a new Example and setting its
-  :attr to ‹""› as well, the matcher expected the new Example to be
-  valid, but it was invalid instead, producing these validation errors:
+          Expected Example to validate that :attr is case-sensitively unique as
+          long as it is not blank, but this could not be proved.
+            After taking the given Example, setting its :attr to ‹""›, and saving
+            it as the existing record, then making a new Example and setting its
+            :attr to ‹""› as well, the matcher expected the new Example to be
+            valid, but it was invalid instead, producing these validation errors:
 
-  * attr: ["has already been taken"]
+            * attr: ["has already been taken"]
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -1233,14 +1233,14 @@ long as it is not blank, but this could not be proved.
         end
 
         message = <<-MESSAGE
-Expected Example to validate that :attr is case-sensitively unique as
-long as it is not blank, but this could not be proved.
-  Given an existing Example, after setting its :attr to ‹""›, then
-  making a new Example and setting its :attr to ‹""› as well, the
-  matcher expected the new Example to be valid, but it was invalid
-  instead, producing these validation errors:
+          Expected Example to validate that :attr is case-sensitively unique as
+          long as it is not blank, but this could not be proved.
+            Given an existing Example, after setting its :attr to ‹""›, then
+            making a new Example and setting its :attr to ‹""› as well, the
+            matcher expected the new Example to be valid, but it was invalid
+            instead, producing these validation errors:
 
-  * attr: ["has already been taken"]
+            * attr: ["has already been taken"]
         MESSAGE
 
         expect(&assertion).to fail_with_message(message)
@@ -1313,9 +1313,9 @@ long as it is not blank, but this could not be proved.
       end
 
       message = <<-MESSAGE.strip
-Expected Example to validate that :attr is case-sensitively unique, but
-this could not be proved.
-  :attr does not seem to be an attribute on Example.
+        Expected Example to validate that :attr is case-sensitively unique, but
+        this could not be proved.
+          :attr does not seem to be an attribute on Example.
       MESSAGE
 
       expect(&assertion).to fail_with_message(message)
@@ -1341,25 +1341,25 @@ this could not be proved.
           end
 
           message = <<-MESSAGE.strip
-Expected Example to validate that :name is case-sensitively unique, but
-this could not be proved.
-  After taking the given Example, setting its :name to ‹"dummy value"›
-  (read back as ‹"DUMMY VALUE"›), and saving it as the existing record,
-  then making a new Example and setting its :name to ‹"dummy value"›
-  (read back as ‹"DUMMY VALUE"›) as well, the matcher expected the new
-  Example to be valid, but it was invalid instead, producing these
-  validation errors:
+            Expected Example to validate that :name is case-sensitively unique, but
+            this could not be proved.
+              After taking the given Example, setting its :name to ‹"dummy value"›
+              (read back as ‹"DUMMY VALUE"›), and saving it as the existing record,
+              then making a new Example and setting its :name to ‹"dummy value"›
+              (read back as ‹"DUMMY VALUE"›) as well, the matcher expected the new
+              Example to be valid, but it was invalid instead, producing these
+              validation errors:
 
-  * name: ["has already been taken"]
+              * name: ["has already been taken"]
 
-  As indicated in the message above, :name seems to be changing certain
-  values as they are set, and this could have something to do with why
-  this test is failing. If you or something else has overridden the
-  writer method for this attribute to normalize values by changing their
-  case in any way (for instance, ensuring that the attribute is always
-  downcased), then try adding `ignoring_case_sensitivity` onto the end
-  of the uniqueness matcher. Otherwise, you may need to write the test
-  yourself, or do something different altogether.
+              As indicated in the message above, :name seems to be changing certain
+              values as they are set, and this could have something to do with why
+              this test is failing. If you or something else has overridden the
+              writer method for this attribute to normalize values by changing their
+              case in any way (for instance, ensuring that the attribute is always
+              downcased), then try adding `ignoring_case_sensitivity` onto the end
+              of the uniqueness matcher. Otherwise, you may need to write the test
+              yourself, or do something different altogether.
           MESSAGE
 
           expect(&assertion).to fail_with_message(message)

--- a/spec/unit/shoulda/matchers/independent/delegate_method_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/independent/delegate_method_matcher_spec.rb
@@ -556,11 +556,11 @@ describe Shoulda::Matchers::Independent::DelegateMethodMatcher do
           person = Person.new
 
           message = <<-MESSAGE
-Expected Person to delegate #hello to the #country object, allowing
-#country to return nil.
+            Expected Person to delegate #hello to the #country object, allowing
+            #country to return nil.
 
-Person#hello did delegate to #country when it was non-nil, but it failed
-to account for when #country *was* nil.
+            Person#hello did delegate to #country when it was non-nil, but it failed
+            to account for when #country *was* nil.
           MESSAGE
 
           expectation = lambda do
@@ -587,11 +587,11 @@ to account for when #country *was* nil.
           person = Person.new
 
           message = <<-MESSAGE
-Expected Person to delegate #hello to the #country object, allowing
-#country to return nil.
+            Expected Person to delegate #hello to the #country object, allowing
+            #country to return nil.
 
-Person#hello did delegate to #country when it was non-nil, but it failed
-to account for when #country *was* nil.
+            Person#hello did delegate to #country when it was non-nil, but it failed
+            to account for when #country *was* nil.
           MESSAGE
 
           expectation = lambda do
@@ -639,11 +639,11 @@ to account for when #country *was* nil.
           person = Person.new
 
           message = <<-MESSAGE
-Expected Person to delegate #hello to the #country object, allowing
-#country to return nil.
+            Expected Person to delegate #hello to the #country object, allowing
+            #country to return nil.
 
-Person#hello did delegate to #country when it was non-nil, but it failed
-to account for when #country *was* nil.
+            Person#hello did delegate to #country when it was non-nil, but it failed
+            to account for when #country *was* nil.
           MESSAGE
 
           expectation = lambda do

--- a/spec/unit/shoulda/matchers/util/word_wrap_spec.rb
+++ b/spec/unit/shoulda/matchers/util/word_wrap_spec.rb
@@ -4,195 +4,195 @@ require 'shoulda/matchers/util/word_wrap'
 describe Shoulda::Matchers, '.word_wrap' do
   it 'can wrap a simple paragraph' do
     wrapped_message = described_class.word_wrap(<<-MESSAGE.rstrip)
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean luctus, ipsum sit amet efficitur feugiat
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean luctus, ipsum sit amet efficitur feugiat
     MESSAGE
 
     expect(wrapped_message).to eq(<<-MESSAGE.rstrip)
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean luctus,
-ipsum sit amet efficitur feugiat
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean luctus,
+      ipsum sit amet efficitur feugiat
     MESSAGE
   end
 
   it 'does not split words up when wrapping' do
     wrapped_message = described_class.word_wrap(<<-MESSAGE.rstrip)
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean lusciousness, ipsum sit amet efficitur feugiat
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean lusciousness, ipsum sit amet efficitur feugiat
     MESSAGE
 
     expect(wrapped_message).to eq(<<-MESSAGE.rstrip)
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean
-lusciousness, ipsum sit amet efficitur feugiat
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean
+      lusciousness, ipsum sit amet efficitur feugiat
     MESSAGE
   end
 
   it 'considers punctuation as part of a word' do
     wrapped_message = described_class.word_wrap(<<-MESSAGE.rstrip)
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean luscious, ipsum sit amet efficitur feugiat
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean luscious, ipsum sit amet efficitur feugiat
     MESSAGE
 
     expect(wrapped_message).to eq(<<-MESSAGE.rstrip)
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean
-luscious, ipsum sit amet efficitur feugiat
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean
+      luscious, ipsum sit amet efficitur feugiat
     MESSAGE
   end
 
   it 'does not break at the maximum line length, but afterward' do
     wrapped_message = described_class.word_wrap(<<-MESSAGE.rstrip)
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean luscius, ipsum sit amet efficitur feugiat
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean luscius, ipsum sit amet efficitur feugiat
     MESSAGE
 
     expect(wrapped_message).to eq(<<-MESSAGE.rstrip)
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean luscius,
-ipsum sit amet efficitur feugiat
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean luscius,
+      ipsum sit amet efficitur feugiat
     MESSAGE
   end
 
   it 're-wraps entire paragraphs' do
     wrapped_message = described_class.word_wrap(<<-MESSAGE.rstrip)
-Lorem ipsum dolor sit amet,
-consectetur adipiscing elit.
-Aenean luctus,
-ipsum sit amet efficitur feugiat,
-dolor mauris fringilla erat, sed posuere diam ex ut velit.
+      Lorem ipsum dolor sit amet,
+      consectetur adipiscing elit.
+      Aenean luctus,
+      ipsum sit amet efficitur feugiat,
+      dolor mauris fringilla erat, sed posuere diam ex ut velit.
     MESSAGE
 
     expect(wrapped_message).to eq(<<-MESSAGE.rstrip)
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean luctus,
-ipsum sit amet efficitur feugiat, dolor mauris fringilla erat, sed
-posuere diam ex ut velit.
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean luctus,
+      ipsum sit amet efficitur feugiat, dolor mauris fringilla erat, sed
+      posuere diam ex ut velit.
     MESSAGE
   end
 
   it 'can wrap multiple paragraphs' do
     wrapped_message = described_class.word_wrap(<<-MESSAGE.rstrip)
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean luctus, ipsum sit amet efficitur feugiat, dolor mauris fringilla erat, sed posuere diam ex ut velit.
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean luctus, ipsum sit amet efficitur feugiat, dolor mauris fringilla erat, sed posuere diam ex ut velit.
 
-Etiam ultrices cursus ligula eget feugiat. Vestibulum eget tincidunt risus, non faucibus sem.
+      Etiam ultrices cursus ligula eget feugiat. Vestibulum eget tincidunt risus, non faucibus sem.
     MESSAGE
 
     expect(wrapped_message).to eq(<<-MESSAGE.rstrip)
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean luctus,
-ipsum sit amet efficitur feugiat, dolor mauris fringilla erat, sed
-posuere diam ex ut velit.
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean luctus,
+      ipsum sit amet efficitur feugiat, dolor mauris fringilla erat, sed
+      posuere diam ex ut velit.
 
-Etiam ultrices cursus ligula eget feugiat. Vestibulum eget tincidunt
-risus, non faucibus sem.
+      Etiam ultrices cursus ligula eget feugiat. Vestibulum eget tincidunt
+      risus, non faucibus sem.
     MESSAGE
   end
 
   it 'can wrap a bulleted list' do
     wrapped_message = described_class.word_wrap(<<-MESSAGE.rstrip)
-* Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean luctus, ipsum sit amet efficitur feugiat, dolor mauris fringilla erat, sed posuere diam ex ut velit.
-* And the beat goes on.
-    MESSAGE
+      * Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean luctus, ipsum sit amet efficitur feugiat, dolor mauris fringilla erat, sed posuere diam ex ut velit.
+      * And the beat goes on.
+          MESSAGE
 
-    expect(wrapped_message).to eq(<<-MESSAGE.rstrip)
-* Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean
-  luctus, ipsum sit amet efficitur feugiat, dolor mauris fringilla erat,
-  sed posuere diam ex ut velit.
-* And the beat goes on.
+          expect(wrapped_message).to eq(<<-MESSAGE.rstrip)
+      * Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean
+        luctus, ipsum sit amet efficitur feugiat, dolor mauris fringilla erat,
+        sed posuere diam ex ut velit.
+      * And the beat goes on.
     MESSAGE
   end
 
   it 're-wraps bulleted lists' do
     wrapped_message = described_class.word_wrap(<<-MESSAGE.rstrip)
-* Lorem ipsum dolor sit amet,
-  consectetur adipiscing elit.
-  Aenean luctus,
-  ipsum sit amet efficitur feugiat,
-  dolor mauris fringilla erat,
-  sed posuere diam ex ut velit.
-* And the beat goes on.
+      * Lorem ipsum dolor sit amet,
+        consectetur adipiscing elit.
+        Aenean luctus,
+        ipsum sit amet efficitur feugiat,
+        dolor mauris fringilla erat,
+        sed posuere diam ex ut velit.
+      * And the beat goes on.
     MESSAGE
 
     expect(wrapped_message).to eq(<<-MESSAGE.rstrip)
-* Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean
-  luctus, ipsum sit amet efficitur feugiat, dolor mauris fringilla erat,
-  sed posuere diam ex ut velit.
-* And the beat goes on.
+      * Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean
+        luctus, ipsum sit amet efficitur feugiat, dolor mauris fringilla erat,
+        sed posuere diam ex ut velit.
+      * And the beat goes on.
     MESSAGE
   end
 
   it 'can wrap a numbered list' do
     wrapped_message = described_class.word_wrap(<<-MESSAGE.rstrip)
-1. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean luctus, ipsum sit amet efficitur feugiat, dolor mauris fringilla erat, sed posuere diam ex ut velit.
-2. And the beat goes on.
+      1. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean luctus, ipsum sit amet efficitur feugiat, dolor mauris fringilla erat, sed posuere diam ex ut velit.
+      2. And the beat goes on.
     MESSAGE
 
     expect(wrapped_message).to eq(<<-MESSAGE.rstrip)
-1. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean
-   luctus, ipsum sit amet efficitur feugiat, dolor mauris fringilla
-   erat, sed posuere diam ex ut velit.
-2. And the beat goes on.
+      1. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean
+        luctus, ipsum sit amet efficitur feugiat, dolor mauris fringilla
+        erat, sed posuere diam ex ut velit.
+      2. And the beat goes on.
     MESSAGE
   end
 
   it 're-wraps numbered lists' do
     wrapped_message = described_class.word_wrap(<<-MESSAGE.rstrip)
-1. Lorem ipsum dolor sit amet,
-   consectetur adipiscing elit.
-   Aenean luctus,
-   ipsum sit amet efficitur feugiat,
-   dolor mauris fringilla erat,
-   sed posuere diam ex ut velit.
-2. And the beat goes on.
+      1. Lorem ipsum dolor sit amet,
+        consectetur adipiscing elit.
+        Aenean luctus,
+        ipsum sit amet efficitur feugiat,
+        dolor mauris fringilla erat,
+        sed posuere diam ex ut velit.
+      2. And the beat goes on.
     MESSAGE
 
     expect(wrapped_message).to eq(<<-MESSAGE.rstrip)
-1. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean
-   luctus, ipsum sit amet efficitur feugiat, dolor mauris fringilla
-   erat, sed posuere diam ex ut velit.
-2. And the beat goes on.
+      1. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean
+        luctus, ipsum sit amet efficitur feugiat, dolor mauris fringilla
+        erat, sed posuere diam ex ut velit.
+      2. And the beat goes on.
     MESSAGE
   end
 
   it 'can wrap a numbered list, using x) instead of x. as the leader' do
     wrapped_message = described_class.word_wrap(<<-MESSAGE.rstrip)
-1) Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean luctus, ipsum sit amet efficitur feugiat, dolor mauris fringilla erat, sed posuere diam ex ut velit.
-2) And the beat goes on.
+      1) Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean luctus, ipsum sit amet efficitur feugiat, dolor mauris fringilla erat, sed posuere diam ex ut velit.
+      2) And the beat goes on.
     MESSAGE
 
     expect(wrapped_message).to eq(<<-MESSAGE.rstrip)
-1) Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean
-   luctus, ipsum sit amet efficitur feugiat, dolor mauris fringilla
-   erat, sed posuere diam ex ut velit.
-2) And the beat goes on.
+      1) Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean
+        luctus, ipsum sit amet efficitur feugiat, dolor mauris fringilla
+        erat, sed posuere diam ex ut velit.
+      2) And the beat goes on.
     MESSAGE
   end
 
   it 're-wraps numbered lists using x) instead of x. as the leader' do
     wrapped_message = described_class.word_wrap(<<-MESSAGE.rstrip)
-1) Lorem ipsum dolor sit amet,
-   consectetur adipiscing elit.
-   Aenean luctus,
-   ipsum sit amet efficitur feugiat,
-   dolor mauris fringilla erat,
-   sed posuere diam ex ut velit.
-2) And the beat goes on.
+      1) Lorem ipsum dolor sit amet,
+        consectetur adipiscing elit.
+        Aenean luctus,
+        ipsum sit amet efficitur feugiat,
+        dolor mauris fringilla erat,
+        sed posuere diam ex ut velit.
+      2) And the beat goes on.
     MESSAGE
 
     expect(wrapped_message).to eq(<<-MESSAGE.rstrip)
-1) Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean
-   luctus, ipsum sit amet efficitur feugiat, dolor mauris fringilla
-   erat, sed posuere diam ex ut velit.
-2) And the beat goes on.
+      1) Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean
+        luctus, ipsum sit amet efficitur feugiat, dolor mauris fringilla
+        erat, sed posuere diam ex ut velit.
+      2) And the beat goes on.
     MESSAGE
   end
 
   it "doesn't mess with indented blocks" do
     wrapped_message = described_class.word_wrap(<<-MESSAGE.rstrip)
-Some text is gonna go here.
+      Some text is gonna go here.
 
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean luctus, ipsum sit amet efficitur feugiat, dolor mauris fringilla erat, sed posuere diam ex ut velit.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean luctus, ipsum sit amet efficitur feugiat, dolor mauris fringilla erat, sed posuere diam ex ut velit.
 
-And now we return.
+      And now we return.
     MESSAGE
 
     expect(wrapped_message).to eq(<<-MESSAGE.rstrip)
-Some text is gonna go here.
+      Some text is gonna go here.
 
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean luctus, ipsum sit amet efficitur feugiat, dolor mauris fringilla erat, sed posuere diam ex ut velit.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean luctus, ipsum sit amet efficitur feugiat, dolor mauris fringilla erat, sed posuere diam ex ut velit.
 
-And now we return.
+      And now we return.
     MESSAGE
   end
 
@@ -200,12 +200,12 @@ And now we return.
     context 'which stands on its own' do
       it 'simply returns the string' do
         wrapped_message = described_class.word_wrap(<<-MESSAGE.rstrip)
-Foo bar baz and stuff and things Loremipsumdolorsitamet,consecteturadipiscingelit.Aeneanluctus,ipsumsitametefficiturfeugiat,
+          Foo bar baz and stuff and things Loremipsumdolorsitamet,consecteturadipiscingelit.Aeneanluctus,ipsumsitametefficiturfeugiat,
         MESSAGE
 
         expect(wrapped_message).to eq(<<-MESSAGE.rstrip)
-Foo bar baz and stuff and things
-Loremipsumdolorsitamet,consecteturadipiscingelit.Aeneanluctus,ipsumsitametefficiturfeugiat,
+          Foo bar baz and stuff and things
+          Loremipsumdolorsitamet,consecteturadipiscingelit.Aeneanluctus,ipsumsitametefficiturfeugiat,
         MESSAGE
       end
     end
@@ -213,12 +213,12 @@ Loremipsumdolorsitamet,consecteturadipiscingelit.Aeneanluctus,ipsumsitameteffici
     context 'which is preceded by some text' do
       it 'leaves the word on its own line' do
         wrapped_message = described_class.word_wrap(<<-MESSAGE.rstrip)
-Foo bar baz and stuff and things Loremipsumdolorsitamet,consecteturadipiscingelit.Aeneanluctus,ipsumsitametefficiturfeugiat,
+          Foo bar baz and stuff and things Loremipsumdolorsitamet,consecteturadipiscingelit.Aeneanluctus,ipsumsitametefficiturfeugiat,
         MESSAGE
 
         expect(wrapped_message).to eq(<<-MESSAGE.rstrip)
-Foo bar baz and stuff and things
-Loremipsumdolorsitamet,consecteturadipiscingelit.Aeneanluctus,ipsumsitametefficiturfeugiat,
+          Foo bar baz and stuff and things
+          Loremipsumdolorsitamet,consecteturadipiscingelit.Aeneanluctus,ipsumsitametefficiturfeugiat,
         MESSAGE
       end
     end
@@ -226,12 +226,12 @@ Loremipsumdolorsitamet,consecteturadipiscingelit.Aeneanluctus,ipsumsitameteffici
     context 'which is followed by some text' do
       it 'leaves the word on its own line' do
         wrapped_message = described_class.word_wrap(<<-MESSAGE.rstrip)
-Loremipsumdolorsitamet,consecteturadipiscingelit.Aeneanluctus,ipsumsitametefficiturfeugiat, and something goes after this
+          Loremipsumdolorsitamet,consecteturadipiscingelit.Aeneanluctus,ipsumsitametefficiturfeugiat, and something goes after this
         MESSAGE
 
         expect(wrapped_message).to eq(<<-MESSAGE.rstrip)
-Loremipsumdolorsitamet,consecteturadipiscingelit.Aeneanluctus,ipsumsitametefficiturfeugiat,
-and something goes after this
+          Loremipsumdolorsitamet,consecteturadipiscingelit.Aeneanluctus,ipsumsitametefficiturfeugiat,
+          and something goes after this
         MESSAGE
       end
     end
@@ -240,12 +240,12 @@ and something goes after this
   context 'when :indent is given' do
     it 'uses the given indentation level when determining where to wrap lines' do
       wrapped_message = described_class.word_wrap(<<-MESSAGE.strip, indent: 2)
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean luctus, ipsum sit amet efficitur feugiat
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean luctus, ipsum sit amet efficitur feugiat
       MESSAGE
 
       expect(wrapped_message).to eq(<<-MESSAGE.rstrip)
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean
-  luctus, ipsum sit amet efficitur feugiat
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean
+        luctus, ipsum sit amet efficitur feugiat
       MESSAGE
     end
   end


### PR DESCRIPTION
I have fixed multiline strings indentation throughout the project to make the code to look better and more readable.