### PR TITLE
fix: Remove non-inclusive terms

### DIFF
--- a/lib/shoulda/matchers/action_controller/permit_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/permit_matcher.rb
@@ -11,7 +11,7 @@ module Shoulda
   module Matchers
     module ActionController
       # The `permit` matcher tests that an action in your controller receives a
-      # whitelist of parameters using Rails' Strong Parameters feature
+      # allowlist of parameters using Rails' Strong Parameters feature
       # (specifically that `permit` was called with the correct arguments).
       #
       # Here's an example:

--- a/lib/shoulda/matchers/active_model/validate_exclusion_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_exclusion_of_matcher.rb
@@ -3,10 +3,10 @@ module Shoulda
     module ActiveModel
       # The `validate_exclusion_of` matcher tests usage of the
       # `validates_exclusion_of` validation, asserting that an attribute cannot
-      # take a blacklist of values, and inversely, can take values outside of
+      # take a blocklist of values, and inversely, can take values outside of
       # this list.
       #
-      # If your blacklist is an array of values, use `in_array`:
+      # If your blocklist an array of values, use `in_array`:
       #
       #     class Game
       #       include ActiveModel::Model
@@ -29,7 +29,7 @@ module Shoulda
       #         in_array(['Mac', 'Linux'])
       #     end
       #
-      # If your blacklist is a range of values, use `in_range`:
+      # If your blocklist is a range of values, use `in_range`:
       #
       #     class Game
       #       include ActiveModel::Model

--- a/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
@@ -8,9 +8,9 @@ module Shoulda
     module ActiveModel
       # The `validate_inclusion_of` matcher tests usage of the
       # `validates_inclusion_of` validation, asserting that an attribute can
-      # take a whitelist of values and cannot take values outside of this list.
+      # take a allowlist of values and cannot take values outside of this list.
       #
-      # If your whitelist is an array of values, use `in_array`:
+      # If your allowlist is an array of values, use `in_array`:
       #
       #     class Issue
       #       include ActiveModel::Model
@@ -34,7 +34,7 @@ module Shoulda
       #         in_array(['open', 'resolved', 'unresolved'])
       #     end
       #
-      # If your whitelist is a range of values, use `in_range`:
+      # If your allowlist is a range of values, use `in_range`:
       #
       #     class Issue
       #       include ActiveModel::Model

--- a/spec/support/unit/model_creation_strategies/active_record.rb
+++ b/spec/support/unit/model_creation_strategies/active_record.rb
@@ -50,7 +50,7 @@ module UnitTests
           run_block(model, block)
         end
 
-        if whitelist_attributes? && model.respond_to?(:attr_accessible)
+        if allowlist_attributes? && model.respond_to?(:attr_accessible)
           model.attr_accessible(*columns.keys)
         end
 
@@ -85,8 +85,8 @@ module UnitTests
         options.fetch(:customize_table) { proc {} }
       end
 
-      def whitelist_attributes?
-        options.fetch(:whitelist_attributes, true)
+      def allowlist_attributes?
+        options.fetch(:allowlist_attributes, true)
       end
     end
   end


### PR DESCRIPTION
We have been using both the terms "whitelist" and "blacklist" to refer to a list of approved/denied values, but I wanted to point out that our dev community recommends the term "allowlist" and "blocklist" instead.


References:
https://learn.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/w/whitelist
https://inclusivenaming.org/word-lists/tier-1/#whitelist-blacklist
https://github.com/thoughtbot/guides/tree/main/terminology