### PR TITLE
Extend AM validate_length_of matcher to support array attributes

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_absence_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_absence_of_matcher.rb
@@ -143,6 +143,12 @@ module Shoulda
             @subject.class.reflect_on_association(@attribute)
         end
 
+        def array_column?
+          @subject.class.respond_to?(:columns_hash) &&
+            @subject.class.columns_hash[@attribute.to_s].respond_to?(:array) &&
+            @subject.class.columns_hash[@attribute.to_s].array
+        end
+
         def enum_column?
           @subject.class.respond_to?(:defined_enums) &&
             @subject.class.defined_enums.key?(@attribute.to_s)

--- a/lib/shoulda/matchers/active_model/validate_absence_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_absence_of_matcher.rb
@@ -143,12 +143,6 @@ module Shoulda
             @subject.class.reflect_on_association(@attribute)
         end
 
-        def array_column?
-          @subject.class.respond_to?(:columns_hash) &&
-            @subject.class.columns_hash[@attribute.to_s].respond_to?(:array) &&
-            @subject.class.columns_hash[@attribute.to_s].array
-        end
-
         def enum_column?
           @subject.class.respond_to?(:defined_enums) &&
             @subject.class.defined_enums.key?(@attribute.to_s)

--- a/lib/shoulda/matchers/active_model/validate_length_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_length_of_matcher.rb
@@ -468,10 +468,7 @@ module Shoulda
         end
 
         def array_column?
-          @options[:array] || (
-            @subject.class.respond_to?(:columns_hash) &&
-            @subject.class.columns_hash[@attribute.to_s].array?
-          )
+          @options[:array] || super
         end
 
         def translated_short_message

--- a/lib/shoulda/matchers/active_model/validate_length_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_length_of_matcher.rb
@@ -275,6 +275,11 @@ module Shoulda
           @long_message = nil
         end
 
+        def as_array
+          @options[:array] = true
+          self
+        end
+
         def is_at_least(length)
           @options[:minimum] = length
           @short_message ||= :too_short
@@ -451,15 +456,15 @@ module Shoulda
         end
 
         def allows_length_of?(length, message)
-          allows_value_of(string_of_length(length), message)
+          allows_value_of(element_of_length(length), message)
         end
 
         def disallows_length_of?(length, message)
-          disallows_value_of(string_of_length(length), message)
+          disallows_value_of(element_of_length(length), message)
         end
 
-        def string_of_length(length)
-          'x' * length
+        def element_of_length(length)
+          (@options[:array] ? ['x'] : 'x') * length
         end
 
         def translated_short_message

--- a/lib/shoulda/matchers/active_model/validate_length_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_length_of_matcher.rb
@@ -262,11 +262,13 @@ module Shoulda
       #
       # ##### as_array
       #
-      # Use `as_array` to force the attribute being validate with array values
+      # Use `as_array` if you have an ActiveModel model and the attribute being validated
+      # is designed to store an array. (This is not necessary if you have an ActiveRecord
+      # model with an array column, as the matcher will detect this automatically.)
       #
       #     class User
       #       include ActiveModel::Model
-      #       attr_accessor :arr, array: true
+      #       attribute :arr, array: true
       #
       #       validates_length_of :arr, minimum: 15
       #     end

--- a/lib/shoulda/matchers/active_model/validate_length_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_length_of_matcher.rb
@@ -464,7 +464,14 @@ module Shoulda
         end
 
         def element_of_length(length)
-          (@options[:array] ? ['x'] : 'x') * length
+          (array_column? ? ['x'] : 'x') * length
+        end
+
+        def array_column?
+          @options[:array] || (
+            @subject.class.respond_to?(:columns_hash) &&
+            @subject.class.columns_hash[@attribute.to_s].array?
+          )
         end
 
         def translated_short_message

--- a/lib/shoulda/matchers/active_model/validate_length_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_length_of_matcher.rb
@@ -456,14 +456,14 @@ module Shoulda
         end
 
         def allows_length_of?(length, message)
-          allows_value_of(element_of_length(length), message)
+          allows_value_of(value_of_length(length), message)
         end
 
         def disallows_length_of?(length, message)
-          disallows_value_of(element_of_length(length), message)
+          disallows_value_of(value_of_length(length), message)
         end
 
-        def element_of_length(length)
+        def value_of_length(length)
           (array_column? ? ['x'] : 'x') * length
         end
 

--- a/lib/shoulda/matchers/active_model/validate_length_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_length_of_matcher.rb
@@ -260,6 +260,27 @@ module Shoulda
       #       should validate_length_of(:bio).is_at_least(15).allow_blank
       #     end
       #
+      # ##### as_array
+      #
+      # Use `as_array` to force the attribute being validate with array values
+      #
+      #     class User
+      #       include ActiveModel::Model
+      #       attr_accessor :arr, array: true
+      #
+      #       validates_length_of :arr, minimum: 15
+      #     end
+      #
+      #     # RSpec
+      #     describe User do
+      #       it { should validate_length_of(:arr).as_array.is_at_least(15) }
+      #     end
+      #
+      #     # Minitest (Shoulda)
+      #     class UserTest < ActiveSupport::TestCase
+      #       should validate_length_of(:arr).as_array.is_at_least(15)
+      #     end
+      #
       def validate_length_of(attr)
         ValidateLengthOfMatcher.new(attr)
       end

--- a/lib/shoulda/matchers/active_model/validation_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validation_matcher.rb
@@ -186,6 +186,12 @@ module Shoulda
         def blank_values
           ['', ' ', "\n", "\r", "\t", "\f"]
         end
+
+        def array_column?
+          @subject.class.respond_to?(:columns_hash) &&
+            @subject.class.columns_hash[@attribute.to_s].respond_to?(:array) &&
+            @subject.class.columns_hash[@attribute.to_s].array
+        end
       end
     end
   end

--- a/spec/unit/shoulda/matchers/active_model/validate_length_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_length_of_matcher_spec.rb
@@ -554,6 +554,97 @@ but this could not be proved.
     end
   end
 
+  context 'whith ActiveModel attribute marked as array' do
+    context 'an attribute with a non-zero minimum length validation' do
+      it 'accepts ensuring the correct minimum length' do
+        expect(define_active_model_validating_length(minimum: 4)).
+          to validate_length_of(:attr).as_array.is_at_least(4)
+      end
+
+      it 'rejects ensuring a lower minimum length with any message' do
+        expect(define_active_model_validating_length(minimum: 4)).
+          not_to validate_length_of(:attr).as_array.is_at_least(3).with_short_message(/.*/)
+      end
+
+      it 'rejects ensuring a higher minimum length with any message' do
+        expect(define_active_model_validating_length(minimum: 4)).
+          not_to validate_length_of(:attr).as_array.is_at_least(5).with_short_message(/.*/)
+      end
+
+      it 'does not override the default message with a blank' do
+        expect(define_active_model_validating_length(minimum: 4)).
+          to validate_length_of(:attr).as_array.is_at_least(4).with_short_message(nil)
+      end
+
+      it 'fails when used in the negative' do
+        assertion = lambda do
+          expect(define_active_model_validating_length(minimum: 4)).
+            not_to validate_length_of(:attr).as_array.is_at_least(4)
+        end
+
+        message = <<-MESSAGE
+Expected Example not to validate that the length of :attr is at least 4,
+but this could not be proved.
+  After setting :attr to ‹["x", "x", "x", "x"]›, the matcher expected
+  the Example to be invalid, but it was valid instead.
+        MESSAGE
+
+        expect(&assertion).to fail_with_message(message)
+      end
+    end
+
+    context 'an attribute with a minimum length validation of 0' do
+      it 'accepts ensuring the correct minimum length' do
+        expect(define_active_model_validating_length(minimum: 0)).
+          to validate_length_of(:attr).as_array.is_at_least(0)
+      end
+    end
+
+    context 'an attribute with a maximum length' do
+      it 'accepts ensuring the correct maximum length' do
+        expect(define_active_model_validating_length(maximum: 4)).
+          to validate_length_of(:attr).as_array.is_at_most(4)
+      end
+
+      it 'rejects ensuring a lower maximum length with any message' do
+        expect(define_active_model_validating_length(maximum: 4)).
+          not_to validate_length_of(:attr).as_array.is_at_most(3).with_long_message(/.*/)
+      end
+
+      it 'rejects ensuring a higher maximum length with any message' do
+        expect(define_active_model_validating_length(maximum: 4)).
+          not_to validate_length_of(:attr).as_array.is_at_most(5).with_long_message(/.*/)
+      end
+
+      it 'does not override the default message with a blank' do
+        expect(define_active_model_validating_length(maximum: 4)).
+          to validate_length_of(:attr).as_array.is_at_most(4).with_long_message(nil)
+      end
+    end
+
+    context 'an attribute with a required exact length' do
+      it 'accepts ensuring the correct length' do
+        expect(define_active_model_validating_length(is: 4)).
+          to validate_length_of(:attr).as_array.is_equal_to(4)
+      end
+
+      it 'rejects ensuring a lower maximum length with any message' do
+        expect(define_active_model_validating_length(is: 4)).
+          not_to validate_length_of(:attr).as_array.is_equal_to(3).with_message(/.*/)
+      end
+
+      it 'rejects ensuring a higher maximum length with any message' do
+        expect(define_active_model_validating_length(is: 4)).
+          not_to validate_length_of(:attr).as_array.is_equal_to(5).with_message(/.*/)
+      end
+
+      it 'does not override the default message with a blank' do
+        expect(define_active_model_validating_length(is: 4)).
+          to validate_length_of(:attr).as_array.is_equal_to(4).with_message(nil)
+      end
+    end
+  end
+
   def define_model_validating_length(options = {})
     options = options.dup
     attribute_name = options.delete(:attribute_name) { :attr }
@@ -563,6 +654,15 @@ but this could not be proved.
     define_model(:example, attribute_name => { type: type, options: { array: array } }) do |model|
       model.validates_length_of(attribute_name, options)
     end
+  end
+
+  def define_active_model_validating_length(options)
+    attribute_name = options.delete(:attribute_name) { :attr }
+
+    define_active_model_class('Example', accessors: []) do
+      attribute attribute_name, array: true
+      validates_length_of(attribute_name, options)
+    end.new
   end
 
   def validating_array_length(options = {})

--- a/spec/unit/shoulda/matchers/active_model/validate_length_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_length_of_matcher_spec.rb
@@ -461,95 +461,95 @@ but this could not be proved.
         end
       end
     end
+  end
 
-    context 'when column is validated as array' do
-      context 'an attribute with a non-zero minimum length validation' do
-        it 'accepts ensuring the correct minimum length' do
+  context 'when column is validated as array' do
+    context 'an attribute with a non-zero minimum length validation' do
+      it 'accepts ensuring the correct minimum length' do
+        expect(validating_length(type: :jsonb, minimum: 4)).
+          to validate_length_of(:attr).as_array.is_at_least(4)
+      end
+
+      it 'rejects ensuring a lower minimum length with any message' do
+        expect(validating_length(type: :jsonb, minimum: 4)).
+          not_to validate_length_of(:attr).as_array.is_at_least(3).with_short_message(/.*/)
+      end
+
+      it 'rejects ensuring a higher minimum length with any message' do
+        expect(validating_length(type: :jsonb, minimum: 4)).
+          not_to validate_length_of(:attr).as_array.is_at_least(5).with_short_message(/.*/)
+      end
+
+      it 'does not override the default message with a blank' do
+        expect(validating_length(type: :jsonb, minimum: 4)).
+          to validate_length_of(:attr).as_array.is_at_least(4).with_short_message(nil)
+      end
+
+      it 'fails when used in the negative' do
+        assertion = lambda do
           expect(validating_length(type: :jsonb, minimum: 4)).
-            to validate_length_of(:attr).as_array.is_at_least(4)
+            not_to validate_length_of(:attr).as_array.is_at_least(4)
         end
 
-        it 'rejects ensuring a lower minimum length with any message' do
-          expect(validating_length(type: :jsonb, minimum: 4)).
-            not_to validate_length_of(:attr).as_array.is_at_least(3).with_short_message(/.*/)
-        end
-
-        it 'rejects ensuring a higher minimum length with any message' do
-          expect(validating_length(type: :jsonb, minimum: 4)).
-            not_to validate_length_of(:attr).as_array.is_at_least(5).with_short_message(/.*/)
-        end
-
-        it 'does not override the default message with a blank' do
-          expect(validating_length(type: :jsonb, minimum: 4)).
-            to validate_length_of(:attr).as_array.is_at_least(4).with_short_message(nil)
-        end
-
-        it 'fails when used in the negative' do
-          assertion = lambda do
-            expect(validating_length(type: :jsonb, minimum: 4)).
-              not_to validate_length_of(:attr).as_array.is_at_least(4)
-          end
-
-          message = <<-MESSAGE
+        message = <<-MESSAGE
 Expected Example not to validate that the length of :attr is at least 4,
 but this could not be proved.
   After setting :attr to ‹["x", "x", "x", "x"]›, the matcher expected
   the Example to be invalid, but it was valid instead.
-          MESSAGE
+        MESSAGE
 
-          expect(&assertion).to fail_with_message(message)
-        end
+        expect(&assertion).to fail_with_message(message)
+      end
+    end
+
+    context 'an attribute with a minimum length validation of 0' do
+      it 'accepts ensuring the correct minimum length' do
+        expect(validating_length(type: :jsonb, minimum: 0)).
+          to validate_length_of(:attr).as_array.is_at_least(0)
+      end
+    end
+
+    context 'an attribute with a maximum length' do
+      it 'accepts ensuring the correct maximum length' do
+        expect(validating_length(type: :jsonb, maximum: 4)).
+          to validate_length_of(:attr).as_array.is_at_most(4)
       end
 
-      context 'an attribute with a minimum length validation of 0' do
-        it 'accepts ensuring the correct minimum length' do
-          expect(validating_length(type: :jsonb, minimum: 0)).
-            to validate_length_of(:attr).as_array.is_at_least(0)
-        end
+      it 'rejects ensuring a lower maximum length with any message' do
+        expect(validating_length(type: :jsonb, maximum: 4)).
+          not_to validate_length_of(:attr).as_array.is_at_most(3).with_long_message(/.*/)
       end
 
-      context 'an attribute with a maximum length' do
-        it 'accepts ensuring the correct maximum length' do
-          expect(validating_length(type: :jsonb, maximum: 4)).
-            to validate_length_of(:attr).as_array.is_at_most(4)
-        end
-
-        it 'rejects ensuring a lower maximum length with any message' do
-          expect(validating_length(type: :jsonb, maximum: 4)).
-            not_to validate_length_of(:attr).as_array.is_at_most(3).with_long_message(/.*/)
-        end
-
-        it 'rejects ensuring a higher maximum length with any message' do
-          expect(validating_length(type: :jsonb, maximum: 4)).
-            not_to validate_length_of(:attr).as_array.is_at_most(5).with_long_message(/.*/)
-        end
-
-        it 'does not override the default message with a blank' do
-          expect(validating_length(type: :jsonb, maximum: 4)).
-            to validate_length_of(:attr).as_array.is_at_most(4).with_long_message(nil)
-        end
+      it 'rejects ensuring a higher maximum length with any message' do
+        expect(validating_length(type: :jsonb, maximum: 4)).
+          not_to validate_length_of(:attr).as_array.is_at_most(5).with_long_message(/.*/)
       end
 
-      context 'an attribute with a required exact length' do
-        it 'accepts ensuring the correct length' do
-          expect(validating_length(type: :jsonb, is: 4)).
-            to validate_length_of(:attr).as_array.is_equal_to(4)
-        end
+      it 'does not override the default message with a blank' do
+        expect(validating_length(type: :jsonb, maximum: 4)).
+          to validate_length_of(:attr).as_array.is_at_most(4).with_long_message(nil)
+      end
+    end
 
-        it 'rejects ensuring a lower maximum length with any message' do
-          expect(validating_length(type: :jsonb, is: 4)).
-            not_to validate_length_of(:attr).as_array.is_equal_to(3).with_message(/.*/)
-        end
+    context 'an attribute with a required exact length' do
+      it 'accepts ensuring the correct length' do
+        expect(validating_length(type: :jsonb, is: 4)).
+          to validate_length_of(:attr).as_array.is_equal_to(4)
+      end
 
-        it 'rejects ensuring a higher maximum length with any message' do
-          expect(validating_length(type: :jsonb, is: 4)).
-            not_to validate_length_of(:attr).as_array.is_equal_to(5).with_message(/.*/)
-        end
+      it 'rejects ensuring a lower maximum length with any message' do
+        expect(validating_length(type: :jsonb, is: 4)).
+          not_to validate_length_of(:attr).as_array.is_equal_to(3).with_message(/.*/)
+      end
 
-        it 'does not override the default message with a blank' do
-          expect(validating_length(type: :jsonb, is: 4)).
-            to validate_length_of(:attr).as_array.is_equal_to(4).with_message(nil)
-        end
+      it 'rejects ensuring a higher maximum length with any message' do
+        expect(validating_length(type: :jsonb, is: 4)).
+          not_to validate_length_of(:attr).as_array.is_equal_to(5).with_message(/.*/)
+      end
+
+      it 'does not override the default message with a blank' do
+        expect(validating_length(type: :jsonb, is: 4)).
+          to validate_length_of(:attr).as_array.is_equal_to(4).with_message(nil)
       end
     end
   end

--- a/spec/unit/shoulda/matchers/active_model/validate_length_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_length_of_matcher_spec.rb
@@ -375,28 +375,28 @@ this could not be proved.
       context 'an attribute with a non-zero minimum length validation' do
         it 'accepts ensuring the correct minimum length' do
           expect(validating_array_length(minimum: 4)).
-            to validate_length_of(:attr).as_array.is_at_least(4)
+            to validate_length_of(:attr).is_at_least(4)
         end
 
         it 'rejects ensuring a lower minimum length with any message' do
           expect(validating_array_length(minimum: 4)).
-            not_to validate_length_of(:attr).as_array.is_at_least(3).with_short_message(/.*/)
+            not_to validate_length_of(:attr).is_at_least(3).with_short_message(/.*/)
         end
 
         it 'rejects ensuring a higher minimum length with any message' do
           expect(validating_array_length(minimum: 4)).
-            not_to validate_length_of(:attr).as_array.is_at_least(5).with_short_message(/.*/)
+            not_to validate_length_of(:attr).is_at_least(5).with_short_message(/.*/)
         end
 
         it 'does not override the default message with a blank' do
           expect(validating_array_length(minimum: 4)).
-            to validate_length_of(:attr).as_array.is_at_least(4).with_short_message(nil)
+            to validate_length_of(:attr).is_at_least(4).with_short_message(nil)
         end
 
         it 'fails when used in the negative' do
           assertion = lambda do
             expect(validating_array_length(minimum: 4)).
-              not_to validate_length_of(:attr).as_array.is_at_least(4)
+              not_to validate_length_of(:attr).is_at_least(4)
           end
 
           message = <<-MESSAGE
@@ -413,50 +413,141 @@ but this could not be proved.
       context 'an attribute with a minimum length validation of 0' do
         it 'accepts ensuring the correct minimum length' do
           expect(validating_array_length(minimum: 0)).
-            to validate_length_of(:attr).as_array.is_at_least(0)
+            to validate_length_of(:attr).is_at_least(0)
         end
       end
 
       context 'an attribute with a maximum length' do
         it 'accepts ensuring the correct maximum length' do
           expect(validating_array_length(maximum: 4)).
-            to validate_length_of(:attr).as_array.is_at_most(4)
+            to validate_length_of(:attr).is_at_most(4)
         end
 
         it 'rejects ensuring a lower maximum length with any message' do
           expect(validating_array_length(maximum: 4)).
-            not_to validate_length_of(:attr).as_array.is_at_most(3).with_long_message(/.*/)
+            not_to validate_length_of(:attr).is_at_most(3).with_long_message(/.*/)
         end
 
         it 'rejects ensuring a higher maximum length with any message' do
           expect(validating_array_length(maximum: 4)).
-            not_to validate_length_of(:attr).as_array.is_at_most(5).with_long_message(/.*/)
+            not_to validate_length_of(:attr).is_at_most(5).with_long_message(/.*/)
         end
 
         it 'does not override the default message with a blank' do
           expect(validating_array_length(maximum: 4)).
-            to validate_length_of(:attr).as_array.is_at_most(4).with_long_message(nil)
+            to validate_length_of(:attr).is_at_most(4).with_long_message(nil)
         end
       end
 
       context 'an attribute with a required exact length' do
         it 'accepts ensuring the correct length' do
           expect(validating_array_length(is: 4)).
-            to validate_length_of(:attr).as_array.is_equal_to(4)
+            to validate_length_of(:attr).is_equal_to(4)
         end
 
         it 'rejects ensuring a lower maximum length with any message' do
           expect(validating_array_length(is: 4)).
-            not_to validate_length_of(:attr).as_array.is_equal_to(3).with_message(/.*/)
+            not_to validate_length_of(:attr).is_equal_to(3).with_message(/.*/)
         end
 
         it 'rejects ensuring a higher maximum length with any message' do
           expect(validating_array_length(is: 4)).
-            not_to validate_length_of(:attr).as_array.is_equal_to(5).with_message(/.*/)
+            not_to validate_length_of(:attr).is_equal_to(5).with_message(/.*/)
         end
 
         it 'does not override the default message with a blank' do
           expect(validating_array_length(is: 4)).
+            to validate_length_of(:attr).is_equal_to(4).with_message(nil)
+        end
+      end
+    end
+
+    context 'when column is validated as array' do
+      context 'an attribute with a non-zero minimum length validation' do
+        it 'accepts ensuring the correct minimum length' do
+          expect(validating_length(type: :jsonb, minimum: 4)).
+            to validate_length_of(:attr).as_array.is_at_least(4)
+        end
+
+        it 'rejects ensuring a lower minimum length with any message' do
+          expect(validating_length(type: :jsonb, minimum: 4)).
+            not_to validate_length_of(:attr).as_array.is_at_least(3).with_short_message(/.*/)
+        end
+
+        it 'rejects ensuring a higher minimum length with any message' do
+          expect(validating_length(type: :jsonb, minimum: 4)).
+            not_to validate_length_of(:attr).as_array.is_at_least(5).with_short_message(/.*/)
+        end
+
+        it 'does not override the default message with a blank' do
+          expect(validating_length(type: :jsonb, minimum: 4)).
+            to validate_length_of(:attr).as_array.is_at_least(4).with_short_message(nil)
+        end
+
+        it 'fails when used in the negative' do
+          assertion = lambda do
+            expect(validating_length(type: :jsonb, minimum: 4)).
+              not_to validate_length_of(:attr).as_array.is_at_least(4)
+          end
+
+          message = <<-MESSAGE
+Expected Example not to validate that the length of :attr is at least 4,
+but this could not be proved.
+  After setting :attr to ‹["x", "x", "x", "x"]›, the matcher expected
+  the Example to be invalid, but it was valid instead.
+          MESSAGE
+
+          expect(&assertion).to fail_with_message(message)
+        end
+      end
+
+      context 'an attribute with a minimum length validation of 0' do
+        it 'accepts ensuring the correct minimum length' do
+          expect(validating_length(type: :jsonb, minimum: 0)).
+            to validate_length_of(:attr).as_array.is_at_least(0)
+        end
+      end
+
+      context 'an attribute with a maximum length' do
+        it 'accepts ensuring the correct maximum length' do
+          expect(validating_length(type: :jsonb, maximum: 4)).
+            to validate_length_of(:attr).as_array.is_at_most(4)
+        end
+
+        it 'rejects ensuring a lower maximum length with any message' do
+          expect(validating_length(type: :jsonb, maximum: 4)).
+            not_to validate_length_of(:attr).as_array.is_at_most(3).with_long_message(/.*/)
+        end
+
+        it 'rejects ensuring a higher maximum length with any message' do
+          expect(validating_length(type: :jsonb, maximum: 4)).
+            not_to validate_length_of(:attr).as_array.is_at_most(5).with_long_message(/.*/)
+        end
+
+        it 'does not override the default message with a blank' do
+          expect(validating_length(type: :jsonb, maximum: 4)).
+            to validate_length_of(:attr).as_array.is_at_most(4).with_long_message(nil)
+        end
+      end
+
+      context 'an attribute with a required exact length' do
+        it 'accepts ensuring the correct length' do
+          expect(validating_length(type: :jsonb, is: 4)).
+            to validate_length_of(:attr).as_array.is_equal_to(4)
+        end
+
+        it 'rejects ensuring a lower maximum length with any message' do
+          expect(validating_length(type: :jsonb, is: 4)).
+            not_to validate_length_of(:attr).as_array.is_equal_to(3).with_message(/.*/)
+        end
+
+        it 'rejects ensuring a higher maximum length with any message' do
+          expect(validating_length(type: :jsonb, is: 4)).
+            not_to validate_length_of(:attr).as_array.is_equal_to(5).with_message(/.*/)
+        end
+
+        it 'does not override the default message with a blank' do
+          expect(validating_length(type: :jsonb, is: 4)).
             to validate_length_of(:attr).as_array.is_equal_to(4).with_message(nil)
         end
       end
@@ -466,9 +557,10 @@ but this could not be proved.
   def define_model_validating_length(options = {})
     options = options.dup
     attribute_name = options.delete(:attribute_name) { :attr }
+    type = options.delete(:type) || :varchar
     array = options.delete(:array)
 
-    define_model(:example, attribute_name => { type: :varchar, options: { array: array } }) do |model|
+    define_model(:example, attribute_name => { type: type, options: { array: array } }) do |model|
       model.validates_length_of(attribute_name, options)
     end
   end


### PR DESCRIPTION
First step to close: https://github.com/thoughtbot/shoulda-matchers/issues/1559

# Solution

Were added two mechanisms to treat `validate_length_of_matcher` related attribute as array. One was through `array_column?` helper(also used on `validate_absence_of_matcher`) based on column type if `array?` helper is defined on model's `columns_hash` and another one with an explicit chain method `as_array` that will force to validate column with arrays values.
Why this way? First one will cover pure `array: true` columns for postgresql, second one could be dynamically used to check, for example, json columns storing arrays and being treated like that. This second approach will leave more freedom when using the validator.

Main validate_length_of_matcher specs were duplicated for the two variants. After all review's iteration for this PR concluded and if it's finally approved and merged this approach, I'll continue extending the array support to other validators(as inclusion/exclusion). 
