### PR TITLE
Removing array_column? helper from validate_absence_of_matcher

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_absence_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_absence_of_matcher.rb
@@ -143,12 +143,6 @@ module Shoulda
             @subject.class.reflect_on_association(@attribute)
         end
 
-        def array_column?
-          @subject.class.respond_to?(:columns_hash) &&
-            @subject.class.columns_hash[@attribute.to_s].respond_to?(:array) &&
-            @subject.class.columns_hash[@attribute.to_s].array
-        end
-
         def enum_column?
           @subject.class.respond_to?(:defined_enums) &&
             @subject.class.defined_enums.key?(@attribute.to_s)


### PR DESCRIPTION
In https://github.com/thoughtbot/shoulda-matchers/pull/1560, `array_column?` helper was extracted to base `validation_matcher` so this helper definition is no longer required on this matcher.