### PR TITLE
feat: Make `ValidateComparisonOfMatcher` inherit from `ValidationMatcher`

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_numericality_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_numericality_of_matcher.rb
@@ -498,20 +498,6 @@ module Shoulda
           qualify_submatchers
         end
 
-        def overall_failure_message
-          Shoulda::Matchers.word_wrap(
-            "Expected #{model.name} to #{description}, but this could not "\
-            'be proved.',
-          )
-        end
-
-        def overall_failure_message_when_negated
-          Shoulda::Matchers.word_wrap(
-            "Expected #{model.name} not to #{description}, but this could not "\
-            'be proved.',
-          )
-        end
-
         def attribute_is_active_record_column?
           columns_hash.key?(attribute.to_s)
         end


### PR DESCRIPTION
This PR intends to refactor the `ValidateComparisonOfMatcher` class to make it inherit from `ValidationMatcher` to continue on that pattern and make it consistent across all validation classes.

We are also removing some existing methods in the `ValidationMatcher` class from the `ValidateNumericalityOfMatcher` class.