### PR TITLE
Bump `appraisal` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'appraisal', '2.4.0'
+gem 'appraisal', '2.5.0'
 gem 'bundler', '~> 2.0'
 gem 'pry'
 gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    appraisal (2.4.0)
+    appraisal (2.5.0)
       bundler
       rake
       thor (>= 0.14.0)
@@ -82,7 +82,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  appraisal (= 2.4.0)
+  appraisal (= 2.5.0)
   bundler (~> 2.0)
   fssm
   pry

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal", "2.4.0"
+gem "appraisal", "2.5.0"
 gem "bundler", "~> 2.0"
 gem "pry"
 gem "pry-byebug"

--- a/gemfiles/rails_6_1.gemfile.lock
+++ b/gemfiles/rails_6_1.gemfile.lock
@@ -62,7 +62,7 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
-    appraisal (2.4.0)
+    appraisal (2.5.0)
       bundler
       rake
       thor (>= 0.14.0)
@@ -286,7 +286,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  appraisal (= 2.4.0)
+  appraisal (= 2.5.0)
   bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.4)
   bundler (~> 2.0)

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal", "2.4.0"
+gem "appraisal", "2.5.0"
 gem "bundler", "~> 2.0"
 gem "pry"
 gem "pry-byebug"

--- a/gemfiles/rails_7_0.gemfile.lock
+++ b/gemfiles/rails_7_0.gemfile.lock
@@ -68,7 +68,7 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
-    appraisal (2.4.0)
+    appraisal (2.5.0)
       bundler
       rake
       thor (>= 0.14.0)
@@ -282,7 +282,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  appraisal (= 2.4.0)
+  appraisal (= 2.5.0)
   bcrypt (~> 3.1.7)
   bootsnap
   bundler (~> 2.0)


### PR DESCRIPTION
I tried to run specs on my local, but it didn't work. It seems that ``appraisal` v2.4 has a problem with the latest bundler. So I would like to update to the V2.5.

Ref: https://github.com/thoughtbot/appraisal/issues/210#issuecomment-1562556347