### PR TITLE
remove invalid validate_comparison_of from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,8 +374,6 @@ about any of them, make sure to [consult the documentation][rubydocs]!
   tests usage of `validates_numericality_of`.
 * **[validate_presence_of](lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb)**
   tests usage of `validates_presence_of`.
-* **[validate_comparison_of](lib/shoulda/matchers/active_model/validate_comparison_of_matcher.rb)**
-  tests usage of `validates_comparison_of`.
 
 ### ActiveRecord matchers
 


### PR DESCRIPTION
The README on GitHub lists a `validates_comparison_of` shoulda matcher. However, in my testing I get an error that it doesn't exist - this is reflected in the official documentation (https://matchers.shoulda.io/docs/v5.3.0/#activemodel-matchers) Which does NOT have the `validates_comparison_of` matcher listed.