### PR TITLE
fix: catch ruby3.3 format NoMethodError message

### DIFF
--- a/lib/shoulda/matchers/independent/delegate_method_matcher.rb
+++ b/lib/shoulda/matchers/independent/delegate_method_matcher.rb
@@ -400,7 +400,7 @@ module Shoulda
                 false
               rescue NoMethodError => e
                 if e.message =~
-                   /undefined method `#{delegate_method}' for nil:NilClass/
+                   /undefined method `#{delegate_method}' for nil/
                   false
                 else
                   raise e


### PR DESCRIPTION
ruby3.3.0dev changes the error messages on NoMethodError with the following commit / issue:

https://github.com/ruby/ruby/pull/6950
https://bugs.ruby-lang.org/issues/18285

So to catch this new NoMethodError message, modify regex accordingly.

Fixes #1578 .