### PR TITLE
fix: Ensure that validation specs work for ActiveModel without ActiveRecord

### DIFF
--- a/lib/shoulda/matchers/rails_shim.rb
+++ b/lib/shoulda/matchers/rails_shim.rb
@@ -62,7 +62,7 @@ module Shoulda
         def serialized_attributes_for(model)
           attribute_types_for(model).
             inject({}) do |hash, (attribute_name, attribute_type)|
-              if attribute_type.is_a?(::ActiveRecord::Type::Serialized)
+              if Object.const_defined?('ActiveRecord::Type::Serialized') && attribute_type.is_a?(::ActiveRecord::Type::Serialized)
                 hash.merge(attribute_name => attribute_type.coder)
               else
                 hash

--- a/lib/shoulda/matchers/rails_shim.rb
+++ b/lib/shoulda/matchers/rails_shim.rb
@@ -60,9 +60,10 @@ module Shoulda
         end
 
         def serialized_attributes_for(model)
+          type_serialized_defined = Object.const_defined?('ActiveRecord::Type::Serialized')
           attribute_types_for(model).
             inject({}) do |hash, (attribute_name, attribute_type)|
-              if Object.const_defined?('ActiveRecord::Type::Serialized') && attribute_type.is_a?(::ActiveRecord::Type::Serialized)
+              if type_serialized_defined && attribute_type.is_a?(::ActiveRecord::Type::Serialized)
                 hash.merge(attribute_name => attribute_type.coder)
               else
                 hash


### PR DESCRIPTION
This change addresses issue #1553
It is a simple one liner allowing ActiveModel related matchers to run when ActiveRecord is not used.

There are no specs for this change due the fact that stubbing of the constant namespace is neither recommended, nor possible.
