### PR TITLE
refactor: Enhance unit test helpers loading

### DIFF
--- a/spec/support/unit/configuration.rb
+++ b/spec/support/unit/configuration.rb
@@ -1,0 +1,26 @@
+module UnitTests
+  class Configuration
+    CLASSES = %i[
+      ActiveModelHelpers
+      ActiveModelVersions
+      ActiveRecordVersions
+      ClassBuilder
+      ColumnTypeHelpers
+      ControllerBuilder
+      DatabaseHelpers
+      I18nFaker
+      MailerBuilder
+      MessageHelpers
+      ModelBuilder
+      RailsVersions
+      ValidationMatcherScenarioHelpers
+    ].freeze
+
+    def self.configure_example_groups(config)
+      CLASSES.each do |class_name|
+        constantized_class = "UnitTests::#{class_name}"
+        Object.const_get(constantized_class).configure_example_group(config)
+      end
+    end
+  end
+end

--- a/spec/unit_spec_helper.rb
+++ b/spec/unit_spec_helper.rb
@@ -15,20 +15,7 @@ end
 RSpec.configure do |config|
   config.include RSpec::Matchers::FailMatchers
 
-  UnitTests::ActiveModelHelpers.configure_example_group(config)
-  UnitTests::ActiveModelVersions.configure_example_group(config)
-  UnitTests::ClassBuilder.configure_example_group(config)
-  UnitTests::ControllerBuilder.configure_example_group(config)
-  UnitTests::I18nFaker.configure_example_group(config)
-  UnitTests::MailerBuilder.configure_example_group(config)
-  UnitTests::ModelBuilder.configure_example_group(config)
-  UnitTests::RailsVersions.configure_example_group(config)
-  UnitTests::ActiveRecordVersions.configure_example_group(config)
-  UnitTests::ActiveModelVersions.configure_example_group(config)
-  UnitTests::DatabaseHelpers.configure_example_group(config)
-  UnitTests::ColumnTypeHelpers.configure_example_group(config)
-  UnitTests::ValidationMatcherScenarioHelpers.configure_example_group(config)
-  UnitTests::MessageHelpers.configure_example_group(config)
+  UnitTests::Configuration.configure_example_groups(config)
 
   config.include UnitTests::Matchers
 


### PR DESCRIPTION
This commit refactors the way we load unit test helpers. Instead of requiring each file individually, we now have a single file that requires all of them. This makes it easier to add new helpers and ensures that they are loaded in the correct order.