### PR TITLE
fix: Adjust flaky spec on `ValidateAbsenceOfMatcher`

### DIFF
--- a/spec/support/unit/change_value.rb
+++ b/spec/support/unit/change_value.rb
@@ -41,6 +41,7 @@ module UnitTests
         value + [value.first.class.new]
       elsif value.respond_to?(:next)
         return value.to_date + 1.day if date_column?
+        return SecureRandom.uuid if uuid_column?
 
         value.next
       else
@@ -114,6 +115,10 @@ module UnitTests
 
     def date_column?
       [:date, :datetime, :time, :timestamp].include?(column_type)
+    end
+
+    def uuid_column?
+      column_type == :uuid
     end
   end
 end


### PR DESCRIPTION
I'm not entirely sure that this will fix this flaky spec, but my bet is that sometimes an invalid `uuid` was generated using the `next` method, this commit avoids that randomness by always generating a new and valid `uuid`.