### PR TITLE
adds failure_message_when_negated to have_secure_password_matcher

### DIFF
--- a/lib/shoulda/matchers/active_model/have_secure_password_matcher.rb
+++ b/lib/shoulda/matchers/active_model/have_secure_password_matcher.rb
@@ -47,6 +47,8 @@ module Shoulda
           did_not_authenticate_correct_password: 'expected %{subject} to'\
             ' authenticate the correct %{attribute}',
           method_not_found: 'expected %{subject} to respond to %{methods}',
+          should_not_have_secure_password: 'expected %{subject} to'\
+            ' not %{description}!',
         }.freeze
 
         def initialize(attribute)
@@ -67,6 +69,11 @@ module Shoulda
           end
 
           failure.nil?
+        end
+
+        def failure_message_when_negated
+          MESSAGES[:should_not_have_secure_password] %
+            { subject: @subject.class, description: description }
         end
 
         protected

--- a/spec/unit/shoulda/matchers/active_model/have_secure_password_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/have_secure_password_matcher_spec.rb
@@ -33,5 +33,18 @@ describe Shoulda::Matchers::ActiveModel::HaveSecurePasswordMatcher, type: :model
       no_digest_column = define_model(:example) { has_secure_password :reset_password }
       expect(no_digest_column.new).not_to have_secure_password :reset_password
     end
+
+    it 'rejects with an appropriate failure message' do
+      working_model = define_model(:example, reset_password_digest: :string) { has_secure_password :reset_password }
+      assertion = lambda do
+        expect(working_model.new).not_to have_secure_password :reset_password
+      end
+
+      message = <<-MESSAGE
+expected Example to not have a secure password, defined on reset_password attribute!
+      MESSAGE
+
+      expect(&assertion).to fail_with_message(message)
+    end
   end
 end


### PR DESCRIPTION
closes #1187 
credits goes to @Kutomore Im just adding missing specs to his solution on a new PR because I cant override PR #1192