### PR TITLE
chore: Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!-- By contributing to this project, you agree to abide by the thoughtbot Code
+of Conduct: https://thoughtbot.com/open-source-code-of-conduct -->
+
+### Description
+
+<!-- A clear and concise description of what the bug is. -->
+
+### Reproduction Steps
+
+<!-- Steps for others to reproduce the bug. Be as specific as possible. A
+reproduction script or link to a sample application that demonstrates the
+problem are especially helpful. -->
+
+<!-- You can create a reproduction script by copying this sample reproduction
+script and adding whatever code is necessary to get a failing test case:
+https://github.com/thoughtbot/shoulda-matchers/blob/main/.github/REPRODUCTION_SCRIPT.rb -->
+
+### Expected behavior
+
+<!-- What you expected to happen. -->
+
+### Actual behavior
+
+<!-- What happened instead. -->
+
+### System configuration
+**shoulda_matchers version**:  
+**rails version**:  
+**ruby version**:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,28 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!-- By contributing to this project, you agree to abide by the thoughtbot Code
+of Conduct: https://thoughtbot.com/open-source-code-of-conduct -->
+
+### Problem this feature will solve
+
+<!-- A clear and concise description of what the problem is. Ex. When doing
+[...] I find it difficult to [...] -->
+
+### Desired solution
+
+<!-- The feature or change that would solve the problem -->
+
+## Alternatives considered
+
+<!-- Any alternative solutions or features you've considered. -->
+
+## Additional context
+
+<!-- Add any other context about this feature request. -->

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
   TargetRubyVersion: 3.0
   Exclude:
     - 'gemfiles/*'
+    - 'REPRODUCTION_SCRIPT.rb'
 Bundler/OrderedGems:
   Include:
     - '**/Gemfile'

--- a/REPRODUCTION_SCRIPT.rb
+++ b/REPRODUCTION_SCRIPT.rb
@@ -1,0 +1,52 @@
+require 'bundler/inline'
+
+gemfile(true) do
+  source 'https://rubygems.org'
+  gem 'shoulda-matchers'
+  gem 'activerecord'
+  gem 'sqlite3'
+  gem 'rspec'
+end
+
+require 'active_record'
+require 'shoulda-matchers'
+require 'logger'
+
+ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
+ActiveRecord::Base.logger = Logger.new(STDOUT)
+
+# TODO: Update the schema to include the specific tables or columns necessary
+# to reproduct the bug
+ActiveRecord::Schema.define do
+  create_table :posts, force: true do |t|
+    t.string :body
+  end
+end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+
+    with.library :active_record
+    with.library :active_model
+  end
+end
+
+RSpec.configure do |config|
+  config.include Shoulda::Matchers::ActiveRecord
+  config.include Shoulda::Matchers::ActiveModel
+  config.include Shoulda::Matchers::ActionController
+end
+
+# TODO: Add any application specific code necessary to reproduce the bug
+class Post < ActiveRecord::Base
+  validates :body, uniqueness: true
+end
+
+# TODO: Write a failing test case to demonstrate what isn't working as
+# expected
+RSpec.describe Post do
+  describe 'validations' do
+    it { is_expected.to validate_uniqueness_of(:body) }
+  end
+end


### PR DESCRIPTION
Adding templates for opening issues. This is to help maintain the gem as the issues will have a pattern and possibly a reproduction script.