### PR TITLE
release: Bump version to 6.0.0 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 6.0.0 - 2022-12-22
 
 ### Backward-incompatible changes
 

--- a/README.md
+++ b/README.md
@@ -409,6 +409,8 @@ about any of them, make sure to [consult the documentation][rubydocs]!
   usage of the `serialize` macro.
 * **[validate_uniqueness_of](lib/shoulda/matchers/active_record/validate_uniqueness_of_matcher.rb)**
   tests usage of `validates_uniqueness_of`.
+* **[normalize](lib/shoulda/matchers/active_record/normalize_matcher.rb)** tests
+  usage of the `normalize` macro
 
 ### ActionController matchers
 

--- a/lib/shoulda/matchers/version.rb
+++ b/lib/shoulda/matchers/version.rb
@@ -1,6 +1,6 @@
 module Shoulda
   module Matchers
     # @private
-    VERSION = '5.3.0'.freeze
+    VERSION = '6.0.0'.freeze
   end
 end


### PR DESCRIPTION
@VSPPedro the bumping PR is ready. Once we have the changelog I can regenerate the docs, publish to RubyGems and create the new tag on GitHub.