### PR TITLE
fix: Adjust negative form of `ValidateNumericalityMatcher`

### DIFF
--- a/lib/shoulda/matchers/active_model/comparison_matcher.rb
+++ b/lib/shoulda/matchers/active_model/comparison_matcher.rb
@@ -78,11 +78,6 @@ module Shoulda
           comparison_submatchers.matches?(subject)
         end
 
-        def does_not_match?(subject)
-          @subject = subject
-          comparison_submatchers.does_not_match?(subject)
-        end
-
         def comparison_description
           "#{comparison_expectation} #{@value}"
         end

--- a/lib/shoulda/matchers/active_model/numericality_matchers/submatchers.rb
+++ b/lib/shoulda/matchers/active_model/numericality_matchers/submatchers.rb
@@ -13,11 +13,6 @@ module Shoulda
             failing_submatchers.empty?
           end
 
-          def does_not_match?(subject)
-            @subject = subject
-            non_failing_submatchers.empty?
-          end
-
           def failure_message
             failing_submatcher.failure_message
           end

--- a/lib/shoulda/matchers/active_model/validate_comparison_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_comparison_of_matcher.rb
@@ -465,7 +465,7 @@ module Shoulda
         def first_submatcher_that_fails_to_not_match
           @_first_submatcher_that_fails_to_not_match ||=
             @submatchers.detect do |submatcher|
-              !submatcher.does_not_match?(subject)
+              submatcher.matches?(subject)
             end
         end
 

--- a/spec/unit/shoulda/matchers/active_model/validate_numericality_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_numericality_of_matcher_spec.rb
@@ -1987,6 +1987,56 @@ could not be proved.
     end
   end
 
+  describe 'using in the negative form without numericality validations' do
+    context 'when qualified with is_greater_than' do
+      it 'accepts' do
+        record = (define_model :example, attr: :integer).new
+
+        expect(record).not_to validate_numericality.is_greater_than(18)
+      end
+    end
+
+    context 'when qualified with is_greater_than_or_equal_to' do
+      it 'accepts' do
+        record = (define_model :example, attr: :integer).new
+
+        expect(record).not_to validate_numericality.is_greater_than_or_equal_to(18)
+      end
+    end
+
+    context 'when qualified with is_less_than_or_equal_to' do
+      it 'accepts' do
+        record = (define_model :example, attr: :integer).new
+
+        expect(record).not_to validate_numericality.is_less_than_or_equal_to(18)
+      end
+    end
+
+    context 'when qualified with is_less_than' do
+      it 'accepts' do
+        record = (define_model :example, attr: :integer).new
+
+        expect(record).not_to validate_numericality.is_less_than(18)
+      end
+    end
+
+    context 'when qualified with is_equal_to' do
+      it 'accepts' do
+        record = (define_model :example, attr: :integer).new
+
+        expect(record).not_to validate_numericality.is_equal_to(18)
+      end
+    end
+
+    context 'when qualified with is_other_than' do
+      it 'accepts' do
+        record = (define_model :example, attr: :integer).new
+
+        expect(record).not_to validate_numericality.is_other_than(18)
+      end
+    end
+  end
+
   describe '#description' do
     context 'qualified with nothing' do
       it 'describes that it allows numbers' do


### PR DESCRIPTION
This commit adjusts the negative form of the `ValidateNumericalityMatcher` so that is does not use the `does_not_match?` method, but uses the negative result of the `matches?` method. This is easy to understand and requires no special handling for the negative form.

Previously, this matcher on the negative form was always returning `true`, as there were no `does_not_match?` method defined, which caused it to use the `does_not_match?` method from the `ValidationMatcher` parent class, which always returns `true`, this commit fixes that.

Closes: #1601 