### PR TITLE
Support association strict_loading option

### DIFF
--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -235,6 +235,18 @@ module Shoulda
       #       should have_many(:people).strict_loading(true)
       #     end
       #
+      # Default value is true when no argument is specified
+      #
+      #     # RSpec
+      #     RSpec.describe Organization, type: :model do
+      #       it { should have_many(:people).strict_loading }
+      #     end
+      #
+      #     # Minitest (Shoulda)
+      #     class OrganizationTest < ActiveSupport::TestCase
+      #       should have_many(:people).strict_loading
+      #     end
+      #
       # ##### autosave
       #
       # Use `autosave` to assert that the `:autosave` option was specified.

--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -217,6 +217,24 @@ module Shoulda
       #       should belong_to(:organization).touch(true)
       #     end
       #
+      # ##### strict_loading
+      #
+      # Use `strict_loading` to assert that the `:strict_loading` option was specified.
+      #
+      #     class Organization < ActiveRecord::Base
+      #       has_many :people, strict_loading: true
+      #     end
+      #
+      #     # RSpec
+      #     RSpec.describe Organization, type: :model do
+      #       it { should have_many(:people).strict_loading(true) }
+      #     end
+      #
+      #     # Minitest (Shoulda)
+      #     class OrganizationTest < ActiveSupport::TestCase
+      #       should have_many(:people).strict_loading(true)
+      #     end
+      #
       # ##### autosave
       #
       # Use `autosave` to assert that the `:autosave` option was specified.
@@ -1128,6 +1146,11 @@ module Shoulda
           self
         end
 
+        def strict_loading(strict_loading = true)
+          @options[:strict_loading] = strict_loading
+          self
+        end
+
         def join_table(join_table_name)
           @options[:join_table_name] = join_table_name
           self
@@ -1170,6 +1193,7 @@ module Shoulda
             conditions_correct? &&
             validate_correct? &&
             touch_correct? &&
+            strict_loading_correct? &&
             submatchers_match?
         end
 
@@ -1412,6 +1436,21 @@ module Shoulda
             @missing = "#{name} should have touch: #{options[:touch]}"
             false
           end
+        end
+
+        def strict_loading_correct?
+          return true unless options.key?(:strict_loading)
+
+          if option_verifier.correct_for_boolean?(:strict_loading, options[:strict_loading])
+            return true
+          end
+
+          @missing = [
+            "#{name} should have strict_loading set to ",
+            options[:strict_loading].to_s,
+          ].join
+
+          false
         end
 
         def class_has_foreign_key?(klass)

--- a/lib/shoulda/matchers/active_record/association_matchers/model_reflection.rb
+++ b/lib/shoulda/matchers/active_record/association_matchers/model_reflection.rb
@@ -13,7 +13,15 @@ module Shoulda
           end
 
           def associated_class
-            reflection.klass
+            associated_class = reflection.klass
+
+            if subject.strict_loading_by_default
+              unless reflection.options[:strict_loading] == false
+                reflection.options[:strict_loading] = true
+              end
+            end
+
+            associated_class
           end
 
           def polymorphic?

--- a/lib/shoulda/matchers/active_record/association_matchers/model_reflection.rb
+++ b/lib/shoulda/matchers/active_record/association_matchers/model_reflection.rb
@@ -13,13 +13,7 @@ module Shoulda
           end
 
           def associated_class
-            associated_class = reflection.klass
-
-            if subject.strict_loading_by_default && !(reflection.options[:strict_loading] == false)
-              reflection.options[:strict_loading] = true
-            end
-
-            associated_class
+            reflection.klass
           end
 
           def polymorphic?
@@ -74,6 +68,10 @@ module Shoulda
 
           def has_and_belongs_to_many_name
             reflection.options[:through]
+          end
+
+          def strict_loading?
+            reflection.options.fetch(:strict_loading, subject.strict_loading_by_default)
           end
 
           protected

--- a/lib/shoulda/matchers/active_record/association_matchers/model_reflection.rb
+++ b/lib/shoulda/matchers/active_record/association_matchers/model_reflection.rb
@@ -15,10 +15,8 @@ module Shoulda
           def associated_class
             associated_class = reflection.klass
 
-            if subject.strict_loading_by_default
-              unless reflection.options[:strict_loading] == false
-                reflection.options[:strict_loading] = true
-              end
+            if subject.strict_loading_by_default && !(reflection.options[:strict_loading] == false)
+              reflection.options[:strict_loading] = true
             end
 
             associated_class

--- a/lib/shoulda/matchers/active_record/association_matchers/option_verifier.rb
+++ b/lib/shoulda/matchers/active_record/association_matchers/option_verifier.rb
@@ -122,6 +122,10 @@ module Shoulda
             reflector.associated_class
           end
 
+          def actual_value_for_strict_loading
+            reflection.strict_loading?
+          end
+
           def actual_value_for_option(name)
             option_value = reflection.options[name]
 

--- a/spec/support/unit/helpers/application_configuration_helpers.rb
+++ b/spec/support/unit/helpers/application_configuration_helpers.rb
@@ -18,6 +18,24 @@ module UnitTests
       )
     end
 
+    def with_strict_loading_by_default_enabled(&block)
+      configuring_application(
+        ::ActiveRecord::Base,
+        :strict_loading_by_default,
+        true,
+        &block
+      )
+    end
+
+    def with_strict_loading_by_default_disabled(&block)
+      configuring_application(
+        ::ActiveRecord::Base,
+        :strict_loading_by_default,
+        false,
+        &block
+      )
+    end
+
     private
 
     def configuring_application(config, name, value)

--- a/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -1299,7 +1299,7 @@ Expected Parent to have a has_many association called children through conceptio
             with_strict_loading_by_default_disabled do
               message = [
                 'Expected Parent to have a has_many association called children ',
-                '(children should have strict_loading set to true)',
+                '(children should have strict_loading set to false)',
               ].join
 
               define_model :child, parent_id: :integer
@@ -1332,7 +1332,7 @@ Expected Parent to have a has_many association called children through conceptio
             with_strict_loading_by_default_disabled do
               message = [
                 'Expected Parent to have a has_many association called children ',
-                '(children should have strict_loading set to false)',
+                '(children should have strict_loading set to true)',
               ].join
 
               define_model :child, parent_id: :integer
@@ -1351,7 +1351,7 @@ Expected Parent to have a has_many association called children through conceptio
             with_strict_loading_by_default_disabled do
               message = [
                 'Expected Parent to have a has_many association called children ',
-                '(children should have strict_loading set to false)',
+                '(children should have strict_loading set to true)',
               ].join
 
               define_model :child, parent_id: :integer
@@ -1367,11 +1367,176 @@ Expected Parent to have a has_many association called children through conceptio
           end
         end
       end
-
-      # TODO: tests with self.strict_loading_by_default = true on model
     end
 
     context 'when the application is configured with strict_loading enabled by default' do
+      context 'when the association is configured with a strict_loading constraint' do
+        context 'when qualified with strict_loading(true)' do
+          it 'accepts an association with a matching :strict_loading option' do
+            with_strict_loading_by_default_enabled do
+              expect(having_many_children(strict_loading: true)).
+                to have_many(:children).strict_loading(true)
+            end
+          end
+
+          it 'accepts an association with a matching :strict_loading option without explicit value' do
+            with_strict_loading_by_default_enabled do
+              expect(having_many_children(strict_loading: true)).
+                to have_many(:children).strict_loading
+            end
+          end
+
+          it 'rejects an association with a non-matching :strict_loading option with the correct message' do
+            with_strict_loading_by_default_enabled do
+              message = [
+                'Expected Parent to have a has_many association called children ',
+                '(children should have strict_loading set to false)',
+              ].join
+
+              expect {
+                expect(having_many_children(strict_loading: true)).
+                  to have_many(:children).strict_loading(false)
+              }.to fail_with_message(message)
+            end
+          end
+        end
+
+        context 'when qualified with strict_loading(false)' do
+          it 'accepts an association with a matching :strict_loading option' do
+            with_strict_loading_by_default_enabled do
+              expect(having_many_children(strict_loading: false)).
+                to have_many(:children).strict_loading(false)
+            end
+          end
+
+          it 'rejects an association with a matching :strict_loading option without explicit value with the correct message' do
+            with_strict_loading_by_default_enabled do
+              message = [
+                'Expected Parent to have a has_many association called children ',
+                '(children should have strict_loading set to true)',
+              ].join
+
+              expect {
+                expect(having_many_children(strict_loading: false)).
+                  to have_many(:children).strict_loading
+              }.to fail_with_message(message)
+            end
+          end
+
+          it 'rejects an association with a non-matching :strict_loading option with the correct message' do
+            with_strict_loading_by_default_enabled do
+              message = [
+                'Expected Parent to have a has_many association called children ',
+                '(children should have strict_loading set to true)',
+              ].join
+
+              expect {
+                expect(having_many_children(strict_loading: false)).
+                  to have_many(:children).strict_loading(true)
+              }.to fail_with_message(message)
+            end
+          end
+        end
+      end
+
+      context 'when strict_loading is defined on the model level' do
+        context 'when it is set to true' do
+          it 'accepts an association with a matching :strict_loading option' do
+            with_strict_loading_by_default_enabled do
+              define_model :child, parent_id: :integer
+              parent = define_model(:parent) do |model|
+                model.strict_loading_by_default = true
+                model.has_many :children
+              end.new
+
+              expect(parent).to have_many(:children).strict_loading(true)
+            end
+          end
+
+          it 'accepts an association with a matching :strict_loading option without explicit value' do
+            with_strict_loading_by_default_enabled do
+              define_model :child, parent_id: :integer
+              parent = define_model(:parent) do |model|
+                model.strict_loading_by_default = true
+                model.has_many :children
+              end.new
+
+              expect(parent).to have_many(:children).strict_loading
+            end
+          end
+
+          it 'rejects an association with a non-matching :strict_loading option with the correct message' do
+            with_strict_loading_by_default_enabled do
+              message = [
+                'Expected Parent to have a has_many association called children ',
+                '(children should have strict_loading set to false)',
+              ].join
+
+              define_model :child, parent_id: :integer
+              parent = define_model(:parent) do |model|
+                model.strict_loading_by_default = true
+                model.has_many :children
+              end.new
+
+              expect {
+                expect(parent).to have_many(:children).strict_loading(false)
+              }.to fail_with_message(message)
+            end
+          end
+        end
+
+        context 'when it is set to false' do
+          it 'accepts an association with a matching :strict_loading option' do
+            with_strict_loading_by_default_enabled do
+              define_model :child, parent_id: :integer
+              parent = define_model(:parent) do |model|
+                model.strict_loading_by_default = false
+                model.has_many :children
+              end.new
+
+              expect(parent).to have_many(:children).strict_loading(false)
+            end
+          end
+
+          it 'rejects an association with a non-matching :strict_loading option without explicit value with the correct message' do
+            with_strict_loading_by_default_enabled do
+              message = [
+                'Expected Parent to have a has_many association called children ',
+                '(children should have strict_loading set to true)',
+              ].join
+
+              define_model :child, parent_id: :integer
+              parent = define_model(:parent) do |model|
+                model.strict_loading_by_default = false
+                model.has_many :children
+              end.new
+
+              expect {
+                expect(parent).to have_many(:children).strict_loading
+              }.to fail_with_message(message)
+            end
+          end
+
+          it 'rejects an association with a non-matching :strict_loading option with the correct message' do
+            with_strict_loading_by_default_enabled do
+              message = [
+                'Expected Parent to have a has_many association called children ',
+                '(children should have strict_loading set to true)',
+              ].join
+
+              define_model :child, parent_id: :integer
+              parent = define_model(:parent) do |model|
+                model.strict_loading_by_default = false
+                model.has_many :children
+              end.new
+
+              expect {
+                expect(parent).to have_many(:children).strict_loading(true)
+              }.to fail_with_message(message)
+            end
+          end
+        end
+      end
     end
 
     def having_many_children(options = {})

--- a/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -1199,21 +1199,179 @@ Expected Parent to have a has_many association called children through conceptio
       expect(Parent.new).to have_many(:children)
     end
 
-    it 'accepts an association with a matching :strict_loading option' do
-      expect(having_many_children(strict_loading: true)).
-        to have_many(:children).strict_loading(true)
+    context 'when the application is configured with strict_loading disabled by default' do
+      context 'when the association is configured with a strict_loading constraint' do
+        context 'when qualified with strict_loading(true)' do
+          it 'accepts an association with a matching :strict_loading option' do
+            with_strict_loading_by_default_disabled do
+              expect(having_many_children(strict_loading: true)).
+                to have_many(:children).strict_loading(true)
+            end
+          end
+
+          it 'accepts an association with a matching :strict_loading option without explicit value' do
+            with_strict_loading_by_default_disabled do
+              expect(having_many_children(strict_loading: true)).
+                to have_many(:children).strict_loading
+            end
+          end
+
+          it 'rejects an association with a non-matching :strict_loading option with the correct message' do
+            with_strict_loading_by_default_disabled do
+              message = [
+                'Expected Parent to have a has_many association called children ',
+                '(children should have strict_loading set to false)',
+              ].join
+
+              expect {
+                expect(having_many_children(strict_loading: true)).
+                  to have_many(:children).strict_loading(false)
+              }.to fail_with_message(message)
+            end
+          end
+        end
+
+        context 'when qualified with strict_loading(false)' do
+          it 'accepts an association with a matching :strict_loading option' do
+            with_strict_loading_by_default_disabled do
+              expect(having_many_children(strict_loading: false)).
+                to have_many(:children).strict_loading(false)
+            end
+          end
+
+          it 'rejects an association with a matching :strict_loading option without explicit value with the correct message' do
+            with_strict_loading_by_default_disabled do
+              message = [
+                'Expected Parent to have a has_many association called children ',
+                '(children should have strict_loading set to true)',
+              ].join
+
+              expect {
+                expect(having_many_children(strict_loading: false)).
+                  to have_many(:children).strict_loading
+              }.to fail_with_message(message)
+            end
+          end
+
+          it 'rejects an association with a non-matching :strict_loading option with the correct message' do
+            with_strict_loading_by_default_disabled do
+              message = [
+                'Expected Parent to have a has_many association called children ',
+                '(children should have strict_loading set to true)',
+              ].join
+
+              expect {
+                expect(having_many_children(strict_loading: false)).
+                  to have_many(:children).strict_loading(true)
+              }.to fail_with_message(message)
+            end
+          end
+        end
+      end
+
+      context 'when strict_loading is defined on the model level' do
+        context 'when it is set to true' do
+          it 'accepts an association with a matching :strict_loading option' do
+            with_strict_loading_by_default_disabled do
+              define_model :child, parent_id: :integer
+              parent = define_model(:parent) do |model|
+                model.strict_loading_by_default = true
+                model.has_many :children
+              end.new
+
+              expect(parent).to have_many(:children).strict_loading(true)
+            end
+          end
+
+          it 'accepts an association with a matching :strict_loading option without explicit value' do
+            with_strict_loading_by_default_disabled do
+              define_model :child, parent_id: :integer
+              parent = define_model(:parent) do |model|
+                model.strict_loading_by_default = true
+                model.has_many :children
+              end.new
+
+              expect(parent).to have_many(:children).strict_loading
+            end
+          end
+
+          it 'rejects an association with a non-matching :strict_loading option with the correct message' do
+            with_strict_loading_by_default_disabled do
+              message = [
+                'Expected Parent to have a has_many association called children ',
+                '(children should have strict_loading set to true)',
+              ].join
+
+              define_model :child, parent_id: :integer
+              parent = define_model(:parent) do |model|
+                model.strict_loading_by_default = true
+                model.has_many :children
+              end.new
+
+              expect {
+                expect(parent).to have_many(:children).strict_loading(false)
+              }.to fail_with_message(message)
+            end
+          end
+        end
+
+        context 'when it is set to false' do
+          it 'accepts an association with a matching :strict_loading option' do
+            with_strict_loading_by_default_disabled do
+              define_model :child, parent_id: :integer
+              parent = define_model(:parent) do |model|
+                model.strict_loading_by_default = false
+                model.has_many :children
+              end.new
+
+              expect(parent).to have_many(:children).strict_loading(false)
+            end
+          end
+
+          it 'rejects an association with a non-matching :strict_loading option without explicit value with the correct message' do
+            with_strict_loading_by_default_disabled do
+              message = [
+                'Expected Parent to have a has_many association called children ',
+                '(children should have strict_loading set to false)',
+              ].join
+
+              define_model :child, parent_id: :integer
+              parent = define_model(:parent) do |model|
+                model.strict_loading_by_default = false
+                model.has_many :children
+              end.new
+
+              expect {
+                expect(parent).to have_many(:children).strict_loading
+              }.to fail_with_message(message)
+            end
+          end
+
+          it 'rejects an association with a non-matching :strict_loading option with the correct message' do
+            with_strict_loading_by_default_disabled do
+              message = [
+                'Expected Parent to have a has_many association called children ',
+                '(children should have strict_loading set to false)',
+              ].join
+
+              define_model :child, parent_id: :integer
+              parent = define_model(:parent) do |model|
+                model.strict_loading_by_default = false
+                model.has_many :children
+              end.new
+
+              expect {
+                expect(parent).to have_many(:children).strict_loading(true)
+              }.to fail_with_message(message)
+            end
+          end
+        end
+      end
+
+      # TODO: tests with self.strict_loading_by_default = true on model
     end
 
-    it 'rejects an association with a non-matching :strict_loading option with the correct message' do
-      message = [
-        'Expected Parent to have a has_many association called children ',
-        '(children should have strict_loading set to true)',
-      ].join
-
-      expect {
-        expect(having_many_children).
-          to have_many(:children).strict_loading(true)
-      }.to fail_with_message(message)
+    context 'when the application is configured with strict_loading enabled by default' do
     end
 
     def having_many_children(options = {})

--- a/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -1199,403 +1199,405 @@ Expected Parent to have a has_many association called children through conceptio
       expect(Parent.new).to have_many(:children)
     end
 
-    context 'when the application is configured with strict_loading disabled by default' do
-      it 'accepts an association with a matching :strict_loading option' do
-        with_strict_loading_by_default_disabled do
-          expect(having_many_children).
-            to have_many(:children).strict_loading(false)
-        end
-      end
-
-      it 'rejects an association with a non-matching :strict_loading option without explicit value with the correct message' do
-        with_strict_loading_by_default_disabled do
-          message = [
-            'Expected Parent to have a has_many association called children ',
-            '(children should have strict_loading set to true)',
-          ].join
-
-          expect {
-            expect(having_many_children).
-              to have_many(:children).strict_loading
-          }.to fail_with_message(message)
-        end
-      end
-
-      it 'rejects an association with a non-matching :strict_loading option with the correct message' do
-        with_strict_loading_by_default_disabled do
-          message = [
-            'Expected Parent to have a has_many association called children ',
-            '(children should have strict_loading set to true)',
-          ].join
-
-          expect {
-            expect(having_many_children).
-              to have_many(:children).strict_loading(true)
-          }.to fail_with_message(message)
-        end
-      end
-
-      context 'when the association is configured with a strict_loading constraint' do
-        context 'when qualified with strict_loading(true)' do
-          it 'accepts an association with a matching :strict_loading option' do
-            with_strict_loading_by_default_disabled do
-              expect(having_many_children(strict_loading: true)).
-                to have_many(:children).strict_loading(true)
-            end
-          end
-
-          it 'accepts an association with a matching :strict_loading option without explicit value' do
-            with_strict_loading_by_default_disabled do
-              expect(having_many_children(strict_loading: true)).
-                to have_many(:children).strict_loading
-            end
-          end
-
-          it 'rejects an association with a non-matching :strict_loading option with the correct message' do
-            with_strict_loading_by_default_disabled do
-              message = [
-                'Expected Parent to have a has_many association called children ',
-                '(children should have strict_loading set to false)',
-              ].join
-
-              expect {
-                expect(having_many_children(strict_loading: true)).
-                  to have_many(:children).strict_loading(false)
-              }.to fail_with_message(message)
-            end
-          end
-        end
-
-        context 'when qualified with strict_loading(false)' do
-          it 'accepts an association with a matching :strict_loading option' do
-            with_strict_loading_by_default_disabled do
-              expect(having_many_children(strict_loading: false)).
-                to have_many(:children).strict_loading(false)
-            end
-          end
-
-          it 'rejects an association with a non-matching :strict_loading option without explicit value with the correct message' do
-            with_strict_loading_by_default_disabled do
-              message = [
-                'Expected Parent to have a has_many association called children ',
-                '(children should have strict_loading set to true)',
-              ].join
-
-              expect {
-                expect(having_many_children(strict_loading: false)).
-                  to have_many(:children).strict_loading
-              }.to fail_with_message(message)
-            end
-          end
-
-          it 'rejects an association with a non-matching :strict_loading option with the correct message' do
-            with_strict_loading_by_default_disabled do
-              message = [
-                'Expected Parent to have a has_many association called children ',
-                '(children should have strict_loading set to true)',
-              ].join
-
-              expect {
-                expect(having_many_children(strict_loading: false)).
-                  to have_many(:children).strict_loading(true)
-              }.to fail_with_message(message)
-            end
-          end
-        end
-      end
-
-      context 'when strict_loading is defined on the model level' do
-        context 'when it is set to true' do
-          it 'accepts an association with a matching :strict_loading option' do
-            with_strict_loading_by_default_disabled do
-              define_model :child, parent_id: :integer
-              parent = define_model(:parent) do |model|
-                model.strict_loading_by_default = true
-                model.has_many :children
-              end.new
-
-              expect(parent).to have_many(:children).strict_loading(true)
-            end
-          end
-
-          it 'accepts an association with a matching :strict_loading option without explicit value' do
-            with_strict_loading_by_default_disabled do
-              define_model :child, parent_id: :integer
-              parent = define_model(:parent) do |model|
-                model.strict_loading_by_default = true
-                model.has_many :children
-              end.new
-
-              expect(parent).to have_many(:children).strict_loading
-            end
-          end
-
-          it 'rejects an association with a non-matching :strict_loading option with the correct message' do
-            with_strict_loading_by_default_disabled do
-              message = [
-                'Expected Parent to have a has_many association called children ',
-                '(children should have strict_loading set to false)',
-              ].join
-
-              define_model :child, parent_id: :integer
-              parent = define_model(:parent) do |model|
-                model.strict_loading_by_default = true
-                model.has_many :children
-              end.new
-
-              expect {
-                expect(parent).to have_many(:children).strict_loading(false)
-              }.to fail_with_message(message)
-            end
-          end
-        end
-
-        context 'when it is set to false' do
-          it 'accepts an association with a matching :strict_loading option' do
-            with_strict_loading_by_default_disabled do
-              define_model :child, parent_id: :integer
-              parent = define_model(:parent) do |model|
-                model.strict_loading_by_default = false
-                model.has_many :children
-              end.new
-
-              expect(parent).to have_many(:children).strict_loading(false)
-            end
-          end
-
-          it 'rejects an association with a non-matching :strict_loading option without explicit value with the correct message' do
-            with_strict_loading_by_default_disabled do
-              message = [
-                'Expected Parent to have a has_many association called children ',
-                '(children should have strict_loading set to true)',
-              ].join
-
-              define_model :child, parent_id: :integer
-              parent = define_model(:parent) do |model|
-                model.strict_loading_by_default = false
-                model.has_many :children
-              end.new
-
-              expect {
-                expect(parent).to have_many(:children).strict_loading
-              }.to fail_with_message(message)
-            end
-          end
-
-          it 'rejects an association with a non-matching :strict_loading option with the correct message' do
-            with_strict_loading_by_default_disabled do
-              message = [
-                'Expected Parent to have a has_many association called children ',
-                '(children should have strict_loading set to true)',
-              ].join
-
-              define_model :child, parent_id: :integer
-              parent = define_model(:parent) do |model|
-                model.strict_loading_by_default = false
-                model.has_many :children
-              end.new
-
-              expect {
-                expect(parent).to have_many(:children).strict_loading(true)
-              }.to fail_with_message(message)
-            end
-          end
-        end
-      end
-    end
-
-    context 'when the application is configured with strict_loading enabled by default' do
-      it 'accepts an association with a matching :strict_loading option' do
-        with_strict_loading_by_default_enabled do
-          expect(having_many_children).
-            to have_many(:children).strict_loading(true)
-        end
-      end
-
-      it 'accepts an association with a matching :strict_loading option without explicit value' do
-        with_strict_loading_by_default_enabled do
-          expect(having_many_children).
-            to have_many(:children).strict_loading
-        end
-      end
-
-      it 'rejects an association with a non-matching :strict_loading option with the correct message' do
-        with_strict_loading_by_default_enabled do
-          message = [
-            'Expected Parent to have a has_many association called children ',
-            '(children should have strict_loading set to false)',
-          ].join
-
-          expect {
+    describe 'strict_loading' do
+      context 'when the application is configured with strict_loading disabled by default' do
+        it 'accepts an association with a matching :strict_loading option' do
+          with_strict_loading_by_default_disabled do
             expect(having_many_children).
               to have_many(:children).strict_loading(false)
-          }.to fail_with_message(message)
-        end
-      end
-
-      context 'when the association is configured with a strict_loading constraint' do
-        context 'when qualified with strict_loading(true)' do
-          it 'accepts an association with a matching :strict_loading option' do
-            with_strict_loading_by_default_enabled do
-              expect(having_many_children(strict_loading: true)).
-                to have_many(:children).strict_loading(true)
-            end
           end
+        end
 
-          it 'accepts an association with a matching :strict_loading option without explicit value' do
-            with_strict_loading_by_default_enabled do
-              expect(having_many_children(strict_loading: true)).
+        it 'rejects an association with a non-matching :strict_loading option without explicit value with the correct message' do
+          with_strict_loading_by_default_disabled do
+            message = [
+              'Expected Parent to have a has_many association called children ',
+              '(children should have strict_loading set to true)',
+            ].join
+
+            expect {
+              expect(having_many_children).
                 to have_many(:children).strict_loading
+            }.to fail_with_message(message)
+          end
+        end
+
+        it 'rejects an association with a non-matching :strict_loading option with the correct message' do
+          with_strict_loading_by_default_disabled do
+            message = [
+              'Expected Parent to have a has_many association called children ',
+              '(children should have strict_loading set to true)',
+            ].join
+
+            expect {
+              expect(having_many_children).
+                to have_many(:children).strict_loading(true)
+            }.to fail_with_message(message)
+          end
+        end
+
+        context 'when the association is configured with a strict_loading constraint' do
+          context 'when qualified with strict_loading(true)' do
+            it 'accepts an association with a matching :strict_loading option' do
+              with_strict_loading_by_default_disabled do
+                expect(having_many_children(strict_loading: true)).
+                  to have_many(:children).strict_loading(true)
+              end
+            end
+
+            it 'accepts an association with a matching :strict_loading option without explicit value' do
+              with_strict_loading_by_default_disabled do
+                expect(having_many_children(strict_loading: true)).
+                  to have_many(:children).strict_loading
+              end
+            end
+
+            it 'rejects an association with a non-matching :strict_loading option with the correct message' do
+              with_strict_loading_by_default_disabled do
+                message = [
+                  'Expected Parent to have a has_many association called children ',
+                  '(children should have strict_loading set to false)',
+                ].join
+
+                expect {
+                  expect(having_many_children(strict_loading: true)).
+                    to have_many(:children).strict_loading(false)
+                }.to fail_with_message(message)
+              end
             end
           end
 
-          it 'rejects an association with a non-matching :strict_loading option with the correct message' do
-            with_strict_loading_by_default_enabled do
-              message = [
-                'Expected Parent to have a has_many association called children ',
-                '(children should have strict_loading set to false)',
-              ].join
-
-              expect {
-                expect(having_many_children(strict_loading: true)).
+          context 'when qualified with strict_loading(false)' do
+            it 'accepts an association with a matching :strict_loading option' do
+              with_strict_loading_by_default_disabled do
+                expect(having_many_children(strict_loading: false)).
                   to have_many(:children).strict_loading(false)
-              }.to fail_with_message(message)
+              end
+            end
+
+            it 'rejects an association with a non-matching :strict_loading option without explicit value with the correct message' do
+              with_strict_loading_by_default_disabled do
+                message = [
+                  'Expected Parent to have a has_many association called children ',
+                  '(children should have strict_loading set to true)',
+                ].join
+
+                expect {
+                  expect(having_many_children(strict_loading: false)).
+                    to have_many(:children).strict_loading
+                }.to fail_with_message(message)
+              end
+            end
+
+            it 'rejects an association with a non-matching :strict_loading option with the correct message' do
+              with_strict_loading_by_default_disabled do
+                message = [
+                  'Expected Parent to have a has_many association called children ',
+                  '(children should have strict_loading set to true)',
+                ].join
+
+                expect {
+                  expect(having_many_children(strict_loading: false)).
+                    to have_many(:children).strict_loading(true)
+                }.to fail_with_message(message)
+              end
             end
           end
         end
 
-        context 'when qualified with strict_loading(false)' do
-          it 'accepts an association with a matching :strict_loading option' do
-            with_strict_loading_by_default_enabled do
-              expect(having_many_children(strict_loading: false)).
-                to have_many(:children).strict_loading(false)
+        context 'when strict_loading is defined on the model level' do
+          context 'when it is set to true' do
+            it 'accepts an association with a matching :strict_loading option' do
+              with_strict_loading_by_default_disabled do
+                define_model :child, parent_id: :integer
+                parent = define_model(:parent) do |model|
+                  model.strict_loading_by_default = true
+                  model.has_many :children
+                end.new
+
+                expect(parent).to have_many(:children).strict_loading(true)
+              end
+            end
+
+            it 'accepts an association with a matching :strict_loading option without explicit value' do
+              with_strict_loading_by_default_disabled do
+                define_model :child, parent_id: :integer
+                parent = define_model(:parent) do |model|
+                  model.strict_loading_by_default = true
+                  model.has_many :children
+                end.new
+
+                expect(parent).to have_many(:children).strict_loading
+              end
+            end
+
+            it 'rejects an association with a non-matching :strict_loading option with the correct message' do
+              with_strict_loading_by_default_disabled do
+                message = [
+                  'Expected Parent to have a has_many association called children ',
+                  '(children should have strict_loading set to false)',
+                ].join
+
+                define_model :child, parent_id: :integer
+                parent = define_model(:parent) do |model|
+                  model.strict_loading_by_default = true
+                  model.has_many :children
+                end.new
+
+                expect {
+                  expect(parent).to have_many(:children).strict_loading(false)
+                }.to fail_with_message(message)
+              end
             end
           end
 
-          it 'rejects an association with a non-matching :strict_loading option without explicit value with the correct message' do
-            with_strict_loading_by_default_enabled do
-              message = [
-                'Expected Parent to have a has_many association called children ',
-                '(children should have strict_loading set to true)',
-              ].join
+          context 'when it is set to false' do
+            it 'accepts an association with a matching :strict_loading option' do
+              with_strict_loading_by_default_disabled do
+                define_model :child, parent_id: :integer
+                parent = define_model(:parent) do |model|
+                  model.strict_loading_by_default = false
+                  model.has_many :children
+                end.new
 
-              expect {
-                expect(having_many_children(strict_loading: false)).
-                  to have_many(:children).strict_loading
-              }.to fail_with_message(message)
+                expect(parent).to have_many(:children).strict_loading(false)
+              end
             end
-          end
 
-          it 'rejects an association with a non-matching :strict_loading option with the correct message' do
-            with_strict_loading_by_default_enabled do
-              message = [
-                'Expected Parent to have a has_many association called children ',
-                '(children should have strict_loading set to true)',
-              ].join
+            it 'rejects an association with a non-matching :strict_loading option without explicit value with the correct message' do
+              with_strict_loading_by_default_disabled do
+                message = [
+                  'Expected Parent to have a has_many association called children ',
+                  '(children should have strict_loading set to true)',
+                ].join
 
-              expect {
-                expect(having_many_children(strict_loading: false)).
-                  to have_many(:children).strict_loading(true)
-              }.to fail_with_message(message)
+                define_model :child, parent_id: :integer
+                parent = define_model(:parent) do |model|
+                  model.strict_loading_by_default = false
+                  model.has_many :children
+                end.new
+
+                expect {
+                  expect(parent).to have_many(:children).strict_loading
+                }.to fail_with_message(message)
+              end
+            end
+
+            it 'rejects an association with a non-matching :strict_loading option with the correct message' do
+              with_strict_loading_by_default_disabled do
+                message = [
+                  'Expected Parent to have a has_many association called children ',
+                  '(children should have strict_loading set to true)',
+                ].join
+
+                define_model :child, parent_id: :integer
+                parent = define_model(:parent) do |model|
+                  model.strict_loading_by_default = false
+                  model.has_many :children
+                end.new
+
+                expect {
+                  expect(parent).to have_many(:children).strict_loading(true)
+                }.to fail_with_message(message)
+              end
             end
           end
         end
       end
 
-      context 'when strict_loading is defined on the model level' do
-        context 'when it is set to true' do
-          it 'accepts an association with a matching :strict_loading option' do
-            with_strict_loading_by_default_enabled do
-              define_model :child, parent_id: :integer
-              parent = define_model(:parent) do |model|
-                model.strict_loading_by_default = true
-                model.has_many :children
-              end.new
+      context 'when the application is configured with strict_loading enabled by default' do
+        it 'accepts an association with a matching :strict_loading option' do
+          with_strict_loading_by_default_enabled do
+            expect(having_many_children).
+              to have_many(:children).strict_loading(true)
+          end
+        end
 
-              expect(parent).to have_many(:children).strict_loading(true)
+        it 'accepts an association with a matching :strict_loading option without explicit value' do
+          with_strict_loading_by_default_enabled do
+            expect(having_many_children).
+              to have_many(:children).strict_loading
+          end
+        end
+
+        it 'rejects an association with a non-matching :strict_loading option with the correct message' do
+          with_strict_loading_by_default_enabled do
+            message = [
+              'Expected Parent to have a has_many association called children ',
+              '(children should have strict_loading set to false)',
+            ].join
+
+            expect {
+              expect(having_many_children).
+                to have_many(:children).strict_loading(false)
+            }.to fail_with_message(message)
+          end
+        end
+
+        context 'when the association is configured with a strict_loading constraint' do
+          context 'when qualified with strict_loading(true)' do
+            it 'accepts an association with a matching :strict_loading option' do
+              with_strict_loading_by_default_enabled do
+                expect(having_many_children(strict_loading: true)).
+                  to have_many(:children).strict_loading(true)
+              end
+            end
+
+            it 'accepts an association with a matching :strict_loading option without explicit value' do
+              with_strict_loading_by_default_enabled do
+                expect(having_many_children(strict_loading: true)).
+                  to have_many(:children).strict_loading
+              end
+            end
+
+            it 'rejects an association with a non-matching :strict_loading option with the correct message' do
+              with_strict_loading_by_default_enabled do
+                message = [
+                  'Expected Parent to have a has_many association called children ',
+                  '(children should have strict_loading set to false)',
+                ].join
+
+                expect {
+                  expect(having_many_children(strict_loading: true)).
+                    to have_many(:children).strict_loading(false)
+                }.to fail_with_message(message)
+              end
             end
           end
 
-          it 'accepts an association with a matching :strict_loading option without explicit value' do
-            with_strict_loading_by_default_enabled do
-              define_model :child, parent_id: :integer
-              parent = define_model(:parent) do |model|
-                model.strict_loading_by_default = true
-                model.has_many :children
-              end.new
-
-              expect(parent).to have_many(:children).strict_loading
+          context 'when qualified with strict_loading(false)' do
+            it 'accepts an association with a matching :strict_loading option' do
+              with_strict_loading_by_default_enabled do
+                expect(having_many_children(strict_loading: false)).
+                  to have_many(:children).strict_loading(false)
+              end
             end
-          end
 
-          it 'rejects an association with a non-matching :strict_loading option with the correct message' do
-            with_strict_loading_by_default_enabled do
-              message = [
-                'Expected Parent to have a has_many association called children ',
-                '(children should have strict_loading set to false)',
-              ].join
+            it 'rejects an association with a non-matching :strict_loading option without explicit value with the correct message' do
+              with_strict_loading_by_default_enabled do
+                message = [
+                  'Expected Parent to have a has_many association called children ',
+                  '(children should have strict_loading set to true)',
+                ].join
 
-              define_model :child, parent_id: :integer
-              parent = define_model(:parent) do |model|
-                model.strict_loading_by_default = true
-                model.has_many :children
-              end.new
+                expect {
+                  expect(having_many_children(strict_loading: false)).
+                    to have_many(:children).strict_loading
+                }.to fail_with_message(message)
+              end
+            end
 
-              expect {
-                expect(parent).to have_many(:children).strict_loading(false)
-              }.to fail_with_message(message)
+            it 'rejects an association with a non-matching :strict_loading option with the correct message' do
+              with_strict_loading_by_default_enabled do
+                message = [
+                  'Expected Parent to have a has_many association called children ',
+                  '(children should have strict_loading set to true)',
+                ].join
+
+                expect {
+                  expect(having_many_children(strict_loading: false)).
+                    to have_many(:children).strict_loading(true)
+                }.to fail_with_message(message)
+              end
             end
           end
         end
 
-        context 'when it is set to false' do
-          it 'accepts an association with a matching :strict_loading option' do
-            with_strict_loading_by_default_enabled do
-              define_model :child, parent_id: :integer
-              parent = define_model(:parent) do |model|
-                model.strict_loading_by_default = false
-                model.has_many :children
-              end.new
+        context 'when strict_loading is defined on the model level' do
+          context 'when it is set to true' do
+            it 'accepts an association with a matching :strict_loading option' do
+              with_strict_loading_by_default_enabled do
+                define_model :child, parent_id: :integer
+                parent = define_model(:parent) do |model|
+                  model.strict_loading_by_default = true
+                  model.has_many :children
+                end.new
 
-              expect(parent).to have_many(:children).strict_loading(false)
-            end
-          end
-
-          it 'rejects an association with a non-matching :strict_loading option without explicit value with the correct message' do
-            with_strict_loading_by_default_enabled do
-              message = [
-                'Expected Parent to have a has_many association called children ',
-                '(children should have strict_loading set to true)',
-              ].join
-
-              define_model :child, parent_id: :integer
-              parent = define_model(:parent) do |model|
-                model.strict_loading_by_default = false
-                model.has_many :children
-              end.new
-
-              expect {
-                expect(parent).to have_many(:children).strict_loading
-              }.to fail_with_message(message)
-            end
-          end
-
-          it 'rejects an association with a non-matching :strict_loading option with the correct message' do
-            with_strict_loading_by_default_enabled do
-              message = [
-                'Expected Parent to have a has_many association called children ',
-                '(children should have strict_loading set to true)',
-              ].join
-
-              define_model :child, parent_id: :integer
-              parent = define_model(:parent) do |model|
-                model.strict_loading_by_default = false
-                model.has_many :children
-              end.new
-
-              expect {
                 expect(parent).to have_many(:children).strict_loading(true)
-              }.to fail_with_message(message)
+              end
+            end
+
+            it 'accepts an association with a matching :strict_loading option without explicit value' do
+              with_strict_loading_by_default_enabled do
+                define_model :child, parent_id: :integer
+                parent = define_model(:parent) do |model|
+                  model.strict_loading_by_default = true
+                  model.has_many :children
+                end.new
+
+                expect(parent).to have_many(:children).strict_loading
+              end
+            end
+
+            it 'rejects an association with a non-matching :strict_loading option with the correct message' do
+              with_strict_loading_by_default_enabled do
+                message = [
+                  'Expected Parent to have a has_many association called children ',
+                  '(children should have strict_loading set to false)',
+                ].join
+
+                define_model :child, parent_id: :integer
+                parent = define_model(:parent) do |model|
+                  model.strict_loading_by_default = true
+                  model.has_many :children
+                end.new
+
+                expect {
+                  expect(parent).to have_many(:children).strict_loading(false)
+                }.to fail_with_message(message)
+              end
+            end
+          end
+
+          context 'when it is set to false' do
+            it 'accepts an association with a matching :strict_loading option' do
+              with_strict_loading_by_default_enabled do
+                define_model :child, parent_id: :integer
+                parent = define_model(:parent) do |model|
+                  model.strict_loading_by_default = false
+                  model.has_many :children
+                end.new
+
+                expect(parent).to have_many(:children).strict_loading(false)
+              end
+            end
+
+            it 'rejects an association with a non-matching :strict_loading option without explicit value with the correct message' do
+              with_strict_loading_by_default_enabled do
+                message = [
+                  'Expected Parent to have a has_many association called children ',
+                  '(children should have strict_loading set to true)',
+                ].join
+
+                define_model :child, parent_id: :integer
+                parent = define_model(:parent) do |model|
+                  model.strict_loading_by_default = false
+                  model.has_many :children
+                end.new
+
+                expect {
+                  expect(parent).to have_many(:children).strict_loading
+                }.to fail_with_message(message)
+              end
+            end
+
+            it 'rejects an association with a non-matching :strict_loading option with the correct message' do
+              with_strict_loading_by_default_enabled do
+                message = [
+                  'Expected Parent to have a has_many association called children ',
+                  '(children should have strict_loading set to true)',
+                ].join
+
+                define_model :child, parent_id: :integer
+                parent = define_model(:parent) do |model|
+                  model.strict_loading_by_default = false
+                  model.has_many :children
+                end.new
+
+                expect {
+                  expect(parent).to have_many(:children).strict_loading(true)
+                }.to fail_with_message(message)
+              end
             end
           end
         end

--- a/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -1200,6 +1200,41 @@ Expected Parent to have a has_many association called children through conceptio
     end
 
     context 'when the application is configured with strict_loading disabled by default' do
+      it 'accepts an association with a matching :strict_loading option' do
+        with_strict_loading_by_default_disabled do
+          expect(having_many_children).
+            to have_many(:children).strict_loading(false)
+        end
+      end
+
+      it 'rejects an association with a non-matching :strict_loading option without explicit value with the correct message' do
+        with_strict_loading_by_default_disabled do
+          message = [
+            'Expected Parent to have a has_many association called children ',
+            '(children should have strict_loading set to true)',
+          ].join
+
+          expect {
+            expect(having_many_children).
+              to have_many(:children).strict_loading
+          }.to fail_with_message(message)
+        end
+      end
+
+      it 'rejects an association with a non-matching :strict_loading option with the correct message' do
+        with_strict_loading_by_default_disabled do
+          message = [
+            'Expected Parent to have a has_many association called children ',
+            '(children should have strict_loading set to true)',
+          ].join
+
+          expect {
+            expect(having_many_children).
+              to have_many(:children).strict_loading(true)
+          }.to fail_with_message(message)
+        end
+      end
+
       context 'when the association is configured with a strict_loading constraint' do
         context 'when qualified with strict_loading(true)' do
           it 'accepts an association with a matching :strict_loading option' do
@@ -1239,7 +1274,7 @@ Expected Parent to have a has_many association called children through conceptio
             end
           end
 
-          it 'rejects an association with a matching :strict_loading option without explicit value with the correct message' do
+          it 'rejects an association with a non-matching :strict_loading option without explicit value with the correct message' do
             with_strict_loading_by_default_disabled do
               message = [
                 'Expected Parent to have a has_many association called children ',
@@ -1370,6 +1405,34 @@ Expected Parent to have a has_many association called children through conceptio
     end
 
     context 'when the application is configured with strict_loading enabled by default' do
+      it 'accepts an association with a matching :strict_loading option' do
+        with_strict_loading_by_default_enabled do
+          expect(having_many_children).
+            to have_many(:children).strict_loading(true)
+        end
+      end
+
+      it 'accepts an association with a matching :strict_loading option without explicit value' do
+        with_strict_loading_by_default_enabled do
+          expect(having_many_children).
+            to have_many(:children).strict_loading
+        end
+      end
+
+      it 'rejects an association with a non-matching :strict_loading option with the correct message' do
+        with_strict_loading_by_default_enabled do
+          message = [
+            'Expected Parent to have a has_many association called children ',
+            '(children should have strict_loading set to false)',
+          ].join
+
+          expect {
+            expect(having_many_children).
+              to have_many(:children).strict_loading(false)
+          }.to fail_with_message(message)
+        end
+      end
+
       context 'when the association is configured with a strict_loading constraint' do
         context 'when qualified with strict_loading(true)' do
           it 'accepts an association with a matching :strict_loading option' do
@@ -1409,7 +1472,7 @@ Expected Parent to have a has_many association called children through conceptio
             end
           end
 
-          it 'rejects an association with a matching :strict_loading option without explicit value with the correct message' do
+          it 'rejects an association with a non-matching :strict_loading option without explicit value with the correct message' do
             with_strict_loading_by_default_enabled do
               message = [
                 'Expected Parent to have a has_many association called children ',

--- a/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/association_matcher_spec.rb
@@ -1199,6 +1199,23 @@ Expected Parent to have a has_many association called children through conceptio
       expect(Parent.new).to have_many(:children)
     end
 
+    it 'accepts an association with a matching :strict_loading option' do
+      expect(having_many_children(strict_loading: true)).
+        to have_many(:children).strict_loading(true)
+    end
+
+    it 'rejects an association with a non-matching :strict_loading option with the correct message' do
+      message = [
+        'Expected Parent to have a has_many association called children ',
+        '(children should have strict_loading set to true)',
+      ].join
+
+      expect {
+        expect(having_many_children).
+          to have_many(:children).strict_loading(true)
+      }.to fail_with_message(message)
+    end
+
     def having_many_children(options = {})
       define_model :child, parent_id: :integer
       define_model(:parent).tap do |model|


### PR DESCRIPTION
`strict_loading` was added to [Rails 6.1] to prevent lazy loading of associations.

As adding it to an association declaration can have a massive impact on the way the record and its association is treated, it can be useful to ensure in a test suite the presence of this option.

This adds support for adding the `strict_loading` option to an association declaration.

[Rails 6.1]: https://github.com/rails/rails/pull/37400

Co-authored-by: Jose Blanco @laicuRoot <jose.blanco@thoughtbot.com>