### PR TITLE
Ensure uniqueness validation matcher works with STI

### DIFF
--- a/lib/shoulda/matchers/active_record/uniqueness/model.rb
+++ b/lib/shoulda/matchers/active_record/uniqueness/model.rb
@@ -29,7 +29,7 @@ module Shoulda
           end
 
           def symlink_to(parent)
-            namespace.set(name, parent.dup)
+            namespace.set(name, Class.new(parent))
           end
 
           def to_s

--- a/spec/support/unit/model_creation_strategies/active_record.rb
+++ b/spec/support/unit/model_creation_strategies/active_record.rb
@@ -74,7 +74,7 @@ module UnitTests
       end
 
       def table_name
-        class_name.tableize.gsub('/', '_')
+        options.fetch(:table_name, class_name.tableize.gsub('/', '_'))
       end
 
       def parent_class


### PR DESCRIPTION
Quotin @StefSchenkelaars on #1450:

> The uniqueness validation matcher generates a fake class when the scope name ends on _type. This fake class is a duplicate of the original class. In most cases this is not a problem, however when using single table inheritance (STI), this new fake class is not a subclass of the original class and therefore ActiveRecord will throw an error. See #1245
> 
> These problems are fixed by making the fake class inherrit from the original class. Therefore it closes #1245 and closes #854