### PR TITLE
Allow beginless and endless ranges in validates_inclusion_of

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
@@ -309,8 +309,8 @@ EOT
 
         def in_range(range)
           @range = range
-          @minimum = range.first
-          @maximum = range.max
+          @minimum = minimum_range_value
+          @maximum = maximum_range_value
           self
         end
 
@@ -400,6 +400,18 @@ EOT
 
         private
 
+        def minimum_range_value
+          @range.begin
+        end
+
+        def maximum_range_value
+          if @range.exclude_end?
+            @range.end ? (@range.end - 1) : nil
+          else
+            @range.end
+          end
+        end
+
         def matches_for_range?
           disallows_lower_value &&
             allows_minimum_value &&
@@ -441,27 +453,27 @@ EOT
         end
 
         def allows_minimum_value
-          allows_value_of(@minimum, @low_message)
+          @minimum.nil? || allows_value_of(@minimum, @low_message)
         end
 
         def disallows_minimum_value
-          disallows_value_of(@minimum, @low_message)
+          @minimum.nil? || disallows_value_of(@minimum, @low_message)
         end
 
         def allows_maximum_value
-          allows_value_of(@maximum, @high_message)
+          @maximum.nil? || allows_value_of(@maximum, @high_message)
         end
 
         def disallows_maximum_value
-          disallows_value_of(@maximum, @high_message)
+          @maximum.nil? || disallows_value_of(@maximum, @high_message)
         end
 
         def allows_higher_value
-          allows_value_of(@maximum + 1, @high_message)
+          @maximum.nil? || allows_value_of(@maximum + 1, @high_message)
         end
 
         def disallows_higher_value
-          disallows_value_of(@maximum + 1, @high_message)
+          @maximum.nil? || disallows_value_of(@maximum + 1, @high_message)
         end
 
         def allows_all_values_in_array?

--- a/lib/shoulda/matchers/util.rb
+++ b/lib/shoulda/matchers/util.rb
@@ -66,7 +66,7 @@ module Shoulda
       end
 
       def self.inspect_range(range)
-        "#{inspect_value(range.first)} to #{inspect_value(range.last)}"
+        "#{inspect_value(range.begin)} to #{inspect_value(range.end)}"
       end
 
       def self.inspect_hash(hash)

--- a/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb
@@ -572,6 +572,22 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
       expect_to_match_on_values(builder, possible_values)
     end
 
+    it 'matches given a beginless range that covers the possible values' do
+      builder = build_object_allowing(possible_values)
+      expect_to_match_on_values(
+        builder,
+        Range.new(nil, possible_values.last),
+      )
+    end
+
+    it 'matches given a endless range that covers the possible values' do
+      builder = build_object_allowing(possible_values)
+      expect_to_match_on_values(
+        builder,
+        Range.new(possible_values.first, nil),
+      )
+    end
+
     it 'does not match given a range whose start value falls outside valid range' do
       builder = build_object_allowing(possible_values)
       expect_not_to_match_on_values(


### PR DESCRIPTION
### Problem
Currently, the min and max range values are checked with `range.first` and `range.max`, that will fail with `cannot get the first element of beginless range (RangeError)` and `cannot get the maximum of endless range (RangeError)` respectively for beginless/endless ranges.

### Proposed solution
We can rely on `range.begin` and `range.end` (by correctly checking if `end` should be considered by looking at `exclude_end?`) instead, that will both return `nil` instead of raising for beginless/endless ranges.

Also added the required early returns on minimum/maximum value checks when the begin/end of range is absent and updated the specs with two scenarios for beginless/endless ranges.

Fixes #1614.