### PR TITLE
chore: Bump version to 6.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 6.2.0 - 2024-03-15
+
+### Bug fixes
+
+* Allow beginless and endless ranges in validates_inclusion_of by @pjpires ([#1615])
+* Ensure uniqueness validation matcher works with STI by @matsales28 ([#1610])
+
+### Features
+
+* Add `against` method in allow_value matcher by @EduardoSCosta ([#1543])
+* Add support for `strict_loading` option in association matchers by @rhannequin and @laicuRoot ([#1607])
+* Add `have_delegated_type` matcher by @matsales28 ([#1606])
+* Add support for `foreign_type` qualifier on `AssociationMatcher` by @matsales28 ([#1609])
+
+### Improvements
+
+* Lazy load `ActionController` and `Routing` matchers for `ActionController::TestCase` by @ilianah ([#1613])
+* Call dynamic-readme reusable workflow by @stefannibrasil ([#1617])
+* Update dependencies by @matsales28 ([#1611])
+* Fix inline documentation for `is_greater_than` in `validate_comparison_of` matcher by @jeduardo824 ([#1616])
+* Fix forgotten colon in documentation by @hotoolong ([#1612])
+
+[#1543]: https://github.com/thoughtbot/shoulda-matchers/pull/1543
+[#1606]: https://github.com/thoughtbot/shoulda-matchers/pull/1606
+[#1607]: https://github.com/thoughtbot/shoulda-matchers/pull/1607
+[#1609]: https://github.com/thoughtbot/shoulda-matchers/pull/1609
+[#1610]: https://github.com/thoughtbot/shoulda-matchers/pull/1610
+[#1611]: https://github.com/thoughtbot/shoulda-matchers/pull/1611
+[#1612]: https://github.com/thoughtbot/shoulda-matchers/pull/1612
+[#1613]: https://github.com/thoughtbot/shoulda-matchers/pull/1613
+[#1615]: https://github.com/thoughtbot/shoulda-matchers/pull/1615
+[#1616]: https://github.com/thoughtbot/shoulda-matchers/pull/1616
+[#1617]: https://github.com/thoughtbot/shoulda-matchers/pull/1617
+
 ## 6.1.0 - 2024-01-19
 
 ### Bug fixes

--- a/README.md
+++ b/README.md
@@ -385,8 +385,10 @@ about any of them, make sure to [consult the documentation][rubydocs]!
   tests your `belongs_to` associations.
 * **[define_enum_for](lib/shoulda/matchers/active_record/define_enum_for_matcher.rb)**
   tests usage of the `enum` macro.
-* **[have_and_belong_to_many](lib/shoulda/matchers/active_record/association_matcher.rb#L827)**
+* **[have_and_belong_to_many](lib/shoulda/matchers/active_record/association_matcher.rb)**
   tests your `has_and_belongs_to_many` associations.
+* **[have_delegated_type](lib/shoulda/matchers/active_record/association_matcher.rb#L687)**
+  tests usage of the `delegated_type` macro.
 * **[have_db_column](lib/shoulda/matchers/active_record/have_db_column_matcher.rb)**
   tests that the table that backs your model has a specific column.
 * **[have_db_index](lib/shoulda/matchers/active_record/have_db_index_matcher.rb)**

--- a/lib/shoulda/matchers/active_record/association_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matcher.rb
@@ -392,7 +392,7 @@ module Shoulda
       #
       #     # Minitest (Shoulda)
       #     class VehicleTest < ActiveSupport::TestCase
-        #     should have_delegated_type(:drivable)
+      #       should have_delegated_type(:drivable)
       #     end
       #
       # #### Qualifiers

--- a/lib/shoulda/matchers/version.rb
+++ b/lib/shoulda/matchers/version.rb
@@ -1,6 +1,6 @@
 module Shoulda
   module Matchers
     # @private
-    VERSION = '6.1.0'.freeze
+    VERSION = '6.2.0'.freeze
   end
 end


### PR DESCRIPTION
Releasing the version 6.2.0 of the gem!

### Bug fixes

* Allow beginless and endless ranges in validates_inclusion_of by @pjpires ([#1615])
* Ensure uniqueness validation matcher works with STI by @matsales28 ([#1610])

### Features

* Add `against` method in allow_value matcher by @EduardoSCosta ([#1543])
* Add support for `strict_loading` option in association matchers by @rhannequin and @laicuRoot ([#1607])
* Add `have_delegated_type` matcher by @matsales28 ([#1606])
* Add support for `foreign_type` qualifier on `AssociationMatcher` by @matsales28 ([#1609])

### Improvements

* Lazy load `ActionController` and `Routing` matchers for `ActionController::TestCase` by @ilianah ([#1613])
* Call dynamic-readme reusable workflow by @stefannibrasil ([#1617])
* Update dependencies by @matsales28 ([#1611])
* Fix inline documentation for `is_greater_than` in `validate_comparison_of` matcher by @jeduardo824 ([#1616])
* Fix forgotten colon in documentation by @hotoolong ([#1612])

[#1543]: https://github.com/thoughtbot/shoulda-matchers/pull/1543
[#1606]: https://github.com/thoughtbot/shoulda-matchers/pull/1606
[#1607]: https://github.com/thoughtbot/shoulda-matchers/pull/1607
[#1609]: https://github.com/thoughtbot/shoulda-matchers/pull/1609
[#1610]: https://github.com/thoughtbot/shoulda-matchers/pull/1610
[#1611]: https://github.com/thoughtbot/shoulda-matchers/pull/1611
[#1612]: https://github.com/thoughtbot/shoulda-matchers/pull/1612
[#1613]: https://github.com/thoughtbot/shoulda-matchers/pull/1613
[#1615]: https://github.com/thoughtbot/shoulda-matchers/pull/1615
[#1616]: https://github.com/thoughtbot/shoulda-matchers/pull/1616
[#1617]: https://github.com/thoughtbot/shoulda-matchers/pull/1617
