### PR TITLE
fix: with_high_message expects a custom validation message too

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb
@@ -344,6 +344,7 @@ EOT
 
         def with_high_message(message)
           if message
+            @expects_custom_validation_message = true
             @high_message = message
           end
 


### PR DESCRIPTION
The only impact being in the generated documentation (via description_clauses_for_qualifiers):

before:

> is expected to validate that Y lies inside the range R

after

> is expected to validate that X lies inside the range R producing a
custom validation error on failure

As with_low_message already does.