### PR TITLE
fix: Polymorphic + STI uniqueness check

### DIFF
--- a/lib/shoulda/matchers/active_record/uniqueness/model.rb
+++ b/lib/shoulda/matchers/active_record/uniqueness/model.rb
@@ -29,7 +29,19 @@ module Shoulda
           end
 
           def symlink_to(parent)
-            namespace.set(name, Class.new(parent))
+            table_name = parent.table_name
+
+            new_class = Class.new(parent) do
+              define_singleton_method :table_name do
+                table_name
+              end
+
+              define_singleton_method :base_class do
+                self
+              end
+            end
+
+            namespace.set(name, new_class)
           end
 
           def to_s


### PR DESCRIPTION
Instead of just initializing a new class that inherits from the parent class, we are initializing a new class but also overriding some method definitions. That is necessary because the Rails guides recommend that whenever you have a polymorphic association and STI you should override the `..._type` column to use the type name of the base STI class.

https://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html#module-ActiveRecord::Associations::ClassMethods-label-Polymorphic+Associations

This should fix #1622 