### PR TITLE
Fixes for breaking changes in Rails 8

### DIFF
--- a/lib/shoulda/matchers/active_record/association_matchers/counter_cache_matcher.rb
+++ b/lib/shoulda/matchers/active_record/association_matchers/counter_cache_matcher.rb
@@ -19,10 +19,7 @@ module Shoulda
           def matches?(subject)
             self.subject = ModelReflector.new(subject, name)
 
-            if option_verifier.correct_for_string?(
-              :counter_cache,
-              counter_cache,
-            )
+            if correct_value?
               true
             else
               self.missing_option = "#{name} should have #{description}"
@@ -34,8 +31,41 @@ module Shoulda
 
           attr_accessor :subject, :counter_cache, :name
 
+          def correct_value?
+            expected = normalize_value
+
+            if expected.is_a?(Hash)
+              option_verifier.correct_for_hash?(
+                :counter_cache,
+                expected,
+              )
+            else
+              option_verifier.correct_for_string?(
+                :counter_cache,
+                expected,
+              )
+            end
+          end
+
           def option_verifier
             @_option_verifier ||= OptionVerifier.new(subject)
+          end
+
+          def normalize_value
+            if Rails::VERSION::MAJOR >= 8
+              case counter_cache
+              when true
+                { active: true, column: nil }
+              when String, Symbol
+                { active: true, column: counter_cache.to_s }
+              when Hash
+                ({ active: true }).merge(counter_cache)
+              else
+                raise ArgumentError, 'Invalid counter_cache option'
+              end
+            else
+              counter_cache
+            end
           end
         end
       end

--- a/lib/shoulda/matchers/active_record/define_enum_for_matcher.rb
+++ b/lib/shoulda/matchers/active_record/define_enum_for_matcher.rb
@@ -619,10 +619,16 @@ module Shoulda
         end
 
         def actual_default_value
-          attribute_schema = model.attributes_to_define_after_schema_loads[attribute_name.to_s]
+          attribute_schema = model.respond_to?(:_default_attributes) ? model._default_attributes[attribute_name.to_s] : model.attributes_to_define_after_schema_loads[attribute_name.to_s]
+
+          if Kernel.const_defined?('ActiveModel::Attribute::UserProvidedDefault') && attribute_schema.is_a?(::ActiveModel::Attribute::UserProvidedDefault)
+            attribute_schema = attribute_schema.marshal_dump
+          end
 
           value = case attribute_schema
                   in [_, { default: default_value } ]
+                    default_value
+                  in [_, default_value, *]
                     default_value
                   in [_, default_value]
                     default_value

--- a/spec/support/unit/rails_application.rb
+++ b/spec/support/unit/rails_application.rb
@@ -90,7 +90,7 @@ module UnitTests
     end
 
     def rails_new_command
-      "bundle exec rails new #{fs.project_directory} --database=#{database.adapter_name} --skip-bundle --skip-javascript --no-rc --skip-bootsnap"
+      "bundle exec rails new #{fs.project_directory} --database=#{database.adapter_name} --asset-pipeline=sprockets --skip-bundle --skip-javascript --no-rc --skip-bootsnap"
     end
 
     def fix_available_locales_warning

--- a/spec/unit/shoulda/matchers/active_record/have_attached_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/have_attached_matcher_spec.rb
@@ -185,7 +185,13 @@ def record_having_one_attached(
     end
 
     if remove_attachments
-      reflections.delete("#{attached_name}_attachment")
+      if respond_to?(:normalized_reflections)
+        clear_reflections_cache
+        _reflections.delete("#{attached_name}_attachment".to_sym)
+        normalized_reflections
+      else
+        reflections.delete("#{attached_name}_attachment")
+      end
     end
 
     if invalidate_blobs
@@ -223,7 +229,13 @@ def record_having_many_attached(
     end
 
     if remove_attachments
-      reflections.delete("#{attached_name}_attachments")
+      if respond_to?(:normalized_reflections)
+        clear_reflections_cache
+        _reflections.delete("#{attached_name}_attachments".to_sym)
+        normalized_reflections
+      else
+        reflections.delete("#{attached_name}_attachments")
+      end
     end
 
     if invalidate_blobs

--- a/spec/unit/shoulda/matchers/active_record/serialize_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/serialize_matcher_spec.rb
@@ -68,13 +68,13 @@ describe Shoulda::Matchers::ActiveRecord::SerializeMatcher, type: :model do
   end
 
   def with_serialized_attr(type: nil, coder: YAML)
-    type_or_coder = rails_version >= 7.1 ? nil : type || coder
+    args = rails_version >= 7.1 ? [] : [type || coder]
 
     define_model(:example, attr: :string) do
       if type
-        serialize :attr, type_or_coder, type: type, coder: coder
+        serialize :attr, *args, type: type, coder: coder
       else
-        serialize :attr, type_or_coder, coder: coder
+        serialize :attr, *args, coder: coder
       end
     end.new
   end

--- a/spec/unit_spec_helper.rb
+++ b/spec/unit_spec_helper.rb
@@ -32,7 +32,11 @@ RSpec.configure do |config|
   end
 end
 
-ActiveSupport::Deprecation.behavior = :stderr
+if Rails::VERSION::MAJOR >= 8
+  Rails.application.deprecators.behavior = :stderr
+else
+  ActiveSupport::Deprecation.behavior = :stderr
+end
 
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|


### PR DESCRIPTION
I've been running tests against Rails main branch for one of my projects and noticed there are a couple things breaking in shoulda-matchers. Most of the things (so far) are resolved in this PR, and I've submitted a fix to Rails that solves a regression indicated by the shoulda-matcher test suite (see https://github.com/rails/rails/pull/51929).

Let me know if you'd like me to refactor and/or reword anything here.

I also think it would make sense to add tests against the main branch/Rails 8, but I'm unable to get the acceptance specs to play along nicely and I don't want to commit the appraisal I have for the unit specs ~~as it depends on our fork of Rails to fully pass~~ until the current changes are reviewed and I've figured out how to get the acceptance specs to run.
