### PR TITLE
Remove useless `logger` require

### DIFF
--- a/lib/shoulda/matchers/doublespeak.rb
+++ b/lib/shoulda/matchers/doublespeak.rb
@@ -1,5 +1,4 @@
 require 'forwardable'
-require 'logger'
 
 module Shoulda
   module Matchers


### PR DESCRIPTION
Ruby 3.4 will warn when `logger` is required without it being part of the gemspec: https://github.com/ruby/ruby/commit/d7e558e3c48c213d0e8bedca4fb547db55613f7c. In 3.5 it will error.

The usage of a logger was added and removed in #1350