### PR TITLE
fix: Ensure DefineEnumForMatcher#validating handles Hash enum values correctly

### DIFF
--- a/lib/shoulda/matchers/active_record/define_enum_for_matcher.rb
+++ b/lib/shoulda/matchers/active_record/define_enum_for_matcher.rb
@@ -736,7 +736,7 @@ module Shoulda
           record.class.validators.detect do |validator|
             validator.kind == :inclusion &&
               validator.attributes.include?(attribute_name.to_s) &&
-              validator.options[:in] == expected_enum_values
+              validator.options[:in] == expected_enum_value_names
           end
         end
 


### PR DESCRIPTION
## Why

`DefineEnumForMatcher#validating` is added at #1630 

At 6.3.0, `DefineEnumForMatcher#validating` only worked with Array enum values. This PR ensures it now also correctly handles Hash enum values.

## How it works

```rb
class Issue < ActiveRecord::Base
  enum :status, {
    open: 0,
    closed: 1
  }, validate: true
end

RSpec.describe Issue, type: :model do
  before do
    ActiveRecord::Base.connection.create_table('issues', temporary: true) do |t|
      t.integer :status
    end
  end

  it do
    should define_enum_for(:status)
      .with_values(open: 0, closed: 1)
      .validating
  end
end
```

### At 6.3.0

assertion fails. This is because the existing code only assumes that enum values is an Array.

```
       Expected Issue to define :status as an enum backed by an integer,
       mapping ‹"open"› to ‹0›、‹"closed"› to ‹1›, and being validated not
       allowing nil values. However, :status is not being validated.
```

### By this patch

assertion succeed. 

```
  is expected to define :status as an enum backed by an integer with values ‹{open: 0, closed: 1}›
```