### PR TITLE
docs: add section on testing style that we promote (#1645)

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,24 @@ RSpec.describe Person, type: :model do
 end
 ```
 
+### A Note on Testing Style
+
+If you inspect the source code, you'll notice quickly that `shoulda-matchers`
+is largely implemented using reflections and other introspection methods that
+Rails provides. On first sight, this might seem to go against the common
+practice of testing behavior rather than implementation. However, as the
+available matchers indicate, we recommend that you treat `shoulda-matchers` as
+a tool to help you ensure correct configuration and adherence to best practices
+and idiomatic Rails in your models and controllers - especially for aspects
+that in your experience are often insufficiently tested, such as ActiveRecord
+validations or controller callbacks (a.k.a. the "framework-y" parts).
+
+For your specific business logic, on the hand, you should very much favor
+testing behavior/outcome over testing implementation: Not only will this
+facilitate refactoring, but the reality is that no generic testing tool will
+ever map adequately to your specific domain. (But you could certainly write
+your own custom matchers and use `shoulda-matchers` as an inspiration.)
+
 ## Matchers
 
 Here is the full list of matchers that ship with this gem. If you need details

--- a/README.md
+++ b/README.md
@@ -358,11 +358,12 @@ and idiomatic Rails in your models and controllers - especially for aspects
 that in your experience are often insufficiently tested, such as ActiveRecord
 validations or controller callbacks (a.k.a. the "framework-y" parts).
 
-For your specific business logic, on the hand, you should very much favor
-testing behavior/outcome over testing implementation: Not only will this
-facilitate refactoring, but the reality is that no generic testing tool will
-ever map adequately to your specific domain. (But you could certainly write
-your own custom matchers and use `shoulda-matchers` as an inspiration.)
+For testing your application's unique business logic, however, we recommend focusing on
+behavior and outcomes over implementation details. This approach will better support
+refactoring and ensure that your tests remain resilient to changes in how your code
+is structured. While no generalized testing tool can fully capture the nuances of your
+specific domain, you can draw inspiration from shoulda-matchers to write custom
+matchers that align more closely with your application's needs.
 
 ## Matchers
 


### PR DESCRIPTION
As outlined in my comment in https://github.com/thoughtbot/shoulda-matchers/issues/1645, this adds a section that explains the implementation-based testing style that `shoulda-matchers` promotes over behavior-/outcome-based style for the sake of providing clarity to newcomers to the gem, especially less experienced engineers.

I've added it to the "Usage" section. It seemed appropriate there because this section also addresses the topic of `should` vs. `is_expected.to` which, to me, is a similar stylistic topic where opinions and promoted practices might differ.

I'm absolutely open to feedback and adapting individual phrases as well as adding/removing parts as needed -- just let me know.