### PR TITLE
Add Ruby 3.4 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - head
           - 3.3.0
           - 3.2.2
           - 3.1.4
@@ -40,6 +41,9 @@ jobs:
           - sqlite3
           - postgresql
         exclude:
+          - { ruby: head, appraisal: rails_6_1 }
+          - { ruby: head, appraisal: rails_7_0 }
+          - { ruby: head, appraisal: rails_7_1 }
           - { ruby: 3.3.0, appraisal: rails_6_1 }
           - { ruby: 3.3.0, appraisal: rails_7_0 }
           - { ruby: 3.2.2, appraisal: rails_6_1 }

--- a/lib/shoulda/matchers/independent/delegate_method_matcher.rb
+++ b/lib/shoulda/matchers/independent/delegate_method_matcher.rb
@@ -447,7 +447,7 @@ module Shoulda
                 false
               rescue NoMethodError => e
                 if e.message =~
-                   /undefined method `#{delegate_method}' for nil/
+                   /undefined method [`']#{delegate_method}' for nil/
                   false
                 else
                   raise e
@@ -468,7 +468,7 @@ module Shoulda
                 false
               rescue NoMethodError => e
                 if e.message =~
-                   /private method `#{delegating_method}' called for/
+                   /private method [`']#{delegating_method}' called for/
                   true
                 else
                   raise e

--- a/spec/unit/shoulda/matchers/independent/delegate_method_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/independent/delegate_method_matcher_spec.rb
@@ -27,7 +27,7 @@ describe Shoulda::Matchers::Independent::DelegateMethodMatcher do
         it 'states that it should delegate method to the right object with right argument' do
           matcher = delegate_method(:method_name).to(:delegate).
             with_arguments(:foo, bar: [1, 2])
-          message = 'delegate #method_name to the #delegate object passing arguments [:foo, {:bar=>[1, 2]}]'
+          message = "delegate #method_name to the #delegate object passing arguments [:foo, #{{:bar=>[1, 2]}.to_s}]"
 
           expect(matcher.description).to eq message
         end
@@ -138,7 +138,7 @@ describe Shoulda::Matchers::Independent::DelegateMethodMatcher do
         it 'states that it should delegate method to the right object with right argument' do
           matcher = delegate_method(:method_name).to(:delegate).
             with_arguments(:foo, bar: [1, 2])
-          message = 'delegate .method_name to the .delegate object passing arguments [:foo, {:bar=>[1, 2]}]'
+          message = "delegate .method_name to the .delegate object passing arguments [:foo, #{{:bar=>[1, 2]}.to_s}]"
 
           expect(matcher.description).to eq message
         end
@@ -294,7 +294,7 @@ describe Shoulda::Matchers::Independent::DelegateMethodMatcher do
         context 'negating the matcher' do
           it 'rejects with the correct failure message' do
             post_office = PostOffice.new
-            message = 'Expected PostOffice not to delegate #deliver_mail to the #mailman object passing arguments ["221B Baker St.", {:hastily=>true}], but it did.'
+            message = "Expected PostOffice not to delegate #deliver_mail to the #mailman object passing arguments [\"221B Baker St.\", #{{:hastily=>true}.to_s}], but it did."
 
             expect {
               expect(post_office).
@@ -315,7 +315,7 @@ describe Shoulda::Matchers::Independent::DelegateMethodMatcher do
             '',
             'Method calls sent to PostOffice#mailman:',
             '',
-            '1) deliver_mail("221B Baker St.", {:hastily=>true})',
+            "1) deliver_mail(\"221B Baker St.\", #{{:hastily=>true}.to_s})"
           ].join("\n")
 
           expect {


### PR DESCRIPTION
* Use a single quote instead of a backtick as an opening quote. [[Feature #16495](https://bugs.ruby-lang.org/]issues/16495)]
* Hash#inspect rendering have been changed. [[Bug #20433](https://bugs.ruby-lang.org/issues/20433)]

One thing to consider is if the single quote / backtick support should not be guarded by some Ruby version check. That would make it more explicit and later allowed easier removal, when Ruby <= 3.3 support is going to be removed.

The same applies to the Hashes, although this is likely good change on its own, since the Hash string representation is considered internal detail AFAIK.