### PR TITLE
Enable sqlite3 2.x+

### DIFF
--- a/spec/support/acceptance/helpers/step_helpers.rb
+++ b/spec/support/acceptance/helpers/step_helpers.rb
@@ -23,7 +23,7 @@ module AcceptanceTests
       add_gem 'activerecord', active_record_version
       add_gem 'rake'
 
-      add_gem 'sqlite3', '~>1.4'
+      add_gem 'sqlite3', '>=1.4'
     end
 
     def create_generic_bundler_project


### PR DESCRIPTION
Rails 7.2 enforces sqlite3 >= 1.4
https://github.com/rails/rails/commit/fd1c635d2f1fd8f348ef9fe8a41fb042a8e43482

Rails 8.0 enforces sqlite3 >= 2.1
https://github.com/rails/rails/commit/7c34062b38aa57cdde17a82dd0b10f30a730f655