### PR TITLE
Fix literal string modification

### DIFF
--- a/lib/shoulda/matchers/action_controller/render_with_layout_matcher.rb
+++ b/lib/shoulda/matchers/action_controller/render_with_layout_matcher.rb
@@ -94,14 +94,14 @@ module Shoulda
         end
 
         def description
-          description = 'render with '
-          description <<
-            if @expected_layout.nil?
-              'a layout'
-            else
-              "the #{@expected_layout.inspect} layout"
-            end
-          description
+          String.new('render with ').tap do |string|
+            string <<
+              if @expected_layout.nil?
+                'a layout'
+              else
+                "the #{@expected_layout.inspect} layout"
+              end
+          end
         end
 
         private

--- a/spec/unit/shoulda/matchers/action_controller/render_with_layout_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/action_controller/render_with_layout_matcher_spec.rb
@@ -16,6 +16,20 @@ describe Shoulda::Matchers::ActionController::RenderWithLayoutMatcher, type: :co
       expect(controller_with_wide_layout).not_to render_with_layout(:other)
     end
 
+    it 'produces the correct message for rendering with another layout' do
+      expected_message = 'Expected to render with the "other" layout, but rendered with "wide", "wide"'
+
+      expect { expect(controller_with_wide_layout).to render_with_layout(:other) }.
+        to fail_with_message(expected_message)
+    end
+
+    it 'produces the correct message for the negation' do
+      expected_message = 'Did not expect to render with a layout, but rendered with "wide", "wide"'
+
+      expect { expect(controller_with_wide_layout).not_to render_with_layout }.
+        to fail_with_message(expected_message)
+    end
+
     def controller_with_wide_layout
       create_view('layouts/wide.html.erb', 'some content, <%= yield %>')
       build_fake_response { render layout: 'wide' }
@@ -27,6 +41,14 @@ describe Shoulda::Matchers::ActionController::RenderWithLayoutMatcher, type: :co
       controller_without_layout = build_fake_response { render layout: false }
 
       expect(controller_without_layout).not_to render_with_layout
+    end
+
+    it 'produces the correct message' do
+      controller_without_layout = build_fake_response { render layout: false }
+      expected_message = 'Expected to render with a layout, but rendered without a layout'
+
+      expect { expect(controller_without_layout).to render_with_layout }.
+        to fail_with_message(expected_message)
     end
   end
 


### PR DESCRIPTION
https://github.com/thoughtbot/shoulda-matchers/pull/1598 fixed most frozen-string-literal violations, allowing the test suit to pass with `--enable=frozen-string-literal`.

However, `render_with_layout_matcher` had a violation in its description method that wasn't exercised by tests, and therefore still causes deprecation warnings under Ruby 3.4 (and failures with the flag enabled)

This PR adds tests that exercise `RenderWithLayoutMatcher#description`, and fixes the literal-string violation.

I'm not clear why the rendered layout is quoted _twice_ in the message, but considered that to be out of scope.