### PR TITLE
feat: Support encrypted ActionText attributes

### DIFF
--- a/lib/shoulda/matchers/active_record/have_rich_text_matcher.rb
+++ b/lib/shoulda/matchers/active_record/have_rich_text_matcher.rb
@@ -71,7 +71,7 @@ module Shoulda
         def has_expected_action_text?
           defined?(ActionText::RichText) &&
             @subject.send(rich_text_attribute).
-              instance_of?(ActionText::RichText)
+              is_a?(ActionText::RichText)
         end
 
         def error_description

--- a/spec/unit/shoulda/matchers/active_record/have_rich_text_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/have_rich_text_matcher_spec.rb
@@ -5,6 +5,10 @@ describe Shoulda::Matchers::ActiveRecord::HaveRichTextMatcher, type: :model do
     defined?(ActionText::RichText)
   end
 
+  def self.encrypted_rich_text_is_defined?
+    defined?(ActionText::EncryptedRichText)
+  end
+
   context '#description' do
     it 'returns the message including the name of the provided association' do
       matcher = have_rich_text(:content)
@@ -23,6 +27,20 @@ describe Shoulda::Matchers::ActiveRecord::HaveRichTextMatcher, type: :model do
         expect { have_rich_text(:content) }.
           to match_against(valid_record).
           or_fail_with(expected_message)
+      end
+    end
+
+    if encrypted_rich_text_is_defined?
+      context 'when the model has an encrypted RichText association' do
+        it 'matches when the subject configures has_rich_text' do
+          valid_record = new_post(is_rich_text_association: true, encrypted: true)
+
+          expected_message = 'Did not expect Post to have ActionText::RichText :content'
+
+          expect { have_rich_text(:content) }.
+            to match_against(valid_record).
+            or_fail_with(expected_message)
+        end
       end
     end
 
@@ -69,7 +87,7 @@ describe Shoulda::Matchers::ActiveRecord::HaveRichTextMatcher, type: :model do
     end
   end
 
-  def new_post(has_invalid_content: false, is_rich_text_association: false)
+  def new_post(has_invalid_content: false, is_rich_text_association: false, encrypted: false)
     columns = {}
 
     if has_invalid_content
@@ -78,7 +96,11 @@ describe Shoulda::Matchers::ActiveRecord::HaveRichTextMatcher, type: :model do
 
     define_model 'Post', columns do
       if is_rich_text_association
-        has_rich_text :content
+        if encrypted
+          has_rich_text :content, encrypted: encrypted
+        else
+          has_rich_text :content
+        end
       end
     end.new
   end


### PR DESCRIPTION
## Synopsis

When rich text attributes are declared by passing `encrypted: true` to `has_rich_text`, the attribute class will be
`ActionText::EncryptedRichText` rather than the `ActionText::RichText` base class.

Extend the existing `have_rich_text` matcher such that it will continue to match, even when rich text attributes are specified with the `encrypted: true` option.

Extends work done in #1263.