### PR TITLE
Ensure @options is always set in ActiveModel::ValidationMatcher.

### DIFF
--- a/lib/shoulda/matchers/active_model/validation_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validation_matcher.rb
@@ -8,6 +8,7 @@ module Shoulda
         def initialize(attribute)
           super
           @attribute = attribute
+          @options = {}
           @expects_strict = false
           @subject = nil
           @last_submatcher_run = nil


### PR DESCRIPTION
This was broken by this commit. https://github.com/thoughtbot/shoulda-matchers/commit/a4289e9651f140f3d0d40e3480c0ce26f4341822#diff-3762aac43395307304ac640d275475f4e8512211cdd02bfcca21a1223f130d60R27