### PR TITLE
feat: Add `service`, `strict_loading`, and `dependent` options to `have_attached` matcher

### DIFF
--- a/spec/unit/shoulda/matchers/active_record/have_attached_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/have_attached_matcher_spec.rb
@@ -80,6 +80,96 @@ Expected User to have a has_one_attached called avatar, but this could not be pr
         end
       end
     end
+
+    context 'when specifying a service' do
+      it 'matches when the service is correct' do
+        record = record_having_one_attached(:avatar, options: { service: :local })
+        expect { have_one_attached(:avatar).service(:local) }.
+          to match_against(record).
+          or_fail_with(<<-MESSAGE)
+Did not expect User to have a has_one_attached called avatar with service :local, but it does.
+          MESSAGE
+      end
+
+      it 'does not match when the service is incorrect' do
+        record = record_having_one_attached(:avatar, options: { service: :local })
+        expect { have_one_attached(:avatar).service(:foo) }.
+          not_to match_against(record).
+          and_fail_with(<<-MESSAGE)
+Expected User to have a has_one_attached called avatar with service :foo, but this could not be proved.
+  The service for the association called avatar_attachment is incorrect (expected: :foo, actual: :local)
+          MESSAGE
+      end
+
+      it 'matches when no service is specified' do
+        record = record_having_one_attached(:avatar, options: { service: :local })
+        expect { have_one_attached(:avatar) }.
+          to match_against(record).
+          or_fail_with(<<-MESSAGE)
+Did not expect User to have a has_one_attached called avatar, but it does.
+          MESSAGE
+      end
+    end
+
+    context 'when specifying strict loading option' do
+      it 'matches when the strict loading option is correct' do
+        record = record_having_one_attached(:avatar, options: { strict_loading: true })
+        expect { have_one_attached(:avatar).strict_loading }.
+          to match_against(record).
+          or_fail_with(<<-MESSAGE)
+Did not expect User to have a has_one_attached called avatar with strict_loading option set to true, but it does.
+          MESSAGE
+      end
+
+      it 'does not match when the strict loading option is incorrect' do
+        record = record_having_one_attached(:avatar, options: { strict_loading: true })
+        expect { have_one_attached(:avatar).strict_loading(false) }.
+          not_to match_against(record).
+          and_fail_with(<<-MESSAGE)
+Expected User to have a has_one_attached called avatar with strict_loading option set to false, but this could not be proved.
+  Expected User to have a has_one association called avatar_blob through avatar_attachment (avatar_blob should have strict_loading set to false)
+          MESSAGE
+      end
+
+      it 'matches when no strict loading option is specified' do
+        record = record_having_one_attached(:avatar, options: { strict_loading: true })
+        expect { have_one_attached(:avatar) }.
+          to match_against(record).
+          or_fail_with(<<-MESSAGE)
+Did not expect User to have a has_one_attached called avatar, but it does.
+          MESSAGE
+      end
+    end
+
+    context 'when specifying a dependent option' do
+      it 'matches when the dependent option is correct' do
+        record = record_having_one_attached(:avatar, options: { dependent: :destroy })
+        expect { have_one_attached(:avatar).dependent(:destroy) }.
+          to match_against(record).
+          or_fail_with(<<-MESSAGE)
+Did not expect User to have a has_one_attached called avatar with dependent option set to :destroy, but it does.
+          MESSAGE
+      end
+
+      it 'does not match when the dependent option is incorrect' do
+        record = record_having_one_attached(:avatar, options: { dependent: :destroy })
+        expect { have_one_attached(:avatar).dependent(:nullify) }.
+          not_to match_against(record).
+          and_fail_with(<<-MESSAGE)
+Expected User to have a has_one_attached called avatar with dependent option set to :nullify, but this could not be proved.
+  The dependent option for the association called avatar_attachment is incorrect (expected: :nullify, actual: :destroy)
+          MESSAGE
+      end
+
+      it 'matches when no dependent option is specified' do
+        record = record_having_one_attached(:avatar, options: { dependent: :destroy })
+        expect { have_one_attached(:avatar) }.
+          to match_against(record).
+          or_fail_with(<<-MESSAGE)
+Did not expect User to have a has_one_attached called avatar, but it does.
+          MESSAGE
+      end
+    end
   end
 
   describe 'have_many_attached' do
@@ -161,6 +251,96 @@ Expected User to have a has_many_attached called avatars, but this could not be 
         end
       end
     end
+
+    context 'when specifying a service' do
+      it 'matches when the service is correct' do
+        record = record_having_many_attached(:avatars, options: { service: :local })
+        expect { have_many_attached(:avatars).service(:local) }.
+          to match_against(record).
+          or_fail_with(<<-MESSAGE)
+Did not expect User to have a has_many_attached called avatars with service :local, but it does.
+          MESSAGE
+      end
+
+      it 'does not match when the service is incorrect' do
+        record = record_having_many_attached(:avatars, options: { service: :local })
+        expect { have_many_attached(:avatars).service(:foo) }.
+          not_to match_against(record).
+          and_fail_with(<<-MESSAGE)
+Expected User to have a has_many_attached called avatars with service :foo, but this could not be proved.
+  The service for the association called avatars_attachments is incorrect (expected: :foo, actual: :local)
+          MESSAGE
+      end
+
+      it 'matches when no service is specified' do
+        record = record_having_many_attached(:avatars, options: { service: :local })
+        expect { have_many_attached(:avatars) }.
+          to match_against(record).
+          or_fail_with(<<-MESSAGE)
+Did not expect User to have a has_many_attached called avatars, but it does.
+          MESSAGE
+      end
+    end
+
+    context 'when specifying strict loading option' do
+      it 'matches when the strict loading option is correct' do
+        record = record_having_many_attached(:avatars, options: { strict_loading: true })
+        expect { have_many_attached(:avatars).strict_loading }.
+          to match_against(record).
+          or_fail_with(<<-MESSAGE)
+Did not expect User to have a has_many_attached called avatars with strict_loading option set to true, but it does.
+          MESSAGE
+      end
+
+      it 'does not match when the strict loading option is incorrect' do
+        record = record_having_many_attached(:avatars, options: { strict_loading: true })
+        expect { have_many_attached(:avatars).strict_loading(false) }.
+          not_to match_against(record).
+          and_fail_with(<<-MESSAGE)
+Expected User to have a has_many_attached called avatars with strict_loading option set to false, but this could not be proved.
+  Expected User to have a has_many association called avatars_blobs through avatars_attachments (avatars_blobs should have strict_loading set to false)
+          MESSAGE
+      end
+
+      it 'matches when no strict loading option is specified' do
+        record = record_having_many_attached(:avatars, options: { strict_loading: true })
+        expect { have_many_attached(:avatars) }.
+          to match_against(record).
+          or_fail_with(<<-MESSAGE)
+Did not expect User to have a has_many_attached called avatars, but it does.
+          MESSAGE
+      end
+    end
+
+    context 'when specifying a dependent option' do
+      it 'matches when the dependent option is correct' do
+        record = record_having_many_attached(:avatars, options: { dependent: :destroy })
+        expect { have_many_attached(:avatars).dependent(:destroy) }.
+          to match_against(record).
+          or_fail_with(<<-MESSAGE)
+Did not expect User to have a has_many_attached called avatars with dependent option set to :destroy, but it does.
+          MESSAGE
+      end
+
+      it 'does not match when the dependent option is incorrect' do
+        record = record_having_many_attached(:avatars, options: { dependent: :destroy })
+        expect { have_many_attached(:avatars).dependent(:nullify) }.
+          not_to match_against(record).
+          and_fail_with(<<-MESSAGE)
+Expected User to have a has_many_attached called avatars with dependent option set to :nullify, but this could not be proved.
+  The dependent option for the association called avatars_attachments is incorrect (expected: :nullify, actual: :destroy)
+          MESSAGE
+      end
+
+      it 'matches when no dependent option is specified' do
+        record = record_having_many_attached(:avatars, options: { dependent: :destroy })
+        expect { have_many_attached(:avatars) }.
+          to match_against(record).
+          or_fail_with(<<-MESSAGE)
+Did not expect User to have a has_many_attached called avatars, but it does.
+          MESSAGE
+      end
+    end
   end
 end
 
@@ -171,10 +351,11 @@ def record_having_one_attached(
   remove_writer: false,
   remove_attachments: false,
   invalidate_blobs: false,
-  remove_eager_loading_scope: false
+  remove_eager_loading_scope: false,
+  options: {}
 )
   model = define_model(model_name) do
-    has_one_attached attached_name
+    has_one_attached attached_name, **options
 
     if remove_reader
       undef_method attached_name
@@ -215,10 +396,11 @@ def record_having_many_attached(
   remove_writer: false,
   remove_attachments: false,
   invalidate_blobs: false,
-  remove_eager_loading_scope: false
+  remove_eager_loading_scope: false,
+  options: {}
 )
   model = define_model(model_name) do
-    has_many_attached attached_name
+    has_many_attached attached_name, **options
 
     if remove_reader
       undef_method attached_name


### PR DESCRIPTION
On this commit we enhance the `have_attached` matcher to include an optional `service`, `strict_loading`, and `dependent` methods. This allows users to specify the expected Active Storage service, strict loading option, and dependent behavior for the attachment, providing greater flexibility and precision in their tests.

Usage:

```ruby
  expect(record).to have_one_attached(:avatar).service(:local).strict_loading.dependent(:destroy)
```

Closes #1668 