### PR TITLE
Require MFA for gem pushes

### DIFF
--- a/shoulda-matchers.gemspec
+++ b/shoulda-matchers.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
     'documentation_uri' => 'https://matchers.shoulda.io/docs',
     'homepage_uri' => 'https://matchers.shoulda.io',
     'source_code_uri' => 'https://github.com/thoughtbot/shoulda-matchers',
+    'rubygems_mfa_required' => 'true',
   }
 
   s.files = Dir['{docs,lib}/**/*', 'README.md', 'LICENSE',


### PR DESCRIPTION
This adds the `rubygems_mfa_required` metadata to the gemspec, requiring multi-factor authentication for privileged operations on RubyGems.org.

This is a protection against supply chain attacks like the recent NPM Axios compromise: https://socket.dev/blog/axios-npm-package-compromised

Reference: https://guides.rubygems.org/mfa-requirement-opt-in/