### PR TITLE
Use a fixed date in validate_inclusion_of date attribute spec

### DIFF
--- a/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/validate_inclusion_of_matcher_spec.rb
@@ -117,7 +117,7 @@ describe Shoulda::Matchers::ActiveModel::ValidateInclusionOfMatcher, type: :mode
     end
 
     context 'against a date attribute' do
-      today = Date.today
+      today = Date.new(2023, 1, 1)
 
       define_method(:today) { today }
 


### PR DESCRIPTION
The `against a date attribute` context in the `ValidateInclusionOfMatcher` spec captures the test date with `Date.today` at spec-load time. While this means the value is fixed for a given run, it ties the test values to the calendar — if the suite happens to load right before midnight the date could advance before some examples finish, leading to a subtle but hard-to-reproduce failure.

Looking at the same spec file, both the `against a datetime attribute` and `against a timestamp column` contexts already use hardcoded dates:

```ruby
now = DateTime.new(2022, 1, 1)
```

This PR brings the date attribute context in line with that approach:

```ruby
# before
today = Date.today

# after
today = Date.new(2023, 1, 1)
```

No behaviour changes — the tests exercise the same code paths, just with a stable anchor date instead of a moving one.

Fixes #1666