### PR TITLE
fix: Prevent test-model leak without DescendantsTracker.clear

### DIFF
--- a/lib/shoulda/matchers/active_record/uniqueness/namespace.rb
+++ b/lib/shoulda/matchers/active_record/uniqueness/namespace.rb
@@ -18,25 +18,10 @@ module Shoulda
           end
 
           def clear
-            test_model_classes = []
-
             constant.constants.each do |child_constant|
-              child = constant.const_get(child_constant)
-
-              if defined?(::ActiveRecord::Base) &&
-                 child.is_a?(Class) &&
-                 child < ::ActiveRecord::Base
-                test_model_classes << child
-              end
-
               constant.remove_const(child_constant)
             rescue NameError
               # Constant may have been removed elsewhere; ignore
-            end
-
-            if defined?(::ActiveSupport::DescendantsTracker) &&
-               test_model_classes.any?
-              ::ActiveSupport::DescendantsTracker.clear(test_model_classes)
             end
           end
 

--- a/lib/shoulda/matchers/active_record/uniqueness/test_models.rb
+++ b/lib/shoulda/matchers/active_record/uniqueness/test_models.rb
@@ -5,7 +5,25 @@ module Shoulda
       module Uniqueness
         # @private
         module TestModels
+          # Test models subclass real ActiveRecord models, so they register
+          # in `descendants`/`subclasses` and cannot be unregistered after
+          # the fact: ActiveSupport::DescendantsTracker.clear raises when
+          # config.enable_reloading is false (the default in the test
+          # environment), and the classes cannot be reliably garbage
+          # collected. Instead, mirror the filtering technique Rails itself
+          # uses for reloaded classes and hide them at the source.
+          module DescendantsFiltering
+            def descendants
+              super.reject { |klass| TestModels.contains?(klass) }
+            end
+
+            def subclasses
+              super.reject { |klass| TestModels.contains?(klass) }
+            end
+          end
+
           def self.create(model_name)
+            hide_from_descendants
             TestModelCreator.create(model_name, root_namespace)
           end
 
@@ -15,6 +33,20 @@ module Shoulda
 
           def self.root_namespace
             @_root_namespace ||= Namespace.new(self)
+          end
+
+          def self.contains?(klass)
+            !klass.name.nil? && klass.name.start_with?(name_prefix)
+          end
+
+          def self.name_prefix
+            @_name_prefix ||= "#{name}::"
+          end
+
+          def self.hide_from_descendants
+            @_hide_from_descendants ||=
+              ::ActiveRecord::Base.singleton_class.
+                prepend(DescendantsFiltering) && true
           end
         end
       end

--- a/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_record/validate_uniqueness_of_matcher_spec.rb
@@ -1566,6 +1566,39 @@ this could not be proved.
       expect(test_model_descendants).to be_empty,
         "Expected no test models in ActiveRecord::Base.descendants, but found: #{test_model_descendants.join(', ')}"
     end
+
+    it 'removes test models from descendants when clearing is disabled' do
+      tracker = ActiveSupport::DescendantsTracker
+      original = tracker.instance_variable_get(:@clear_disabled)
+      tracker.instance_variable_set(:@clear_disabled, true)
+
+      descendants_before = ActiveRecord::Base.descendants.map(&:to_s)
+
+      model = define_model :example, owner_id: :integer, owner_type: :string do |m|
+        m.belongs_to :owner, polymorphic: true
+        m.validates_uniqueness_of :owner_id, scope: :owner_type
+      end
+
+      existing_owner_model = define_model(:user)
+      owner = existing_owner_model.create!
+      model.create!(owner:)
+
+      record = model.new
+
+      expect(record).to validate_uniqueness_of(:owner_id).scoped_to(:owner_type)
+
+      descendants_after = ActiveRecord::Base.descendants.map(&:to_s)
+      new_descendants = descendants_after - descendants_before
+
+      test_model_descendants = new_descendants.select do |name|
+        name.start_with?('Shoulda::Matchers::ActiveRecord::Uniqueness::TestModels::')
+      end
+
+      expect(test_model_descendants).to be_empty,
+        "Expected no test models in ActiveRecord::Base.descendants, but found: #{test_model_descendants.join(', ')}"
+    ensure
+      tracker.instance_variable_set(:@clear_disabled, original)
+    end
   end
 
   let(:model_attributes) { {} }


### PR DESCRIPTION
ActiveSupport::DescendantsTracker.clear after each matcher run. That call raises "DescendantsTracker.clear was disabled because config.enable_reloading is false" in the Rails test environment, where reloading is off by default. This caused every app using validate_uniqueness_of with a polymorphic scope to crash after upgrading to 8.0.

The test models must be real ActiveRecord subclasses. A plain class or constant alias breaks polymorphic association loading and the STI type-writer pattern that calls constantize.base_class.to_s, so real subclasses are unavoidable. Real subclasses always register in descendants, and there is no API to unregister them when reloading is disabled and the classes cannot be garbage collected.

Instead, mirror the technique Rails itself uses for hiding reloaded classes (ReloadedClassesFiltering): lazily prepend a DescendantsFiltering module onto ActiveRecord::Base's singleton class the first time a test model is created. The module filters any class in the private TestModels:: namespace out of descendants and subclasses. This keeps the original #1663 leak fixed while also working when config.enable_reloading is false.

Fixes regression introduced by #1694.

Closes: #1712