### PR TITLE
Bump version to 8.0.1 [ci skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 8.0.1 - 2026-06-12
+
+### Bug fixes
+
+- Fix `validate_uniqueness_of` raising "DescendantsTracker.clear was disabled"
+  when `config.enable_reloading` is false by @matsales28 ([#1713])
+
+[#1713]: https://github.com/thoughtbot/shoulda-matchers/pull/1713
+
 ## 8.0.0 - 2026-06-12
 
 ### Backward-incompatible changes

--- a/lib/shoulda/matchers/version.rb
+++ b/lib/shoulda/matchers/version.rb
@@ -1,6 +1,6 @@
 module Shoulda
   module Matchers
     # @private
-    VERSION = '8.0.0'.freeze
+    VERSION = '8.0.1'.freeze
   end
 end


### PR DESCRIPTION
Patch release with the fix for the 8.0.0 regression where `validate_uniqueness_of` with a
   polymorphic scope raised:

   ```
   RuntimeError: DescendantsTracker.clear was disabled because config.enable_reloading is false
   ```

   This crashed in any Rails test environment, since `config.enable_reloading` defaults to false
   there. Fixed by #1713.

   ## Changes

   - Add 8.0.1 section to CHANGELOG.md
   - Bump `VERSION` to 8.0.1