### PR TITLE
feat: Add without_validations qualifier to have_secure_password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add `without_validations`, `with_reset_token`, and `without_reset_token`
+  qualifiers to the `have_secure_password` matcher by @matsales28 ([#1716])
+
+[#1716]: https://github.com/thoughtbot/shoulda-matchers/pull/1716
+
 ## 8.0.1 - 2026-06-12
 
 ### Bug fixes

--- a/lib/shoulda/matchers/active_model/have_secure_password_matcher.rb
+++ b/lib/shoulda/matchers/active_model/have_secure_password_matcher.rb
@@ -54,6 +54,71 @@ module Shoulda
       #       should have_secure_password.without_validations
       #     end
       #
+      # The built-in validations are detected through the confirmation validator
+      # that `has_secure_password` registers, since the presence and length
+      # checks are anonymous validators that cannot be inspected. A model that
+      # opts out with `validations: false` and then defines its own
+      # `validates_confirmation_of` will therefore be treated as having the
+      # built-in validations.
+      #
+      # ##### with_reset_token
+      #
+      # Use `with_reset_token` to assert that `has_secure_password` generates a
+      # password reset token (the `#{attribute}_reset_token` method along with
+      # the `find_by_#{attribute}_reset_token` lookups). This is the default for
+      # `has_secure_password` and is only supported on Rails 8.0 and later.
+      #
+      #     class User < ApplicationRecord
+      #       has_secure_password
+      #     end
+      #
+      #     # RSpec
+      #     RSpec.describe User, type: :model do
+      #       it { should have_secure_password.with_reset_token }
+      #     end
+      #
+      #     # Minitest (Shoulda)
+      #     class UserTest < ActiveSupport::TestCase
+      #       should have_secure_password.with_reset_token
+      #     end
+      #
+      # Pass `expires_in` to also assert how long the reset token is valid for.
+      # Configuring the expiry requires Rails 8.1 or later.
+      #
+      #     class User < ApplicationRecord
+      #       has_secure_password reset_token: { expires_in: 1.hour }
+      #     end
+      #
+      #     # RSpec
+      #     RSpec.describe User, type: :model do
+      #       it { should have_secure_password.with_reset_token(expires_in: 1.hour) }
+      #     end
+      #
+      #     # Minitest (Shoulda)
+      #     class UserTest < ActiveSupport::TestCase
+      #       should have_secure_password.with_reset_token(expires_in: 1.hour)
+      #     end
+      #
+      # ##### without_reset_token
+      #
+      # Use `without_reset_token` to assert that `has_secure_password` was
+      # declared with `reset_token: false`, which opts out of generating the
+      # password reset token. This is only supported on Rails 8.0 and later.
+      #
+      #     class User < ApplicationRecord
+      #       has_secure_password reset_token: false
+      #     end
+      #
+      #     # RSpec
+      #     RSpec.describe User, type: :model do
+      #       it { should have_secure_password.without_reset_token }
+      #     end
+      #
+      #     # Minitest (Shoulda)
+      #     class UserTest < ActiveSupport::TestCase
+      #       should have_secure_password.without_reset_token
+      #     end
+      #
       # @return [HaveSecurePasswordMatcher]
       #
       def have_secure_password(attr = :password)
@@ -74,8 +139,14 @@ module Shoulda
             ' authenticate the correct %{attribute}',
           method_not_found: 'expected %{subject} to respond to %{methods}',
           unexpected_validations: 'expected %{subject} to have a secure'\
-            ' password without validations on %{attribute}, but'\
-            ' validations were present',
+            ' password without validations on %{attribute}, but the'\
+            ' built-in validations were present',
+          unexpected_reset_token: 'expected %{subject} to have a secure'\
+            ' password without a reset token on %{attribute}, but a'\
+            ' reset token was present',
+          incorrect_reset_token_expiry: 'expected the %{attribute} reset'\
+            ' token on %{subject} to expire in %{expected}, but it expires'\
+            ' in %{actual}',
           should_not_have_secure_password: 'expected %{subject} to'\
             ' not %{description}!',
         }.freeze
@@ -83,6 +154,7 @@ module Shoulda
         def initialize(attribute)
           @attribute = attribute.to_sym
           @expects_no_validations = false
+          @reset_token = nil
         end
 
         def without_validations
@@ -90,15 +162,28 @@ module Shoulda
           self
         end
 
+        def with_reset_token(expires_in: nil)
+          @reset_token = { expected: true, expires_in: expires_in }
+          self
+        end
+
+        def without_reset_token
+          @reset_token = { expected: false, expires_in: nil }
+          self
+        end
+
         def description
-          description = "have a secure password, defined on #{@attribute}"\
-            ' attribute'
-          description += ' without validations' if @expects_no_validations
-          description
+          text = "have a secure password, defined on #{@attribute} attribute"
+          text += ' without validations' if @expects_no_validations
+          text += ' with a reset token' if expects_reset_token?
+          text += ' without a reset token' if expects_no_reset_token?
+          text
         end
 
         def matches?(subject)
           @subject = subject
+
+          assert_reset_token_qualifiers_supported!
 
           if failure = validate
             key, params = failure
@@ -119,9 +204,7 @@ module Shoulda
         attr_reader :subject
 
         def validate
-          missing_methods = expected_methods.reject do |m|
-            subject.respond_to?(m)
-          end
+          missing_methods = missing_expected_methods
 
           if missing_methods.present?
             [:method_not_found, { methods: missing_methods.to_sentence }]
@@ -136,6 +219,13 @@ module Shoulda
               [:authenticated_incorrect_password, { attribute: @attribute }]
             elsif @expects_no_validations && validations_present?
               [:unexpected_validations, { attribute: @attribute }]
+            elsif expects_no_reset_token? && reset_token_present?
+              [:unexpected_reset_token, { attribute: @attribute }]
+            elsif expects_reset_token? && reset_token_expiry_mismatch?
+              [:incorrect_reset_token_expiry,
+               { attribute: @attribute,
+                 expected: expected_reset_token_expires_in.inspect,
+                 actual: actual_reset_token_expires_in.inspect, },]
             end
           end
         end
@@ -156,14 +246,103 @@ module Shoulda
           end
         end
 
+        def missing_expected_methods
+          expected_methods.reject { |m| subject.respond_to?(m) } +
+            expected_class_methods.reject { |m| subject.class.respond_to?(m) }
+        end
+
         def expected_methods
-          @_expected_methods ||= %I[
+          methods = %I[
             #{authenticate_method}
             #{@attribute}=
             #{@attribute}_confirmation=
             #{@attribute}_digest
             #{@attribute}_digest=
           ]
+          methods += reset_token_instance_methods if expects_reset_token?
+          methods
+        end
+
+        def expected_class_methods
+          expects_reset_token? ? reset_token_class_methods : []
+        end
+
+        # The `#{attribute}_reset_token_expires_in` reader only exists on Rails
+        # 8.1+, so it is expected only when an expiry is asserted (which the
+        # version gate already restricts to 8.1+). Including it then means a
+        # missing reader fails with a clear `method_not_found` message rather
+        # than a raw NoMethodError from #actual_reset_token_expires_in.
+        def reset_token_instance_methods
+          methods = [:"#{@attribute}_reset_token"]
+          methods << :"#{@attribute}_reset_token_expires_in" if expiry_specified?
+          methods
+        end
+
+        def reset_token_class_methods
+          %I[
+            find_by_#{@attribute}_reset_token
+            find_by_#{@attribute}_reset_token!
+          ]
+        end
+
+        def reset_token_present?
+          subject.respond_to?(:"#{@attribute}_reset_token")
+        end
+
+        def reset_token_expiry_mismatch?
+          return false unless expiry_specified?
+
+          actual_reset_token_expires_in != expected_reset_token_expires_in
+        end
+
+        def actual_reset_token_expires_in
+          subject.public_send(:"#{@attribute}_reset_token_expires_in")
+        end
+
+        def assert_reset_token_qualifiers_supported!
+          if reset_token_qualified? && !RailsShim.active_model_gte_8_0?
+            raise reset_token_not_supported_error('8.0')
+          elsif expiry_specified? && !RailsShim.active_model_gte_8_1?
+            raise reset_token_not_supported_error('8.1')
+          end
+        end
+
+        def reset_token_not_supported_error(required_version)
+          ResetTokenNotSupportedError.create(
+            model: @subject.class,
+            qualifier: reset_token_qualifier_name,
+            required_version: required_version,
+          )
+        end
+
+        def reset_token_qualifier_name
+          if expiry_specified?
+            'with_reset_token(expires_in:)'
+          elsif expects_reset_token?
+            'with_reset_token'
+          else
+            'without_reset_token'
+          end
+        end
+
+        def reset_token_qualified?
+          !@reset_token.nil?
+        end
+
+        def expects_reset_token?
+          @reset_token && @reset_token[:expected]
+        end
+
+        def expects_no_reset_token?
+          @reset_token && !@reset_token[:expected]
+        end
+
+        def expiry_specified?
+          !expected_reset_token_expires_in.nil?
+        end
+
+        def expected_reset_token_expires_in
+          @reset_token && @reset_token[:expires_in]
         end
 
         def authenticate_method
@@ -171,6 +350,18 @@ module Shoulda
             :authenticate
           else
             "authenticate_#{@attribute}".to_sym
+          end
+        end
+
+        # @private
+        class ResetTokenNotSupportedError < Shoulda::Matchers::Error
+          attr_accessor :model, :qualifier, :required_version
+
+          def message
+            Shoulda::Matchers.word_wrap <<-MESSAGE
+The `#{qualifier}` qualifier requires Rails #{required_version} or later, but
+#{model.name} is running an earlier version.
+            MESSAGE
           end
         end
       end

--- a/lib/shoulda/matchers/active_model/have_secure_password_matcher.rb
+++ b/lib/shoulda/matchers/active_model/have_secure_password_matcher.rb
@@ -28,6 +28,32 @@ module Shoulda
       #       should have_secure_password(:reset_password)
       #     end
       #
+      # #### Qualifiers
+      #
+      # ##### without_validations
+      #
+      # Use `without_validations` to assert that `has_secure_password` was
+      # declared with `validations: false`, which opts out of the built-in
+      # password presence, length, and confirmation validations.
+      #
+      #     class User
+      #       include ActiveModel::Model
+      #       include ActiveModel::SecurePassword
+      #       attr_accessor :password
+      #
+      #       has_secure_password validations: false
+      #     end
+      #
+      #     # RSpec
+      #     RSpec.describe User, type: :model do
+      #       it { should have_secure_password.without_validations }
+      #     end
+      #
+      #     # Minitest (Shoulda)
+      #     class UserTest < ActiveSupport::TestCase
+      #       should have_secure_password.without_validations
+      #     end
+      #
       # @return [HaveSecurePasswordMatcher]
       #
       def have_secure_password(attr = :password)
@@ -47,16 +73,28 @@ module Shoulda
           did_not_authenticate_correct_password: 'expected %{subject} to'\
             ' authenticate the correct %{attribute}',
           method_not_found: 'expected %{subject} to respond to %{methods}',
+          unexpected_validations: 'expected %{subject} to have a secure'\
+            ' password without validations on %{attribute}, but'\
+            ' validations were present',
           should_not_have_secure_password: 'expected %{subject} to'\
             ' not %{description}!',
         }.freeze
 
         def initialize(attribute)
           @attribute = attribute.to_sym
+          @expects_no_validations = false
+        end
+
+        def without_validations
+          @expects_no_validations = true
+          self
         end
 
         def description
-          "have a secure password, defined on #{@attribute} attribute"
+          description = "have a secure password, defined on #{@attribute}"\
+            ' attribute'
+          description += ' without validations' if @expects_no_validations
+          description
         end
 
         def matches?(subject)
@@ -96,11 +134,27 @@ module Shoulda
                { attribute: @attribute },]
             elsif subject.send(authenticate_method, INCORRECT_PASSWORD)
               [:authenticated_incorrect_password, { attribute: @attribute }]
+            elsif @expects_no_validations && validations_present?
+              [:unexpected_validations, { attribute: @attribute }]
             end
           end
         end
 
         private
+
+        # `has_secure_password` (with the default `validations: true`) registers
+        # a confirmation validator on the attribute alongside its other built-in
+        # validations. They are all installed together, so the presence of that
+        # validator is a reliable structural signal that validations are enabled
+        # without having to run them, which is what `without_validations`
+        # asserts against.
+        def validations_present?
+          return false unless subject.class.respond_to?(:validators_on)
+
+          subject.class.validators_on(@attribute).any? do |validator|
+            validator.is_a?(::ActiveModel::Validations::ConfirmationValidator)
+          end
+        end
 
         def expected_methods
           @_expected_methods ||= %I[

--- a/lib/shoulda/matchers/rails_shim.rb
+++ b/lib/shoulda/matchers/rails_shim.rb
@@ -25,6 +25,14 @@ module Shoulda
           Gem::Requirement.new('< 7').satisfied_by?(active_model_version)
         end
 
+        def active_model_gte_8_0?
+          Gem::Requirement.new('>= 8.0').satisfied_by?(active_model_version)
+        end
+
+        def active_model_gte_8_1?
+          Gem::Requirement.new('>= 8.1').satisfied_by?(active_model_version)
+        end
+
         def active_record_gte_8_1?
           Gem::Requirement.new('>= 8.1').satisfied_by?(active_record_version)
         end

--- a/spec/unit/shoulda/matchers/active_model/have_secure_password_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/have_secure_password_matcher_spec.rb
@@ -50,9 +50,118 @@ describe Shoulda::Matchers::ActiveModel::HaveSecurePasswordMatcher, type: :model
       end
 
       message = 'expected Example to have a secure password without'\
-        ' validations on password, but validations were present'
+        ' validations on password, but the built-in validations were present'
 
       expect(&assertion).to fail_with_message_including(message)
+    end
+  end
+
+  if rails_gt_8_0?
+    context 'with the with_reset_token qualifier' do
+      it 'matches when has_secure_password generates a reset token' do
+        working_model = define_model(:example, password_digest: :string) do
+          has_secure_password
+        end
+        expect(working_model.new).to have_secure_password.with_reset_token
+      end
+
+      it 'does not match when the reset token is disabled' do
+        working_model = define_model(:example, password_digest: :string) do
+          has_secure_password reset_token: false
+        end
+        expect(working_model.new).
+          not_to have_secure_password.with_reset_token
+      end
+
+      # The configurable reset token expiry (and the
+      # `<attr>_reset_token_expires_in` reader it relies on) was introduced in
+      # Rails 8.1. Remove this version split once support for Rails 8.0 is
+      # dropped.
+      if rails_version >= '8.1'
+        it 'matches when the reset token expiry matches expires_in' do
+          working_model = define_model(:example, password_digest: :string) do
+            has_secure_password reset_token: { expires_in: 1.hour }
+          end
+          expect(working_model.new).
+            to have_secure_password.with_reset_token(expires_in: 1.hour)
+        end
+
+        it 'does not match when the reset token expiry differs' do
+          working_model = define_model(:example, password_digest: :string) do
+            has_secure_password
+          end
+          expect(working_model.new).
+            not_to have_secure_password.with_reset_token(expires_in: 1.hour)
+        end
+
+        it 'rejects with an appropriate failure message for a wrong expiry' do
+          working_model = define_model(:example, password_digest: :string) do
+            has_secure_password
+          end
+          assertion = lambda do
+            expect(working_model.new).
+              to have_secure_password.with_reset_token(expires_in: 1.hour)
+          end
+
+          expect(&assertion).to fail_with_message_including('reset token')
+        end
+      else
+        it 'raises an error when expires_in is used on Rails older than 8.1' do
+          working_model = define_model(:example, password_digest: :string) do
+            has_secure_password
+          end
+          assertion = lambda do
+            expect(working_model.new).
+              to have_secure_password.with_reset_token(expires_in: 1.hour)
+          end
+
+          expect(&assertion).to raise_error(/Rails 8\.1/)
+        end
+      end
+    end
+
+    context 'with the without_reset_token qualifier' do
+      it 'matches when the reset token is disabled' do
+        working_model = define_model(:example, password_digest: :string) do
+          has_secure_password reset_token: false
+        end
+        expect(working_model.new).to have_secure_password.without_reset_token
+      end
+
+      it 'does not match when a reset token is generated' do
+        working_model = define_model(:example, password_digest: :string) do
+          has_secure_password
+        end
+        expect(working_model.new).
+          not_to have_secure_password.without_reset_token
+      end
+    end
+  else
+    # The reset token feature was introduced in Rails 8.0. Remove this branch
+    # (and keep only the qualifier specs above) once support for Rails 7.2 is
+    # dropped.
+    context 'with reset token qualifiers on Rails older than 8.0' do
+      it 'raises an error when with_reset_token is used' do
+        working_model = define_model(:example, password_digest: :string) do
+          has_secure_password
+        end
+        assertion = lambda do
+          expect(working_model.new).to have_secure_password.with_reset_token
+        end
+
+        expect(&assertion).to raise_error(/Rails 8\.0/)
+      end
+
+      it 'raises an error when without_reset_token is used' do
+        working_model = define_model(:example, password_digest: :string) do
+          has_secure_password
+        end
+        assertion = lambda do
+          expect(working_model.new).to have_secure_password.without_reset_token
+        end
+
+        expect(&assertion).to raise_error(/Rails 8\.0/)
+      end
     end
   end
 

--- a/spec/unit/shoulda/matchers/active_model/have_secure_password_matcher_spec.rb
+++ b/spec/unit/shoulda/matchers/active_model/have_secure_password_matcher_spec.rb
@@ -18,6 +18,44 @@ describe Shoulda::Matchers::ActiveModel::HaveSecurePasswordMatcher, type: :model
     end
   end
 
+  context 'with the without_validations qualifier' do
+    it 'matches when has_secure_password is declared with validations: false' do
+      working_model = define_model(:example, password_digest: :string) do
+        has_secure_password validations: false
+      end
+      expect(working_model.new).to have_secure_password.without_validations
+    end
+
+    it 'does not match when the password validations are present' do
+      working_model = define_model(:example, password_digest: :string) do
+        has_secure_password
+      end
+      expect(working_model.new).not_to have_secure_password.without_validations
+    end
+
+    it 'matches when the model opts out but defines its own validations' do
+      working_model = define_model(:example, password_digest: :string) do
+        has_secure_password validations: false
+        validates :password, presence: true
+      end
+      expect(working_model.new).to have_secure_password.without_validations
+    end
+
+    it 'rejects with an appropriate failure message' do
+      working_model = define_model(:example, password_digest: :string) do
+        has_secure_password
+      end
+      assertion = lambda do
+        expect(working_model.new).to have_secure_password.without_validations
+      end
+
+      message = 'expected Example to have a secure password without'\
+        ' validations on password, but validations were present'
+
+      expect(&assertion).to fail_with_message_including(message)
+    end
+  end
+
   context 'when custom attribute is given to has_secure_password' do
     it 'matches when the subject configures has_secure_password with correct options' do
       working_model = define_model(:example, reset_password_digest: :string) { has_secure_password :reset_password }


### PR DESCRIPTION
### [feat: Add without_validations qualifier to have_secure_password](https://github.com/thoughtbot/shoulda-matchers/pull/1716/commits/62c4cbc6ee3acc1be588be1386a74e09362e8ac8) 
The qualifier asserts that has_secure_password was declared with
validations: false, opting out of the built-in presence, length, and
confirmation validations.

Detection is structural via validators_on: the macro registers a
confirmation validator on the attribute alongside its other built-in
validations only when validations are enabled, so the validator's
presence is a reliable signal without having to run the validations.
This also avoids false positives when a model opts out and then defines
its own presence validation.

### [feat: Add reset token qualifiers to have_secure_password](https://github.com/thoughtbot/shoulda-matchers/pull/1716/commits/e3b9884a8086ae71bde54c0f561d75a06893d3ff)
Add with_reset_token and without_reset_token to assert how
has_secure_password was declared with respect to its reset_token option.

- with_reset_token asserts the reset token methods are generated
(#{attribute}_reset_token and the find_by_#{attribute}_reset_token
lookups).
- with_reset_token(expires_in:) additionally asserts the configured token
expiry by reading #{attribute}_reset_token_expires_in.
- without_reset_token asserts the token was opted out of with
reset_token: false.

Detection is structural (respond_to? on the generated methods), and the
qualifiers are opt-in, so the default matcher behavior is unchanged.

The reset_token option only exists on Rails 8.0+, and its configurable
expiry only on Rails 8.1+, so using the qualifiers on an earlier version
raises a clear error naming the qualifier and the required version.

Closes: #1706 